### PR TITLE
Add article rendering and syntax-highlighted code blocks

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
@@ -1,0 +1,168 @@
+package pub.hackers.android.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import pub.hackers.android.R
+import pub.hackers.android.domain.model.Post
+
+@Composable
+fun ArticleCard(
+    post: Post,
+    onClick: () -> Unit,
+    onProfileClick: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val displayPost = post.sharedPost ?: post
+    val isRepost = post.sharedPost != null
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Column {
+            Column(
+                modifier = Modifier.padding(12.dp)
+            ) {
+                if (isRepost) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Repeat,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.secondary,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = "${post.actor.name ?: post.actor.handle} ${stringResource(R.string.share)}d",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.secondary
+                        )
+                    }
+                }
+
+                // Author row
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    AsyncImage(
+                        model = displayPost.actor.avatarUrl,
+                        contentDescription = "Avatar",
+                        modifier = Modifier
+                            .size(48.dp)
+                            .clip(CircleShape)
+                            .clickable { onProfileClick(displayPost.actor.handle) },
+                        contentScale = ContentScale.Crop
+                    )
+
+                    Spacer(modifier = Modifier.width(12.dp))
+
+                    Column(modifier = Modifier.weight(1f)) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = displayPost.actor.name ?: displayPost.actor.handle,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier
+                                    .weight(1f, fill = false)
+                                    .clickable { onProfileClick(displayPost.actor.handle) }
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(
+                                text = formatRelativeTime(displayPost.published),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+
+                        Text(
+                            text = "@${displayPost.actor.handle}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Article title
+                displayPost.name?.let { title ->
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+
+                // Summary or excerpt
+                val summaryText = displayPost.summary ?: displayPost.excerpt
+                if (summaryText.isNotBlank()) {
+                    Text(
+                        text = summaryText,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 4,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+
+            // "Read full article" footer
+            HorizontalDivider()
+            Text(
+                text = stringResource(R.string.read_full_article),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                    .padding(vertical = 12.dp, horizontal = 16.dp),
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center
+            )
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/components/CodeBlockView.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/CodeBlockView.kt
@@ -1,0 +1,256 @@
+package pub.hackers.android.ui.components
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+private val SPAN_REGEX = Regex("""<span([^>]*)>([\s\S]*?)</span>""")
+private val STYLE_ATTR_REGEX = Regex("""style=["']([^"']*)["']""")
+private val SHIKI_DARK_REGEX = Regex("""--shiki-dark:\s*(#[0-9a-fA-F]{3,8})""")
+private val SHIKI_LIGHT_REGEX = Regex("""(?:^|;)\s*color:\s*(#[0-9a-fA-F]{3,8})""")
+private val SHIKI_DARK_FONT_STYLE_REGEX = Regex("""--shiki-dark-font-style:\s*(\w+)""")
+private val SHIKI_DARK_FONT_WEIGHT_REGEX = Regex("""--shiki-dark-font-weight:\s*(\w+)""")
+private val TAG_STRIP_REGEX = Regex("""<[^>]+>""")
+
+@Composable
+fun CodeBlockView(
+    codeHtml: String,
+    modifier: Modifier = Modifier
+) {
+    val isDark = isSystemInDarkTheme()
+    val bgColor = if (isDark) Color(0xFF1E293B) else Color(0xFFF1F5F9)
+    val defaultTextColor = if (isDark) Color(0xFFE2E8F0) else Color(0xFF1E293B)
+
+    val annotatedCode = remember(codeHtml, isDark) {
+        parseShikiCodeBlock(codeHtml, isDark, defaultTextColor)
+    }
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
+        color = bgColor
+    ) {
+        Text(
+            text = annotatedCode,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 13.sp,
+            lineHeight = 19.sp,
+            color = defaultTextColor,
+            modifier = Modifier
+                .horizontalScroll(rememberScrollState())
+                .padding(12.dp)
+        )
+    }
+}
+
+private fun parseShikiCodeBlock(
+    html: String,
+    isDark: Boolean,
+    defaultColor: Color
+): AnnotatedString {
+    return buildAnnotatedString {
+        parseShikiSpans(this, html, isDark, defaultColor, depth = 0)
+    }
+}
+
+private fun parseShikiSpans(
+    builder: AnnotatedString.Builder,
+    html: String,
+    isDark: Boolean,
+    defaultColor: Color,
+    depth: Int
+) {
+    var pos = 0
+
+    while (pos < html.length) {
+        // Find the next <span or </span or <br or plain text
+        val nextTag = findNextTag(html, pos)
+
+        if (nextTag == null) {
+            // Remaining text
+            val text = decodeCodeEntities(html.substring(pos))
+            if (text.isNotEmpty()) {
+                builder.append(text)
+            }
+            break
+        }
+
+        // Text before the tag
+        if (nextTag.start > pos) {
+            val text = decodeCodeEntities(html.substring(pos, nextTag.start))
+            if (text.isNotEmpty()) {
+                builder.append(text)
+            }
+        }
+
+        when {
+            nextTag.tag == "br" -> {
+                builder.append("\n")
+                pos = nextTag.end
+            }
+            nextTag.tag == "span" && !nextTag.isClosing -> {
+                // Find matching </span>
+                val innerEnd = findMatchingClose(html, nextTag.end, "span")
+                if (innerEnd != null) {
+                    val innerHtml = html.substring(nextTag.end, innerEnd.first)
+                    val style = extractSpanStyle(nextTag.attrs, isDark)
+
+                    if (style != null) {
+                        builder.withStyle(style) {
+                            parseShikiSpans(this, innerHtml, isDark, defaultColor, depth + 1)
+                        }
+                    } else {
+                        parseShikiSpans(builder, innerHtml, isDark, defaultColor, depth + 1)
+                    }
+
+                    pos = innerEnd.second
+                } else {
+                    pos = nextTag.end
+                }
+            }
+            else -> {
+                // Skip other tags
+                pos = nextTag.end
+            }
+        }
+    }
+}
+
+private data class TagInfo(
+    val tag: String,
+    val isClosing: Boolean,
+    val attrs: String,
+    val start: Int,
+    val end: Int
+)
+
+private val TAG_FIND_REGEX = Regex("""<(/?)(\w+)([^>]*)>""")
+
+private fun findNextTag(html: String, startPos: Int): TagInfo? {
+    val match = TAG_FIND_REGEX.find(html, startPos) ?: return null
+    return TagInfo(
+        tag = match.groupValues[2].lowercase(),
+        isClosing = match.groupValues[1] == "/",
+        attrs = match.groupValues[3],
+        start = match.range.first,
+        end = match.range.last + 1
+    )
+}
+
+private fun findMatchingClose(html: String, startPos: Int, tagName: String): Pair<Int, Int>? {
+    var depth = 1
+    var pos = startPos
+
+    while (pos < html.length) {
+        val tag = findNextTag(html, pos) ?: return null
+
+        if (tag.tag == tagName) {
+            if (tag.isClosing) {
+                depth--
+                if (depth == 0) {
+                    return Pair(tag.start, tag.end)
+                }
+            } else {
+                depth++
+            }
+        }
+
+        pos = tag.end
+    }
+
+    return null
+}
+
+private fun extractSpanStyle(attrs: String, isDark: Boolean): SpanStyle? {
+    val styleMatch = STYLE_ATTR_REGEX.find(attrs) ?: return null
+    val styleValue = styleMatch.groupValues[1]
+
+    val color = if (isDark) {
+        SHIKI_DARK_REGEX.find(styleValue)?.groupValues?.get(1)
+    } else {
+        SHIKI_LIGHT_REGEX.find(styleValue)?.groupValues?.get(1)
+    }
+
+    val fontStyle = if (isDark) {
+        SHIKI_DARK_FONT_STYLE_REGEX.find(styleValue)?.groupValues?.get(1)
+    } else {
+        null
+    }
+
+    val fontWeight = if (isDark) {
+        SHIKI_DARK_FONT_WEIGHT_REGEX.find(styleValue)?.groupValues?.get(1)
+    } else {
+        null
+    }
+
+    if (color == null && fontStyle == null && fontWeight == null) return null
+
+    return SpanStyle(
+        color = color?.let { parseHexColor(it) } ?: Color.Unspecified,
+        fontStyle = when (fontStyle) {
+            "italic" -> FontStyle.Italic
+            else -> null
+        },
+        fontWeight = when (fontWeight) {
+            "bold" -> FontWeight.Bold
+            else -> null
+        }
+    )
+}
+
+private fun parseHexColor(hex: String): Color {
+    return try {
+        val cleaned = hex.removePrefix("#")
+        when (cleaned.length) {
+            3 -> {
+                val r = cleaned[0].toString().repeat(2).toInt(16)
+                val g = cleaned[1].toString().repeat(2).toInt(16)
+                val b = cleaned[2].toString().repeat(2).toInt(16)
+                Color(r, g, b)
+            }
+            6 -> Color(
+                cleaned.substring(0, 2).toInt(16),
+                cleaned.substring(2, 4).toInt(16),
+                cleaned.substring(4, 6).toInt(16)
+            )
+            8 -> Color(
+                cleaned.substring(2, 4).toInt(16),
+                cleaned.substring(4, 6).toInt(16),
+                cleaned.substring(6, 8).toInt(16),
+                cleaned.substring(0, 2).toInt(16)
+            )
+            else -> Color.Unspecified
+        }
+    } catch (_: Exception) {
+        Color.Unspecified
+    }
+}
+
+private fun decodeCodeEntities(text: String): String {
+    return text
+        .replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+}

--- a/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
@@ -444,7 +444,7 @@ private fun parseHtmlToAnnotatedString(
                         }
 
                         "li" -> {
-                            insideListItem = false
+                            // Keep insideListItem = true so next <li> adds a newline
                         }
 
                         "a" -> {

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -52,6 +52,38 @@ fun PostCard(
     modifier: Modifier = Modifier
 ) {
     val displayPost = post.sharedPost ?: post
+
+    if (displayPost.typename == "Article") {
+        ArticleCard(
+            post = post,
+            onClick = onClick,
+            onProfileClick = onProfileClick,
+            modifier = modifier
+        )
+    } else {
+        NoteCard(
+            post = post,
+            onClick = onClick,
+            onProfileClick = onProfileClick,
+            onReplyClick = onReplyClick,
+            onShareClick = onShareClick,
+            onQuotedPostClick = onQuotedPostClick,
+            modifier = modifier
+        )
+    }
+}
+
+@Composable
+private fun NoteCard(
+    post: Post,
+    onClick: () -> Unit,
+    onProfileClick: (String) -> Unit,
+    onReplyClick: (() -> Unit)? = null,
+    onShareClick: (() -> Unit)? = null,
+    onQuotedPostClick: ((String) -> Unit)? = null,
+    modifier: Modifier = Modifier
+) {
+    val displayPost = post.sharedPost ?: post
     val isRepost = post.sharedPost != null
 
     Card(
@@ -416,7 +448,7 @@ fun MediaGrid(media: List<pub.hackers.android.domain.model.Media>) {
 }
 
 
-private fun formatRelativeTime(instant: Instant): String {
+internal fun formatRelativeTime(instant: Instant): String {
     val now = Instant.now()
     val duration = Duration.between(instant, now)
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Reply
+import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -27,6 +28,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import pub.hackers.android.ui.components.CompactTopBar
@@ -38,6 +40,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -70,7 +73,7 @@ fun PostDetailScreen(
         contentWindowInsets = WindowInsets(0),
         topBar = {
             CompactTopBar(
-                title = "Post",
+                title = if (uiState.post?.typename == "Article") stringResource(R.string.article) else "Post",
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(
@@ -216,6 +219,23 @@ private fun PostDetailContent(
                         onClick = { onPostClick(post.quotedPost!!.id) },
                         onProfileClick = onProfileClick
                     )
+                }
+
+                if (post.typename == "Article" && post.url != null) {
+                    val uriHandler = LocalUriHandler.current
+                    Spacer(modifier = Modifier.height(12.dp))
+                    OutlinedButton(
+                        onClick = { uriHandler.openUri(post.url) },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(stringResource(R.string.read_on_web))
+                    }
                 }
 
                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,9 @@
     <string name="no_results">No results found</string>
 
     <!-- Post -->
+    <string name="article">Article</string>
+    <string name="read_full_article">Read full article</string>
+    <string name="read_on_web">Read on web</string>
     <string name="replies">Replies</string>
     <string name="shares">Shares</string>
     <string name="reactions">Reactions</string>


### PR DESCRIPTION
## Summary
- Add distinct ArticleCard with prominent title, summary, and "Read full article" footer, dispatched from PostCard by typename
- Add article-aware PostDetailScreen with "Read on web" button for articles
- Enhance HtmlContent with full rich text support: headings, bold/italic/strikethrough, blockquotes, ordered/unordered lists, inline code, and block code
- Add CodeBlockView that parses Shiki syntax highlighting spans from the server, rendering code blocks with proper per-token colors for both light and dark themes
- Fix list item line break rendering

## Test plan
- [ ] Verify articles in timeline show the new ArticleCard layout (title + summary + "Read full article")
- [ ] Verify notes still show the existing NoteCard layout with engagement bar
- [ ] Tap an article → PostDetailScreen shows "Article" title and "Read on web" button
- [ ] Verify code blocks in posts render with syntax highlighting colors
- [ ] Verify bullet lists and numbered lists have proper line breaks between items
- [ ] Verify headings, bold, italic, blockquotes render correctly
- [ ] Test both light and dark themes