### PR TITLE
Hide reply FAB when not authenticated

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -344,8 +344,8 @@ mutation CompleteLoginChallenge($token: UUID!, $code: String!) {
     }
 }
 
-mutation CreateNote($content: Markdown!, $language: Locale!, $visibility: PostVisibility!, $replyTargetId: ID) {
-    createNote(input: { content: $content, language: $language, visibility: $visibility, replyTargetId: $replyTargetId }) {
+mutation CreateNote($content: Markdown!, $language: Locale!, $visibility: PostVisibility!, $replyTargetId: ID, $quotedPostId: ID) {
+    createNote(input: { content: $content, language: $language, visibility: $visibility, replyTargetId: $replyTargetId, quotedPostId: $quotedPostId }) {
         ... on CreateNotePayload {
             note {
                 id

--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -420,6 +420,50 @@ query SearchActorsByHandle($prefix: String!, $limit: Int = 10) {
     }
 }
 
+query PostShares($id: ID!, $after: String) {
+    node(id: $id) {
+        ... on Post {
+            shares(first: 20, after: $after) {
+                edges {
+                    cursor
+                    node {
+                        id
+                        actor {
+                            ...ActorFields
+                        }
+                    }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+        }
+    }
+}
+
+query PostQuotes($id: ID!, $after: String) {
+    node(id: $id) {
+        ... on Post {
+            quotes(first: 20, after: $after) {
+                edges {
+                    cursor
+                    node {
+                        ...PostFields
+                        sharedPost {
+                            ...SharedPostFields
+                        }
+                    }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+        }
+    }
+}
+
 mutation FollowActor($actorId: ID!) {
     followActor(input: { actorId: $actorId }) {
         ... on FollowActorPayload {

--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -281,6 +281,7 @@ query PostDetail($id: ID!, $repliesAfter: String) {
                             }
                         }
                         totalCount
+                        viewerHasReacted
                     }
                 }
                 ... on CustomEmojiReactionGroup {
@@ -296,6 +297,7 @@ query PostDetail($id: ID!, $repliesAfter: String) {
                             }
                         }
                         totalCount
+                        viewerHasReacted
                     }
                 }
             }
@@ -526,6 +528,36 @@ mutation DeletePost($id: ID!) {
         }
         ... on SharedPostDeletionNotAllowedError {
             inputPath
+        }
+    }
+}
+
+mutation AddReactionToPost($postId: ID!, $emoji: String!) {
+    addReactionToPost(input: { postId: $postId, emoji: $emoji }) {
+        ... on AddReactionToPostPayload {
+            reaction {
+                id
+            }
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+    }
+}
+
+mutation RemoveReactionFromPost($postId: ID!, $emoji: String!) {
+    removeReactionFromPost(input: { postId: $postId, emoji: $emoji }) {
+        ... on RemoveReactionFromPostPayload {
+            success
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
         }
     }
 }

--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -29,6 +29,7 @@ fragment PostFields on Post {
     content
     excerpt
     url
+    iri
     viewerHasShared
     actor {
         ...ActorFields
@@ -49,6 +50,27 @@ fragment PostFields on Post {
     quotedPost {
         ...SharedPostFields
     }
+    reactionGroups {
+        __typename
+        ... on EmojiReactionGroup {
+            emoji
+            reactors(first: 20) {
+                totalCount
+                viewerHasReacted
+            }
+        }
+        ... on CustomEmojiReactionGroup {
+            customEmoji {
+                id
+                name
+                imageUrl
+            }
+            reactors(first: 20) {
+                totalCount
+                viewerHasReacted
+            }
+        }
+    }
 }
 
 fragment SharedPostFields on Post {
@@ -60,6 +82,7 @@ fragment SharedPostFields on Post {
     content
     excerpt
     url
+    iri
     viewerHasShared
     actor {
         ...ActorFields

--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -234,6 +234,10 @@ query ActorByHandle($handle: String!, $after: String) {
     actorByHandle(handle: $handle, allowLocalHandle: true) {
         id
         handle
+        isViewer
+        viewerFollows
+        followsViewer
+        viewerBlocks
         name
         bio
         avatarUrl
@@ -411,5 +415,117 @@ query SearchActorsByHandle($prefix: String!, $limit: Int = 10) {
         handle
         name
         avatarUrl
+    }
+}
+
+mutation FollowActor($actorId: ID!) {
+    followActor(input: { actorId: $actorId }) {
+        ... on FollowActorPayload {
+            followee {
+                id
+            }
+            follower {
+                id
+            }
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+    }
+}
+
+mutation UnfollowActor($actorId: ID!) {
+    unfollowActor(input: { actorId: $actorId }) {
+        ... on UnfollowActorPayload {
+            followee {
+                id
+            }
+            follower {
+                id
+            }
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+    }
+}
+
+mutation BlockActor($actorId: ID!) {
+    blockActor(input: { actorId: $actorId }) {
+        ... on BlockActorPayload {
+            blockee {
+                id
+            }
+            blocker {
+                id
+            }
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+    }
+}
+
+mutation UnblockActor($actorId: ID!) {
+    unblockActor(input: { actorId: $actorId }) {
+        ... on UnblockActorPayload {
+            blockee {
+                id
+            }
+            blocker {
+                id
+            }
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+    }
+}
+
+mutation RemoveFollower($actorId: ID!) {
+    removeFollower(input: { actorId: $actorId }) {
+        ... on RemoveFollowerPayload {
+            followee {
+                id
+            }
+            follower {
+                id
+            }
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+    }
+}
+
+mutation DeletePost($id: ID!) {
+    deletePost(input: { id: $id }) {
+        ... on DeletePostPayload {
+            deletedPostId
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+        ... on SharedPostDeletionNotAllowedError {
+            inputPath
+        }
     }
 }

--- a/app/src/main/graphql/pub/hackers/android/schema.graphqls
+++ b/app/src/main/graphql/pub/hackers/android/schema.graphqls
@@ -1,160 +1,96 @@
 type Account implements Node {
   actor: Actor!
-
   articleDrafts(after: String, before: String, first: Int, last: Int): AccountArticleDraftsConnection!
-
   avatarUrl: URL!
-
   bio: Markdown!
-
   created: DateTime!
-
   defaultNoteVisibility: PostVisibility!
-
   defaultShareVisibility: PostVisibility!
-
   handle: String!
-
   id: ID!
-
   invitationsLeft: Int!
-
   invitees(after: String, before: String, first: Int, last: Int): AccountInviteesConnection!
-
   inviter: Account
-
   links: [AccountLink!]!
-
   locales: [Locale!]
-
   moderator: Boolean!
-
   name: String!
-
   notifications(after: String, before: String, first: Int, last: Int): AccountNotificationsConnection!
-
   passkeys(after: String, before: String, first: Int, last: Int): AccountPasskeysConnection!
-
   preferAiSummary: Boolean!
-
   updated: DateTime!
-
   username: String!
-
   usernameChanged: DateTime
-
   uuid: UUID!
 }
 
 type AccountArticleDraftsConnection {
   edges: [AccountArticleDraftsConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type AccountArticleDraftsConnectionEdge {
   cursor: String!
-
   node: ArticleDraft!
 }
 
 type AccountInviteesConnection {
   edges: [AccountInviteesConnectionEdge!]!
-
   pageInfo: PageInfo!
-
   totalCount: Int!
 }
 
 type AccountInviteesConnectionEdge {
   cursor: String!
-
   node: Account!
 }
 
 type AccountLink implements Node {
   created: DateTime!
-
   handle: String
-
   icon: AccountLinkIcon!
-
   id: ID!
-
   index: Int!
-
   name: String!
-
   url: URL!
-
   verified: DateTime
 }
 
 enum AccountLinkIcon {
   ACTIVITYPUB
-
   AKKOMA
-
   BLUESKY
-
   CODEBERG
-
   DEV
-
   DISCORD
-
   FACEBOOK
-
   GITHUB
-
   GITLAB
-
   HACKERNEWS
-
   HOLLO
-
   INSTAGRAM
-
   KEYBASE
-
   LEMMY
-
   LINKEDIN
-
   LOBSTERS
-
   MASTODON
-
   MATRIX
-
   MISSKEY
-
   PIXELFED
-
   PLEROMA
-
   QIITA
-
   REDDIT
-
   SOURCEHUT
-
   THREADS
-
   VELOG
-
   WEB
-
   WIKIPEDIA
-
   X
-
   ZENN
 }
 
 input AccountLinkInput {
   name: String!
-
   url: URL!
 }
 
@@ -164,404 +100,287 @@ type AccountNotFoundError {
 
 type AccountNotificationsConnection {
   edges: [AccountNotificationsConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type AccountNotificationsConnectionEdge {
   cursor: String!
-
   node: Notification!
 }
 
 type AccountPasskeysConnection {
   edges: [AccountPasskeysConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type AccountPasskeysConnectionEdge {
   cursor: String!
-
   node: Passkey!
 }
 
 type Actor implements Node {
   account: Account
-
   articles(after: String, before: String, first: Int, last: Int): ActorArticlesConnection!
-
   automaticallyApprovesFollowers: Boolean!
-
   avatarInitials: String!
-
   avatarUrl: URL!
-
   bio: HTML
-
   created: DateTime!
-
   fields: [ActorField!]!
-
   followees(after: String, before: String, first: Int, last: Int): ActorFolloweesConnection!
-
   followers(after: String, before: String, first: Int, last: Int): ActorFollowersConnection!
-
   follows(followeeId: ID): Boolean!
-
   followsViewer: Boolean!
-
   handle: String!
-
   handleHost: String!
-
   headerUrl: URL
-
   id: ID!
-
   instance: Instance
-
   instanceHost: String!
-
   iri: URL!
-
   isFollowedBy(followerId: ID): Boolean!
-
+  isViewer: Boolean!
   local: Boolean!
-
   name: HTML
-
   noteByUuid(uuid: UUID!): Note
-
   notes(after: String, before: String, first: Int, last: Int): ActorNotesConnection!
-
   pins(after: String, before: String, first: Int, last: Int): ActorPinsConnection!
-
   posts(after: String, before: String, first: Int, last: Int): ActorPostsConnection!
-
   published: DateTime
-
   questions(after: String, before: String, first: Int, last: Int): ActorQuestionsConnection!
-
   rawName: String
-
   sensitive: Boolean!
-
   sharedPosts(after: String, before: String, first: Int, last: Int): ActorSharedPostsConnection!
-
   successor: Actor
-
   type: ActorType!
-
   updated: DateTime!
-
   url: URL
-
   username: String!
-
   uuid: UUID!
+  viewerBlocks: Boolean!
+  viewerFollows: Boolean!
 }
 
 type ActorArticlesConnection {
   edges: [ActorArticlesConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type ActorArticlesConnectionEdge {
   cursor: String!
-
   node: Article!
 }
 
-"""
-A property pair in an actor's account.
-"""
+"""A property pair in an actor's account."""
 type ActorField {
   name: String!
-
   value: HTML!
 }
 
 type ActorFolloweesConnection {
   edges: [ActorFolloweesConnectionEdge!]!
-
   pageInfo: PageInfo!
-
   totalCount: Int!
 }
 
 type ActorFolloweesConnectionEdge {
   accepted: DateTime
-
   created: DateTime!
-
   cursor: String!
-
   iri: URL!
-
   node: Actor!
 }
 
 type ActorFollowersConnection {
   edges: [ActorFollowersConnectionEdge!]!
-
   pageInfo: PageInfo!
-
   totalCount: Int!
 }
 
 type ActorFollowersConnectionEdge {
   accepted: DateTime
-
   created: DateTime!
-
   cursor: String!
-
   iri: URL!
-
   node: Actor!
 }
 
 type ActorNotesConnection {
   edges: [ActorNotesConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type ActorNotesConnectionEdge {
   cursor: String!
-
   node: Note!
 }
 
 type ActorPinsConnection {
   edges: [ActorPinsConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type ActorPinsConnectionEdge {
   cursor: String!
-
   node: Post!
 }
 
 type ActorPostsConnection {
   edges: [ActorPostsConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type ActorPostsConnectionEdge {
   cursor: String!
-
   node: Post!
 }
 
 type ActorQuestionsConnection {
   edges: [ActorQuestionsConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type ActorQuestionsConnectionEdge {
   cursor: String!
-
   node: Question!
 }
 
 type ActorSharedPostsConnection {
   edges: [ActorSharedPostsConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type ActorSharedPostsConnectionEdge {
   cursor: String!
-
   node: Post!
 }
 
 enum ActorType {
   APPLICATION
-
   GROUP
-
   ORGANIZATION
-
   PERSON
-
   SERVICE
 }
 
 input AddReactionToPostInput {
   clientMutationId: ID
-
   emoji: String!
-
   postId: ID!
 }
 
 type AddReactionToPostPayload {
   clientMutationId: ID
-
   reaction: Reaction
 }
 
-union AddReactionToPostResult = AddReactionToPostPayload|InvalidInputError|NotAuthenticatedError
+union AddReactionToPostResult = AddReactionToPostPayload | InvalidInputError | NotAuthenticatedError
 
 type Article implements Node & Post & Reactable {
   account: Account!
-
   actor: Actor!
-
   allowLlmTranslation: Boolean!
-
   content: HTML!
-
   contents(includeBeingTranslated: Boolean = false, language: Locale): [ArticleContent!]!
-
   engagementStats: PostEngagementStats!
-
   excerpt: String!
-
   hashtags: [Hashtag!]!
-
   id: ID!
-
   iri: URL!
-
   language: String
-
   link: PostLink
-
   media: [PostMedium!]!
-
   mentions(after: String, before: String, first: Int, last: Int): PostMentionsConnection!
-
   name: String
-
   published: DateTime!
-
   publishedYear: Int!
-
   quotedPost: Post
-
   quotes(after: String, before: String, first: Int, last: Int): PostQuotesConnection!
-
   reactionGroups: [ReactionGroup!]!
-
   replies(after: String, before: String, first: Int, last: Int): PostRepliesConnection!
-
   replyTarget: Post
-
   sensitive: Boolean!
-
   sharedPost: Post
-
   shares(after: String, before: String, first: Int, last: Int): PostSharesConnection!
-
   slug: String!
-
   summary: String
-
   tags: [String!]!
-
   updated: DateTime!
-
   url: URL
-
   uuid: UUID!
-
   viewerHasShared: Boolean!
-
   visibility: PostVisibility!
 }
 
 type ArticleContent implements Node {
   beingTranslated: Boolean!
-
   content: HTML!
-
   id: ID!
-
   language: Locale!
-
   originalLanguage: Locale
-
   published: DateTime!
-
   summary: String
-
   summaryStarted: DateTime
-
   title: String!
-
   translationRequester: Account
-
   translator: Account
-
   updated: DateTime!
-
   url: URL!
 }
 
 type ArticleDraft implements Node {
   account: Account!
-
   content: Markdown!
 
+  """The rendered HTML of the draft's markdown content."""
+  contentHtml: HTML!
   created: DateTime!
-
   id: ID!
-
   tags: [String!]!
-
   title: String!
-
   updated: DateTime!
-
   uuid: UUID!
 }
 
+input BlockActorInput {
+  actorId: ID!
+  clientMutationId: ID
+}
+
+type BlockActorPayload {
+  blockee: Actor!
+  blocker: Actor!
+  clientMutationId: ID
+}
+
+union BlockActorResult = BlockActorPayload | InvalidInputError | NotAuthenticatedError
+
 input CreateNoteInput {
   clientMutationId: ID
-
   content: Markdown!
-
   language: Locale!
-
   quotedPostId: ID
-
   replyTargetId: ID
-
   visibility: PostVisibility!
 }
 
 type CreateNotePayload {
   clientMutationId: ID
-
   note: Note!
 }
 
-union CreateNoteResult = CreateNotePayload|InvalidInputError|NotAuthenticatedError
+union CreateNoteResult = CreateNotePayload | InvalidInputError | NotAuthenticatedError
 
 type CustomEmoji implements Node {
   id: ID!
-
   imageUrl: String!
-
   iri: URL!
-
   name: String!
 }
 
 type CustomEmojiReactionGroup implements ReactionGroup {
   customEmoji: CustomEmoji!
-
   reactors(after: String, before: String, first: Int, last: Int): ReactionGroupReactorsConnection!
-
   subject: Reactable!
 }
 
@@ -577,39 +396,40 @@ scalar DateTime
 
 input DeleteArticleDraftInput {
   clientMutationId: ID
-
   id: ID!
 }
 
 type DeleteArticleDraftPayload {
   clientMutationId: ID
-
   deletedDraftId: ID!
 }
 
-union DeleteArticleDraftResult = DeleteArticleDraftPayload|InvalidInputError|NotAuthenticatedError
+union DeleteArticleDraftResult = DeleteArticleDraftPayload | InvalidInputError | NotAuthenticatedError
 
-"""
-A document in a specific language.
-"""
+input DeletePostInput {
+  clientMutationId: ID
+  id: ID!
+}
+
+type DeletePostPayload {
+  clientMutationId: ID
+  deletedPostId: ID!
+}
+
+union DeletePostResult = DeletePostPayload | InvalidInputError | NotAuthenticatedError | SharedPostDeletionNotAllowedError
+
+"""A document in a specific language."""
 type Document {
   html: String!
 
-  """
-  The locale of the document.
-  """
+  """The locale of the document."""
   locale: Locale!
-
   markdown: String!
 
-  """
-  The title of the document.
-  """
+  """The title of the document."""
   title: String!
 
-  """
-  Table of contents for the document.
-  """
+  """Table of contents for the document."""
   toc: JSON!
 }
 
@@ -617,9 +437,7 @@ scalar Email
 
 type EmojiReactionGroup implements ReactionGroup {
   emoji: String!
-
   reactors(after: String, before: String, first: Int, last: Int): ReactionGroupReactorsConnection!
-
   subject: Reactable!
 }
 
@@ -627,26 +445,32 @@ type EmptySearchQueryError {
   message: String!
 }
 
+input FollowActorInput {
+  actorId: ID!
+  clientMutationId: ID
+}
+
+type FollowActorPayload {
+  clientMutationId: ID
+  followee: Actor!
+  follower: Actor!
+}
+
+union FollowActorResult = FollowActorPayload | InvalidInputError | NotAuthenticatedError
+
 type FollowNotification implements Node & Notification {
   account: Account!
-
   actors(after: String, before: String, first: Int, last: Int): NotificationActorsConnection!
-
   created: DateTime!
-
   id: ID!
-
   uuid: UUID!
 }
 
-"""
-An HTML string.
-"""
+"""An HTML string."""
 scalar HTML
 
 type Hashtag {
   href: URL!
-
   name: String!
 }
 
@@ -657,15 +481,10 @@ scalar IP
 
 type Instance implements Node {
   created: DateTime!
-
   host: String!
-
   id: ID!
-
   software: String
-
   softwareVersion: String
-
   updated: DateTime!
 }
 
@@ -673,68 +492,47 @@ type InvalidInputError {
   inputPath: String!
 }
 
-"""
-An invitation that has been created.
-"""
+"""An invitation that has been created."""
 type Invitation {
   email: Email!
-
   inviter: Account!
-
   locale: Locale!
-
   message: Markdown
 }
 
-"""
-A node in the invitation tree.
-"""
+"""A node in the invitation tree."""
 type InvitationTreeNode {
   avatarUrl: URL!
-
   hidden: Boolean!
-
   id: ID!
-
   inviterId: ID
-
   name: String
-
   username: String
 }
 
 enum InviteEmailError {
   EMAIL_ALREADY_TAKEN
-
   EMAIL_INVALID
 }
 
 enum InviteInviterError {
   INVITER_EMAIL_SEND_FAILED
-
   INVITER_NOT_AUTHENTICATED
-
   INVITER_NO_INVITATIONS_LEFT
 }
 
-union InviteResult = Invitation|InviteValidationErrors
+union InviteResult = Invitation | InviteValidationErrors
 
-"""
-Validation errors that occurred during the invitation process.
-"""
+"""Validation errors that occurred during the invitation process."""
 type InviteValidationErrors {
   email: InviteEmailError
-
   emailOwner: Account
-
   inviter: InviteInviterError
-
   verifyUrl: InviteVerifyUrlError
 }
 
 enum InviteVerifyUrlError {
   VERIFY_URL_NO_CODE
-
   VERIFY_URL_NO_TOKEN
 }
 
@@ -743,90 +541,123 @@ The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://
 """
 scalar JSON
 
-"""
-A BCP 47-compliant language tag.
-"""
+"""A BCP 47-compliant language tag."""
 scalar Locale
 
-"""
-A login challenge for an account.
-"""
+"""A login challenge for an account."""
 type LoginChallenge {
   account: Account!
-
   created: DateTime!
-
   token: UUID!
 }
 
-union LoginResult = AccountNotFoundError|LoginChallenge
+union LoginResult = AccountNotFoundError | LoginChallenge
 
-"""
-A Hackers' Pub-flavored Markdown text.
-"""
+"""A Hackers' Pub-flavored Markdown text."""
 scalar Markdown
 
 scalar MediaType
 
 type MentionNotification implements Node & Notification {
   account: Account!
-
   actors(after: String, before: String, first: Int, last: Int): NotificationActorsConnection!
-
   created: DateTime!
-
   id: ID!
-
   post: Post
-
   uuid: UUID!
 }
 
 type Mutation {
   addReactionToPost(input: AddReactionToPostInput!): AddReactionToPostResult!
+  blockActor(input: BlockActorInput!): BlockActorResult!
+  completeLoginChallenge(
+    """The code of the login challenge."""
+    code: String!
 
-  completeLoginChallenge("The code of the login challenge." code: String!, "The token of the login challenge." token: UUID!): Session
+    """The token of the login challenge."""
+    token: UUID!
+  ): Session
 
-  """
-  Complete the signup process by creating a new account and session.
-  """
-  completeSignup("The verification code." code: String!, "The account creation data." input: SignupInput!, "The signup token." token: UUID!): SignupResult!
+  """Complete the signup process by creating a new account and session."""
+  completeSignup(
+    """The verification code."""
+    code: String!
 
+    """The account creation data."""
+    input: SignupInput!
+
+    """The signup token."""
+    token: UUID!
+  ): SignupResult!
   createNote(input: CreateNoteInput!): CreateNoteResult!
-
   deleteArticleDraft(input: DeleteArticleDraftInput!): DeleteArticleDraftResult!
-
-  getPasskeyAuthenticationOptions("Temporary session ID for passkey authentication." sessionId: UUID!): JSON!
-
+  deletePost(input: DeletePostInput!): DeletePostResult!
+  followActor(input: FollowActorInput!): FollowActorResult!
+  getPasskeyAuthenticationOptions(
+    """Temporary session ID for passkey authentication."""
+    sessionId: UUID!
+  ): JSON!
   getPasskeyRegistrationOptions(accountId: ID!): JSON!
+  invite(
+    email: Email!
+    locale: Locale!
+    message: Markdown
 
-  invite(email: Email!, locale: Locale!, message: Markdown, "The RFC 6570-compliant URI Template for the verification link.  Available variables: `{token}` and `{code}`." verifyUrl: URITemplate!): InviteResult!
+    """
+    The RFC 6570-compliant URI Template for the verification link.  Available variables: `{token}` and `{code}`.
+    """
+    verifyUrl: URITemplate!
+  ): InviteResult!
+  loginByEmail(
+    """The email of the account to sign in."""
+    email: String!
 
-  loginByEmail("The email of the account to sign in." email: String!, "The locale for the sign-in email." locale: Locale!, "The RFC 6570-compliant URI Template for the verification link.  Available variabvles: `{token}` and `{code}`." verifyUrl: URITemplate!): LoginResult!
+    """The locale for the sign-in email."""
+    locale: Locale!
 
-  loginByPasskey("WebAuthn authentication response from the client." authenticationResponse: JSON!, "Temporary session ID used for authentication options." sessionId: UUID!): Session
+    """
+    The RFC 6570-compliant URI Template for the verification link.  Available variabvles: `{token}` and `{code}`.
+    """
+    verifyUrl: URITemplate!
+  ): LoginResult!
+  loginByPasskey(
+    """WebAuthn authentication response from the client."""
+    authenticationResponse: JSON!
 
-  loginByUsername("The locale for the sign-in email." locale: Locale!, "The username of the account to sign in." username: String!, "The RFC 6570-compliant URI Template for the verification link.  Available variabvles: `{token}` and `{code}`." verifyUrl: URITemplate!): LoginResult!
+    """Temporary session ID used for authentication options."""
+    sessionId: UUID!
+  ): Session
+  loginByUsername(
+    """The locale for the sign-in email."""
+    locale: Locale!
 
+    """The username of the account to sign in."""
+    username: String!
+
+    """
+    The RFC 6570-compliant URI Template for the verification link.  Available variabvles: `{token}` and `{code}`.
+    """
+    verifyUrl: URITemplate!
+  ): LoginResult!
   publishArticleDraft(input: PublishArticleDraftInput!): PublishArticleDraftResult!
-
+  registerApnsDeviceToken(input: RegisterApnsDeviceTokenInput!): RegisterApnsDeviceTokenResult!
+  removeFollower(input: RemoveFollowerInput!): RemoveFollowerResult!
   removeReactionFromPost(input: RemoveReactionFromPostInput!): RemoveReactionFromPostResult!
-
   revokePasskey(passkeyId: ID!): ID
 
-  """
-  Revoke a session by its ID.
-  """
-  revokeSession("The ID of the session to log out." sessionId: UUID!): Session
-
+  """Revoke a session by its ID."""
+  revokeSession(
+    """The ID of the session to log out."""
+    sessionId: UUID!
+  ): Session
   saveArticleDraft(input: SaveArticleDraftInput!): SaveArticleDraftResult!
-
   sharePost(input: SharePostInput!): SharePostResult!
-
+  unblockActor(input: UnblockActorInput!): UnblockActorResult!
+  unfollowActor(input: UnfollowActorInput!): UnfollowActorResult!
+  unregisterApnsDeviceToken(input: UnregisterApnsDeviceTokenInput!): UnregisterApnsDeviceTokenResult!
   unsharePost(input: UnsharePostInput!): UnsharePostResult!
-
   updateAccount(input: UpdateAccountInput!): UpdateAccountPayload!
-
+  uploadMedia(input: UploadMediaInput!): UploadMediaResult!
   verifyPasskeyRegistration(accountId: ID!, name: String!, registrationResponse: JSON!): PasskeyRegistrationResult!
 }
 
@@ -840,748 +671,572 @@ type NotAuthenticatedError {
 
 type Note implements Node & Post & Reactable {
   actor: Actor!
-
   content: HTML!
-
   engagementStats: PostEngagementStats!
-
   excerpt: String!
-
   hashtags: [Hashtag!]!
-
   id: ID!
-
   iri: URL!
-
   language: String
-
   link: PostLink
-
   media: [PostMedium!]!
-
   mentions(after: String, before: String, first: Int, last: Int): PostMentionsConnection!
-
   name: String
-
   published: DateTime!
-
   quotedPost: Post
-
   quotes(after: String, before: String, first: Int, last: Int): PostQuotesConnection!
-
   reactionGroups: [ReactionGroup!]!
-
   replies(after: String, before: String, first: Int, last: Int): PostRepliesConnection!
-
   replyTarget: Post
-
   sensitive: Boolean!
-
   sharedPost: Post
-
   shares(after: String, before: String, first: Int, last: Int): PostSharesConnection!
-
   summary: String
-
   updated: DateTime!
-
   url: URL
-
   uuid: UUID!
-
   viewerHasShared: Boolean!
-
   visibility: PostVisibility!
 }
 
 interface Notification implements Node {
   account: Account!
-
   actors(after: String, before: String, first: Int, last: Int): NotificationActorsConnection!
-
   created: DateTime!
-
   id: ID!
-
   uuid: UUID!
 }
 
 type NotificationActorsConnection {
   edges: [NotificationActorsConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type NotificationActorsConnectionEdge {
   cursor: String!
-
   node: Actor!
 }
 
 enum NotificationType {
   FOLLOW
-
   MENTION
-
   QUOTE
-
   REACT
-
   REPLY
-
   SHARE
 }
 
 type PageInfo {
   endCursor: String
-
   hasNextPage: Boolean!
-
   hasPreviousPage: Boolean!
-
   startCursor: String
 }
 
 type Passkey implements Node {
   created: DateTime!
-
   id: ID!
-
   lastUsed: DateTime
-
   name: String!
 }
 
 type PasskeyRegistrationResult {
   passkey: Passkey
-
   verified: Boolean!
 }
 
 type Poll implements Node {
   ends: DateTime!
-
   id: ID!
-
   multiple: Boolean!
-
   options: [PollOption!]!
-
   post: Post!
-
   voters(after: String, before: String, first: Int, last: Int): PollVotersConnection!
-
   votes(after: String, before: String, first: Int, last: Int): PollVotesConnection!
 }
 
 type PollOption {
   poll: Poll!
-
   title: String!
-
   votes(after: String, before: String, first: Int, last: Int): PollOptionVotesConnection!
 }
 
 type PollOptionVotesConnection {
   edges: [PollOptionVotesConnectionEdge!]!
-
   pageInfo: PageInfo!
-
   totalCount: Int!
 }
 
 type PollOptionVotesConnectionEdge {
   cursor: String!
-
   node: PollVote!
 }
 
 type PollVote {
   actor: Actor!
-
   created: DateTime!
-
   option: PollOption!
-
   poll: Poll!
 }
 
 type PollVotersConnection {
   edges: [PollVotersConnectionEdge!]!
-
   pageInfo: PageInfo!
-
   totalCount: Int!
 }
 
 type PollVotersConnectionEdge {
   cursor: String!
-
   node: Actor!
 }
 
 type PollVotesConnection {
   edges: [PollVotesConnectionEdge!]!
-
   pageInfo: PageInfo!
-
   totalCount: Int!
 }
 
 type PollVotesConnectionEdge {
   cursor: String!
-
   node: PollVote!
 }
 
 interface Post implements Node & Reactable {
   actor: Actor!
-
   content: HTML!
-
   engagementStats: PostEngagementStats!
-
   excerpt: String!
-
   hashtags: [Hashtag!]!
-
   id: ID!
-
   iri: URL!
-
   language: String
-
   link: PostLink
-
   media: [PostMedium!]!
-
   mentions(after: String, before: String, first: Int, last: Int): PostMentionsConnection!
-
   name: String
-
   published: DateTime!
-
   quotedPost: Post
-
   quotes(after: String, before: String, first: Int, last: Int): PostQuotesConnection!
-
   reactionGroups: [ReactionGroup!]!
-
   replies(after: String, before: String, first: Int, last: Int): PostRepliesConnection!
-
   replyTarget: Post
-
   sensitive: Boolean!
-
   sharedPost: Post
-
   shares(after: String, before: String, first: Int, last: Int): PostSharesConnection!
-
   summary: String
-
   updated: DateTime!
-
   url: URL
-
   uuid: UUID!
-
   viewerHasShared: Boolean!
-
   visibility: PostVisibility!
 }
 
 type PostEngagementStats {
   post: Post!
-
   quotes: Int!
-
   reactions: Int!
-
   replies: Int!
-
   shares: Int!
 }
 
 type PostLink implements Node {
   author: String
-
   creator: Actor
-
   description: String
-
   id: ID!
-
   image: PostLinkImage
-
   siteName: String
-
   title: String
-
   type: String
-
   url: URL!
 }
 
 type PostLinkImage {
   alt: String
-
   height: Int
-
   post: PostLink!
-
   type: MediaType
-
   url: URL!
-
   width: Int
 }
 
 type PostMedium implements Node {
   alt: String
-
   height: Int
-
   id: ID!
-
   sensitive: Boolean!
-
   thumbnailUrl: String
-
   type: MediaType!
-
   url: URL!
-
   width: Int
 }
 
 type PostMentionsConnection {
   edges: [PostMentionsConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type PostMentionsConnectionEdge {
   cursor: String!
-
   node: Actor!
 }
 
 type PostQuotesConnection {
   edges: [PostQuotesConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type PostQuotesConnectionEdge {
   cursor: String!
-
   node: Post!
 }
 
 type PostRepliesConnection {
   edges: [PostRepliesConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type PostRepliesConnectionEdge {
   cursor: String!
-
   node: Post!
 }
 
 type PostSharesConnection {
   edges: [PostSharesConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type PostSharesConnectionEdge {
   cursor: String!
-
   node: Post!
 }
 
 enum PostType {
   ARTICLE
-
   NOTE
-
   QUESTION
 }
 
 enum PostVisibility {
   DIRECT
-
   FOLLOWERS
-
   NONE
-
   PUBLIC
-
   UNLISTED
 }
 
 input PublishArticleDraftInput {
   allowLlmTranslation: Boolean
-
   clientMutationId: ID
-
   id: ID!
-
   language: Locale!
-
   slug: String!
 }
 
 type PublishArticleDraftPayload {
   article: Article!
-
   clientMutationId: ID
-
   deletedDraftId: ID!
 }
 
-union PublishArticleDraftResult = InvalidInputError|NotAuthenticatedError|PublishArticleDraftPayload
+union PublishArticleDraftResult = InvalidInputError | NotAuthenticatedError | PublishArticleDraftPayload
 
 type Query {
   accountByUsername(username: String!): Account
-
-  actorByHandle("Whether to allow local handles (e.g. @username)." allowLocalHandle: Boolean = false, handle: String!): Actor
-
+  actorByHandle(
+    """Whether to allow local handles (e.g. @username)."""
+    allowLocalHandle: Boolean = false
+    handle: String!
+  ): Actor
   actorByUuid(uuid: UUID!): Actor
-
   articleDraft(id: ID, uuid: UUID): ArticleDraft
-
   availableLocales: [Locale!]!
-
-  codeOfConduct("The locale for the Code of Conduct." locale: Locale!): Document!
-
+  codeOfConduct(
+    """The locale for the Code of Conduct."""
+    locale: Locale!
+  ): Document!
   instanceByHost(host: String!): Instance
 
-  """
-  Returns all accounts as a flat array for building the invitation tree.
-  """
+  """Returns all accounts as a flat array for building the invitation tree."""
   invitationTree: [InvitationTreeNode!]!
 
-  markdownGuide("The locale for the Markdown guide." locale: Locale!): Document!
+  """
+  Look up a remote Fediverse user by their handle, fetching their ActivityPub profile and constructing a remote follow URL for the given actor.
+  """
+  lookupRemoteFollower(
+    """The Relay global ID of the Hackers' Pub actor to be followed."""
+    actorId: ID!
 
+    """
+    The Fediverse handle of the remote user who wants to follow (e.g., @user@mastodon.social).
+    """
+    followerHandle: String!
+  ): WebFingerResult
+  markdownGuide(
+    """The locale for the Markdown guide."""
+    locale: Locale!
+  ): Document!
   node(id: ID!): Node
-
   nodes(ids: [ID!]!): [Node]!
-
   personalTimeline(after: String, before: String, first: Int, last: Int, local: Boolean = false, postType: PostType, withoutShares: Boolean = false): QueryPersonalTimelineConnection!
-
   publicTimeline(after: String, before: String, first: Int, languages: [Locale!] = [], last: Int, local: Boolean = false, postType: PostType, withoutShares: Boolean = false): QueryPublicTimelineConnection!
-
   searchActorsByHandle(limit: Int = 25, prefix: String!): [Actor!]!
-
-  searchGuide("The locale for the search guide." locale: Locale!): Document!
-
+  searchGuide(
+    """The locale for the search guide."""
+    locale: Locale!
+  ): Document!
   searchObject(query: String!): SearchObjectResult
-
   searchPost(after: String, before: String, first: Int, languages: [Locale!] = [], last: Int, query: String!): QuerySearchPostConnection!
 
-  """
-  Verify a signup token and return the signup info if valid.
-  """
-  verifySignupToken("The verification code." code: String!, "The signup token to verify." token: UUID!): SignupInfo
+  """Verify a signup token and return the signup info if valid."""
+  verifySignupToken(
+    """The verification code."""
+    code: String!
 
+    """The signup token to verify."""
+    token: UUID!
+  ): SignupInfo
   viewer: Account
 }
 
 type QueryPersonalTimelineConnection {
   edges: [QueryPersonalTimelineConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type QueryPersonalTimelineConnectionEdge {
   added: DateTime!
-
   cursor: String!
-
   lastSharer: Actor
-
   node: Post!
-
   sharersCount: Int!
 }
 
 type QueryPublicTimelineConnection {
   edges: [QueryPublicTimelineConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type QueryPublicTimelineConnectionEdge {
   added: DateTime!
-
   cursor: String!
-
   lastSharer: Actor
-
   node: Post!
-
   sharersCount: Int!
 }
 
 type QuerySearchPostConnection {
   edges: [QuerySearchPostConnectionEdge!]!
-
   pageInfo: PageInfo!
 }
 
 type QuerySearchPostConnectionEdge {
   cursor: String!
-
   node: Post!
 }
 
 type Question implements Node & Post & Reactable {
   actor: Actor!
-
   content: HTML!
-
   engagementStats: PostEngagementStats!
-
   excerpt: String!
-
   hashtags: [Hashtag!]!
-
   id: ID!
-
   iri: URL!
-
   language: String
-
   link: PostLink
-
   media: [PostMedium!]!
-
   mentions(after: String, before: String, first: Int, last: Int): PostMentionsConnection!
-
   name: String
-
   poll: Poll!
-
   published: DateTime!
-
   quotedPost: Post
-
   quotes(after: String, before: String, first: Int, last: Int): PostQuotesConnection!
-
   reactionGroups: [ReactionGroup!]!
-
   replies(after: String, before: String, first: Int, last: Int): PostRepliesConnection!
-
   replyTarget: Post
-
   sensitive: Boolean!
-
   sharedPost: Post
-
   shares(after: String, before: String, first: Int, last: Int): PostSharesConnection!
-
   summary: String
-
   updated: DateTime!
-
   url: URL
-
   uuid: UUID!
-
   viewerHasShared: Boolean!
-
   visibility: PostVisibility!
 }
 
 type QuoteNotification implements Node & Notification {
   account: Account!
-
   actors(after: String, before: String, first: Int, last: Int): NotificationActorsConnection!
-
   created: DateTime!
-
   id: ID!
-
   post: Post
-
   uuid: UUID!
 }
 
 type ReactNotification implements Node & Notification {
   account: Account!
-
   actors(after: String, before: String, first: Int, last: Int): NotificationActorsConnection!
-
   created: DateTime!
-
   customEmoji: CustomEmoji
-
   emoji: String
-
   id: ID!
-
   post: Post
-
   uuid: UUID!
 }
 
 interface Reactable implements Node {
   id: ID!
-
   reactionGroups: [ReactionGroup!]!
 }
 
 type Reaction implements Node {
   actor: Actor!
-
   created: DateTime!
-
   data: ReactionData!
-
   id: ID!
-
   post: Post!
 }
 
-union ReactionData = CustomEmoji|StandardEmoji
+union ReactionData = CustomEmoji | StandardEmoji
 
 interface ReactionGroup {
   reactors(after: String, before: String, first: Int, last: Int): ReactionGroupReactorsConnection!
-
   subject: Reactable!
 }
 
 type ReactionGroupReactorsConnection {
   edges: [ReactionGroupReactorsConnectionEdge!]!
-
   pageInfo: PageInfo!
-
   totalCount: Int!
-
   viewerHasReacted: Boolean!
 }
 
 type ReactionGroupReactorsConnectionEdge {
   cursor: String!
-
   node: Actor!
 }
 
-input RemoveReactionFromPostInput {
+type RegisterApnsDeviceTokenFailedError {
+  limit: Int!
+  message: String!
+}
+
+input RegisterApnsDeviceTokenInput {
   clientMutationId: ID
 
-  emoji: String!
+  """The APNS device token."""
+  deviceToken: String!
+}
 
+type RegisterApnsDeviceTokenPayload {
+  clientMutationId: ID
+  created: DateTime!
+  deviceToken: String!
+  updated: DateTime!
+}
+
+union RegisterApnsDeviceTokenResult = InvalidInputError | NotAuthenticatedError | RegisterApnsDeviceTokenFailedError | RegisterApnsDeviceTokenPayload
+
+input RemoveFollowerInput {
+  actorId: ID!
+  clientMutationId: ID
+}
+
+type RemoveFollowerPayload {
+  clientMutationId: ID
+  followee: Actor!
+  follower: Actor!
+}
+
+union RemoveFollowerResult = InvalidInputError | NotAuthenticatedError | RemoveFollowerPayload
+
+input RemoveReactionFromPostInput {
+  clientMutationId: ID
+  emoji: String!
   postId: ID!
 }
 
 type RemoveReactionFromPostPayload {
   clientMutationId: ID
-
   success: Boolean!
 }
 
-union RemoveReactionFromPostResult = InvalidInputError|NotAuthenticatedError|RemoveReactionFromPostPayload
+union RemoveReactionFromPostResult = InvalidInputError | NotAuthenticatedError | RemoveReactionFromPostPayload
 
 type ReplyNotification implements Node & Notification {
   account: Account!
-
   actors(after: String, before: String, first: Int, last: Int): NotificationActorsConnection!
-
   created: DateTime!
-
   id: ID!
-
   post: Post
-
   uuid: UUID!
 }
 
 input SaveArticleDraftInput {
   clientMutationId: ID
-
   content: Markdown!
-
   id: ID
-
   tags: [String!]!
-
   title: String!
 }
 
 type SaveArticleDraftPayload {
   clientMutationId: ID
-
   draft: ArticleDraft!
 }
 
-union SaveArticleDraftResult = InvalidInputError|NotAuthenticatedError|SaveArticleDraftPayload
+union SaveArticleDraftResult = InvalidInputError | NotAuthenticatedError | SaveArticleDraftPayload
 
-union SearchObjectResult = EmptySearchQueryError|SearchedObject
+union SearchObjectResult = EmptySearchQueryError | SearchedObject
 
 type SearchedObject {
   url: String!
 }
 
-"""
-A login session for an account.
-"""
+"""A login session for an account."""
 type Session {
   account: Account!
 
-  """
-  The creation date of the session.
-  """
+  """The creation date of the session."""
   created: DateTime!
 
-  """
-  The access token for the session.
-  """
+  """The access token for the session."""
   id: UUID!
 
-  """
-  The IP address that created the session.
-  """
+  """The IP address that created the session."""
   ipAddress: IP
 
-  """
-  The user agent of the session.
-  """
+  """The user agent of the session."""
   userAgent: String
 }
 
 type ShareNotification implements Node & Notification {
   account: Account!
-
   actors(after: String, before: String, first: Int, last: Int): NotificationActorsConnection!
-
   created: DateTime!
-
   id: ID!
-
   post: Post
-
   uuid: UUID!
 }
 
 input SharePostInput {
   clientMutationId: ID
-
   postId: ID!
 }
 
 type SharePostPayload {
   clientMutationId: ID
-
   originalPost: Post!
-
   share: Post!
 }
 
-union SharePostResult = InvalidInputError|NotAuthenticatedError|SharePostPayload
+union SharePostResult = InvalidInputError | NotAuthenticatedError | SharePostPayload
+
+type SharedPostDeletionNotAllowedError {
+  inputPath: String!
+}
 
 enum SignupBioError {
   BIO_TOO_LONG
@@ -1589,7 +1244,6 @@ enum SignupBioError {
 
 enum SignupDisplayNameError {
   DISPLAY_NAME_REQUIRED
-
   DISPLAY_NAME_TOO_LONG
 }
 
@@ -1598,41 +1252,29 @@ A signup info containing email and inviter information for account creation.
 """
 type SignupInfo {
   email: String!
-
   inviter: Account
 }
 
-"""
-Input data for completing account signup.
-"""
+"""Input data for completing account signup."""
 input SignupInput {
   bio: String!
-
   name: String!
-
   username: String!
 }
 
-union SignupResult = Session|SignupValidationErrors
+union SignupResult = Session | SignupValidationErrors
 
 enum SignupUsernameError {
   USERNAME_ALREADY_TAKEN
-
   USERNAME_INVALID_CHARACTERS
-
   USERNAME_REQUIRED
-
   USERNAME_TOO_LONG
 }
 
-"""
-Validation errors for signup fields.
-"""
+"""Validation errors for signup fields."""
 type SignupValidationErrors {
   bio: SignupBioError
-
   name: SignupDisplayNameError
-
   username: SignupUsernameError
 }
 
@@ -1652,50 +1294,107 @@ A field whose value is a generic Universally Unique Identifier: https://en.wikip
 """
 scalar UUID
 
-input UnsharePostInput {
+input UnblockActorInput {
+  actorId: ID!
+  clientMutationId: ID
+}
+
+type UnblockActorPayload {
+  blockee: Actor!
+  blocker: Actor!
+  clientMutationId: ID
+}
+
+union UnblockActorResult = InvalidInputError | NotAuthenticatedError | UnblockActorPayload
+
+input UnfollowActorInput {
+  actorId: ID!
+  clientMutationId: ID
+}
+
+type UnfollowActorPayload {
+  clientMutationId: ID
+  followee: Actor!
+  follower: Actor!
+}
+
+union UnfollowActorResult = InvalidInputError | NotAuthenticatedError | UnfollowActorPayload
+
+input UnregisterApnsDeviceTokenInput {
   clientMutationId: ID
 
+  """The APNS device token."""
+  deviceToken: String!
+}
+
+type UnregisterApnsDeviceTokenPayload {
+  clientMutationId: ID
+  deviceToken: String!
+  unregistered: Boolean!
+}
+
+union UnregisterApnsDeviceTokenResult = InvalidInputError | NotAuthenticatedError | UnregisterApnsDeviceTokenPayload
+
+input UnsharePostInput {
+  clientMutationId: ID
   postId: ID!
 }
 
 type UnsharePostPayload {
   clientMutationId: ID
-
   originalPost: Post!
 }
 
-union UnsharePostResult = InvalidInputError|NotAuthenticatedError|UnsharePostPayload
+union UnsharePostResult = InvalidInputError | NotAuthenticatedError | UnsharePostPayload
 
 input UpdateAccountInput {
   avatarUrl: URL
-
   bio: String
-
   clientMutationId: ID
-
   defaultNoteVisibility: PostVisibility
-
   defaultShareVisibility: PostVisibility
-
   hideForeignLanguages: Boolean
-
   hideFromInvitationTree: Boolean
-
   id: ID!
-
   links: [AccountLinkInput!]
-
   locales: [Locale!]
-
   name: String
-
   preferAiSummary: Boolean
-
   username: String
 }
 
 type UpdateAccountPayload {
   account: Account!
-
   clientMutationId: ID
+}
+
+input UploadMediaInput {
+  clientMutationId: ID
+  draftId: UUID
+  mediaUrl: URL!
+}
+
+type UploadMediaPayload {
+  clientMutationId: ID
+  height: Int!
+  url: URL!
+  width: Int!
+}
+
+union UploadMediaResult = InvalidInputError | NotAuthenticatedError | UploadMediaPayload
+
+"""
+Result of looking up a remote follower via WebFinger, including their ActivityPub profile and remote follow URL.
+"""
+type WebFingerResult {
+  domain: String
+  emojis: JSON
+  handle: String
+  iconUrl: URL
+  name: String
+  preferredUsername: String
+  remoteFollowUrl: URL
+  software: String
+  summary: String
+  url: URL
 }

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -353,7 +353,8 @@ class HackersPubRepository @Inject constructor(
         content: String,
         language: String = "en",
         visibility: PostVisibility = PostVisibility.PUBLIC,
-        replyTargetId: String? = null
+        replyTargetId: String? = null,
+        quotedPostId: String? = null
     ): Result<Post> {
         return try {
             val gqlVisibility = when (visibility) {
@@ -369,7 +370,8 @@ class HackersPubRepository @Inject constructor(
                     content = content,
                     language = language,
                     visibility = gqlVisibility,
-                    replyTargetId = Optional.presentIfNotNull(replyTargetId)
+                    replyTargetId = Optional.presentIfNotNull(replyTargetId),
+                    quotedPostId = Optional.presentIfNotNull(quotedPostId)
                 )
             ).execute()
 

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -16,6 +16,8 @@ import pub.hackers.android.graphql.LocalTimelineQuery
 import pub.hackers.android.graphql.LoginByUsernameMutation
 import pub.hackers.android.graphql.NotificationsQuery
 import pub.hackers.android.graphql.PersonalTimelineQuery
+import pub.hackers.android.graphql.PostQuotesQuery
+import pub.hackers.android.graphql.PostSharesQuery
 import pub.hackers.android.graphql.PostDetailQuery
 import pub.hackers.android.graphql.PublicTimelineQuery
 import pub.hackers.android.graphql.RemoveFollowerMutation
@@ -599,6 +601,60 @@ class HackersPubRepository @Inject constructor(
                         Result.failure(Exception("Not authenticated"))
                     else -> Result.failure(Exception("Unknown error"))
                 }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getPostShares(postId: String, after: String? = null): Result<SharesResult> {
+        return try {
+            val response = apolloClient.query(
+                PostSharesQuery(postId, Optional.presentIfNotNull(after))
+            ).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val shares = response.data?.node?.onPost?.shares
+                    ?: return Result.failure(Exception("Post not found"))
+
+                Result.success(
+                    SharesResult(
+                        actors = shares.edges.map { edge ->
+                            edge.node.actor.actorFields.toActor()
+                        },
+                        hasNextPage = shares.pageInfo.hasNextPage,
+                        endCursor = shares.pageInfo.endCursor
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getPostQuotes(postId: String, after: String? = null): Result<QuotesResult> {
+        return try {
+            val response = apolloClient.query(
+                PostQuotesQuery(postId, Optional.presentIfNotNull(after))
+            ).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val quotes = response.data?.node?.onPost?.quotes
+                    ?: return Result.failure(Exception("Post not found"))
+
+                Result.success(
+                    QuotesResult(
+                        posts = quotes.edges.mapNotNull { edge ->
+                            edge.node.postFields.toPost(edge.node.sharedPost?.sharedPostFields?.toPost())
+                        },
+                        hasNextPage = quotes.pageInfo.hasNextPage,
+                        endCursor = quotes.pageInfo.endCursor
+                    )
+                )
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -5,7 +5,27 @@ import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.cache.normalized.FetchPolicy
 import com.apollographql.apollo.cache.normalized.fetchPolicy
 import pub.hackers.android.domain.model.*
-import pub.hackers.android.graphql.*
+import pub.hackers.android.graphql.ActorByHandleQuery
+import pub.hackers.android.graphql.BlockActorMutation
+import pub.hackers.android.graphql.CompleteLoginChallengeMutation
+import pub.hackers.android.graphql.CreateNoteMutation
+import pub.hackers.android.graphql.DeletePostMutation
+import pub.hackers.android.graphql.FollowActorMutation
+import pub.hackers.android.graphql.LocalTimelineQuery
+import pub.hackers.android.graphql.LoginByUsernameMutation
+import pub.hackers.android.graphql.NotificationsQuery
+import pub.hackers.android.graphql.PersonalTimelineQuery
+import pub.hackers.android.graphql.PostDetailQuery
+import pub.hackers.android.graphql.PublicTimelineQuery
+import pub.hackers.android.graphql.RemoveFollowerMutation
+import pub.hackers.android.graphql.RevokeSessionMutation
+import pub.hackers.android.graphql.SearchActorsByHandleQuery
+import pub.hackers.android.graphql.SearchPostQuery
+import pub.hackers.android.graphql.SharePostMutation
+import pub.hackers.android.graphql.UnblockActorMutation
+import pub.hackers.android.graphql.UnfollowActorMutation
+import pub.hackers.android.graphql.UnsharePostMutation
+import pub.hackers.android.graphql.ViewerQuery
 import pub.hackers.android.graphql.fragment.ActorFields
 import pub.hackers.android.graphql.fragment.EngagementStatsFields
 import pub.hackers.android.graphql.fragment.MediaFields
@@ -225,7 +245,11 @@ class HackersPubRepository @Inject constructor(
                             edge.node.postFields.toPost(edge.node.sharedPost?.sharedPostFields?.toPost())
                         },
                         hasNextPage = actor.posts.pageInfo.hasNextPage,
-                        endCursor = actor.posts.pageInfo.endCursor
+                        endCursor = actor.posts.pageInfo.endCursor,
+                        isViewer = actor.isViewer,
+                        viewerFollows = actor.viewerFollows,
+                        followsViewer = actor.followsViewer,
+                        viewerBlocks = actor.viewerBlocks
                     )
                 )
             }
@@ -464,6 +488,134 @@ class HackersPubRepository @Inject constructor(
                     )
                 } ?: emptyList()
                 Result.success(actors)
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun followActor(actorId: String): Result<Unit> {
+        return try {
+            val response = apolloClient.mutation(FollowActorMutation(actorId)).execute()
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.followActor
+                when {
+                    result?.onFollowActorPayload != null -> Result.success(Unit)
+                    result?.onInvalidInputError != null ->
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    result?.onNotAuthenticatedError != null ->
+                        Result.failure(Exception("Not authenticated"))
+                    else -> Result.failure(Exception("Unknown error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun unfollowActor(actorId: String): Result<Unit> {
+        return try {
+            val response = apolloClient.mutation(UnfollowActorMutation(actorId)).execute()
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.unfollowActor
+                when {
+                    result?.onUnfollowActorPayload != null -> Result.success(Unit)
+                    result?.onInvalidInputError != null ->
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    result?.onNotAuthenticatedError != null ->
+                        Result.failure(Exception("Not authenticated"))
+                    else -> Result.failure(Exception("Unknown error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun blockActor(actorId: String): Result<Unit> {
+        return try {
+            val response = apolloClient.mutation(BlockActorMutation(actorId)).execute()
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.blockActor
+                when {
+                    result?.onBlockActorPayload != null -> Result.success(Unit)
+                    result?.onInvalidInputError != null ->
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    result?.onNotAuthenticatedError != null ->
+                        Result.failure(Exception("Not authenticated"))
+                    else -> Result.failure(Exception("Unknown error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun unblockActor(actorId: String): Result<Unit> {
+        return try {
+            val response = apolloClient.mutation(UnblockActorMutation(actorId)).execute()
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.unblockActor
+                when {
+                    result?.onUnblockActorPayload != null -> Result.success(Unit)
+                    result?.onInvalidInputError != null ->
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    result?.onNotAuthenticatedError != null ->
+                        Result.failure(Exception("Not authenticated"))
+                    else -> Result.failure(Exception("Unknown error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun removeFollower(actorId: String): Result<Unit> {
+        return try {
+            val response = apolloClient.mutation(RemoveFollowerMutation(actorId)).execute()
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.removeFollower
+                when {
+                    result?.onRemoveFollowerPayload != null -> Result.success(Unit)
+                    result?.onInvalidInputError != null ->
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    result?.onNotAuthenticatedError != null ->
+                        Result.failure(Exception("Not authenticated"))
+                    else -> Result.failure(Exception("Unknown error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun deletePost(postId: String): Result<Unit> {
+        return try {
+            val response = apolloClient.mutation(DeletePostMutation(postId)).execute()
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.deletePost
+                when {
+                    result?.onDeletePostPayload != null -> Result.success(Unit)
+                    result?.onInvalidInputError != null ->
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    result?.onNotAuthenticatedError != null ->
+                        Result.failure(Exception("Not authenticated"))
+                    result?.onSharedPostDeletionNotAllowedError != null ->
+                        Result.failure(Exception("Cannot delete a shared post"))
+                    else -> Result.failure(Exception("Unknown error"))
+                }
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -745,6 +745,7 @@ class HackersPubRepository @Inject constructor(
             content = content.toString(),
             excerpt = excerpt,
             url = url?.toString(),
+            iri = iri?.toString(),
             viewerHasShared = viewerHasShared,
             actor = actor.actorFields.toActor(),
             media = media.map { it.mediaFields.toMedia() },
@@ -753,7 +754,30 @@ class HackersPubRepository @Inject constructor(
             sharedPost = sharedPost,
             replyTarget = replyTarget,
             quotedPost = quotedPost?.sharedPostFields?.toPost(),
-            visibility = visibility
+            visibility = visibility,
+            reactionGroups = reactionGroups.mapNotNull { group ->
+                when {
+                    group.onEmojiReactionGroup != null -> ReactionGroup(
+                        emoji = group.onEmojiReactionGroup.emoji,
+                        customEmoji = null,
+                        count = group.onEmojiReactionGroup.reactors.totalCount,
+                        reactors = emptyList(),
+                        viewerHasReacted = group.onEmojiReactionGroup.reactors.viewerHasReacted
+                    )
+                    group.onCustomEmojiReactionGroup != null -> ReactionGroup(
+                        emoji = null,
+                        customEmoji = CustomEmoji(
+                            id = group.onCustomEmojiReactionGroup.customEmoji.id,
+                            name = group.onCustomEmojiReactionGroup.customEmoji.name,
+                            imageUrl = group.onCustomEmojiReactionGroup.customEmoji.imageUrl
+                        ),
+                        count = group.onCustomEmojiReactionGroup.reactors.totalCount,
+                        reactors = emptyList(),
+                        viewerHasReacted = group.onCustomEmojiReactionGroup.reactors.viewerHasReacted
+                    )
+                    else -> null
+                }
+            }
         )
     }
 
@@ -767,6 +791,7 @@ class HackersPubRepository @Inject constructor(
             content = content.toString(),
             excerpt = excerpt,
             url = url?.toString(),
+            iri = iri?.toString(),
             viewerHasShared = viewerHasShared,
             actor = actor.actorFields.toActor(),
             media = media.map { it.mediaFields.toMedia() },

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo.cache.normalized.FetchPolicy
 import com.apollographql.apollo.cache.normalized.fetchPolicy
 import pub.hackers.android.domain.model.*
 import pub.hackers.android.graphql.ActorByHandleQuery
+import pub.hackers.android.graphql.AddReactionToPostMutation
 import pub.hackers.android.graphql.BlockActorMutation
 import pub.hackers.android.graphql.CompleteLoginChallengeMutation
 import pub.hackers.android.graphql.CreateNoteMutation
@@ -18,6 +19,7 @@ import pub.hackers.android.graphql.PersonalTimelineQuery
 import pub.hackers.android.graphql.PostDetailQuery
 import pub.hackers.android.graphql.PublicTimelineQuery
 import pub.hackers.android.graphql.RemoveFollowerMutation
+import pub.hackers.android.graphql.RemoveReactionFromPostMutation
 import pub.hackers.android.graphql.RevokeSessionMutation
 import pub.hackers.android.graphql.SearchActorsByHandleQuery
 import pub.hackers.android.graphql.SearchPostQuery
@@ -183,7 +185,8 @@ class HackersPubRepository @Inject constructor(
                             count = group.onEmojiReactionGroup.reactors.totalCount,
                             reactors = group.onEmojiReactionGroup.reactors.edges.map {
                                 it.node.actorFields.toActor()
-                            }
+                            },
+                            viewerHasReacted = group.onEmojiReactionGroup.reactors.viewerHasReacted
                         )
                         group.onCustomEmojiReactionGroup != null -> ReactionGroup(
                             emoji = null,
@@ -195,7 +198,8 @@ class HackersPubRepository @Inject constructor(
                             count = group.onCustomEmojiReactionGroup.reactors.totalCount,
                             reactors = group.onCustomEmojiReactionGroup.reactors.edges.map {
                                 it.node.actorFields.toActor()
-                            }
+                            },
+                            viewerHasReacted = group.onCustomEmojiReactionGroup.reactors.viewerHasReacted
                         )
                         else -> null
                     }
@@ -587,6 +591,52 @@ class HackersPubRepository @Inject constructor(
                 val result = response.data?.removeFollower
                 when {
                     result?.onRemoveFollowerPayload != null -> Result.success(Unit)
+                    result?.onInvalidInputError != null ->
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    result?.onNotAuthenticatedError != null ->
+                        Result.failure(Exception("Not authenticated"))
+                    else -> Result.failure(Exception("Unknown error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun addReactionToPost(postId: String, emoji: String): Result<Unit> {
+        return try {
+            val response = apolloClient.mutation(
+                AddReactionToPostMutation(postId = postId, emoji = emoji)
+            ).execute()
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.addReactionToPost
+                when {
+                    result?.onAddReactionToPostPayload != null -> Result.success(Unit)
+                    result?.onInvalidInputError != null ->
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    result?.onNotAuthenticatedError != null ->
+                        Result.failure(Exception("Not authenticated"))
+                    else -> Result.failure(Exception("Unknown error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun removeReactionFromPost(postId: String, emoji: String): Result<Unit> {
+        return try {
+            val response = apolloClient.mutation(
+                RemoveReactionFromPostMutation(postId = postId, emoji = emoji)
+            ).execute()
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.removeReactionFromPost
+                when {
+                    result?.onRemoveReactionFromPostPayload != null -> Result.success(Unit)
                     result?.onInvalidInputError != null ->
                         Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
                     result?.onNotAuthenticatedError != null ->

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -168,5 +168,9 @@ data class ProfileResult(
     val bio: String?,
     val posts: List<Post>,
     val hasNextPage: Boolean,
-    val endCursor: String?
+    val endCursor: String?,
+    val isViewer: Boolean = false,
+    val viewerFollows: Boolean = false,
+    val followsViewer: Boolean = false,
+    val viewerBlocks: Boolean = false
 )

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -164,6 +164,18 @@ data class PostDetailResult(
     val repliesEndCursor: String?
 )
 
+data class SharesResult(
+    val actors: List<Actor>,
+    val hasNextPage: Boolean,
+    val endCursor: String?
+)
+
+data class QuotesResult(
+    val posts: List<Post>,
+    val hasNextPage: Boolean,
+    val endCursor: String?
+)
+
 data class ProfileResult(
     val actor: Actor,
     val bio: String?,

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -114,7 +114,8 @@ data class ReactionGroup(
     val emoji: String?,
     val customEmoji: CustomEmoji?,
     val count: Int,
-    val reactors: List<Actor>
+    val reactors: List<Actor>,
+    val viewerHasReacted: Boolean = false
 )
 
 data class Viewer(

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -33,6 +33,7 @@ data class Post(
     val content: String,
     val excerpt: String,
     val url: String?,
+    val iri: String? = null,
     val viewerHasShared: Boolean,
     val actor: Actor,
     val media: List<Media>,
@@ -41,7 +42,8 @@ data class Post(
     val sharedPost: Post? = null,
     val replyTarget: Post? = null,
     val quotedPost: Post? = null,
-    val visibility: PostVisibility = PostVisibility.PUBLIC
+    val visibility: PostVisibility = PostVisibility.PUBLIC,
+    val reactionGroups: List<ReactionGroup> = emptyList()
 )
 
 enum class PostVisibility {

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -295,7 +295,8 @@ fun HackersPubApp(
                     },
                     onPostClick = { id ->
                         navController.navigate(DetailScreen.PostDetail.createRoute(id))
-                    }
+                    },
+                    isLoggedIn = isLoggedIn
                 )
             }
 

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -311,6 +311,9 @@ fun HackersPubApp(
                     },
                     onPostClick = { postId ->
                         navController.navigate(DetailScreen.PostDetail.createRoute(postId))
+                    },
+                    onProfileClick = { profileHandle ->
+                        navController.navigate(DetailScreen.Profile.createRoute(profileHandle))
                     }
                 )
             }

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -91,9 +91,13 @@ sealed class Screen(
 
 sealed class DetailScreen(val route: String) {
     data object SignIn : DetailScreen("signin")
-    data object Compose : DetailScreen("compose?replyTo={replyTo}") {
-        fun createRoute(replyTo: String? = null) =
-            if (replyTo != null) "compose?replyTo=$replyTo" else "compose"
+    data object Compose : DetailScreen("compose?replyTo={replyTo}&quoteOf={quoteOf}") {
+        fun createRoute(replyTo: String? = null, quoteOf: String? = null): String {
+            val params = mutableListOf<String>()
+            if (replyTo != null) params.add("replyTo=$replyTo")
+            if (quoteOf != null) params.add("quoteOf=$quoteOf")
+            return if (params.isEmpty()) "compose" else "compose?${params.joinToString("&")}"
+        }
     }
     data object PostDetail : DetailScreen("post/{postId}") {
         fun createRoute(postId: String) = "post/$postId"
@@ -248,12 +252,19 @@ fun HackersPubApp(
                         type = NavType.StringType
                         nullable = true
                         defaultValue = null
+                    },
+                    navArgument("quoteOf") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
                     }
                 )
             ) { backStackEntry ->
                 val replyTo = backStackEntry.arguments?.getString("replyTo")
+                val quoteOf = backStackEntry.arguments?.getString("quoteOf")
                 ComposeScreen(
                     replyToId = replyTo,
+                    quotedPostId = quoteOf,
                     onPostSuccess = {
                         navController.popBackStack()
                     },
@@ -277,7 +288,10 @@ fun HackersPubApp(
                         navController.navigate(DetailScreen.Profile.createRoute(handle))
                     },
                     onReplyClick = { id ->
-                        navController.navigate(DetailScreen.Compose.createRoute(id))
+                        navController.navigate(DetailScreen.Compose.createRoute(replyTo = id))
+                    },
+                    onQuoteClick = { id ->
+                        navController.navigate(DetailScreen.Compose.createRoute(quoteOf = id))
                     },
                     onPostClick = { id ->
                         navController.navigate(DetailScreen.PostDetail.createRoute(id))

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -1,9 +1,13 @@
+@file:OptIn(ExperimentalLayoutApi::class)
+
 package pub.hackers.android.ui.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -163,6 +167,51 @@ fun PostCard(
                     onClick = { onQuotedPostClick?.invoke(displayPost.quotedPost!!.id) },
                     onProfileClick = onProfileClick
                 )
+            }
+
+            if (displayPost.reactionGroups.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    displayPost.reactionGroups.forEach { group ->
+                        Surface(
+                            shape = RoundedCornerShape(16.dp),
+                            color = if (group.viewerHasReacted)
+                                MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)
+                            else
+                                MaterialTheme.colorScheme.surfaceVariant
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                if (group.emoji != null) {
+                                    Text(
+                                        text = group.emoji,
+                                        style = MaterialTheme.typography.labelSmall
+                                    )
+                                } else if (group.customEmoji != null) {
+                                    AsyncImage(
+                                        model = group.customEmoji.imageUrl,
+                                        contentDescription = group.customEmoji.name,
+                                        modifier = Modifier.size(14.dp)
+                                    )
+                                }
+                                Spacer(modifier = Modifier.width(4.dp))
+                                Text(
+                                    text = group.count.toString(),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = if (group.viewerHasReacted)
+                                        MaterialTheme.colorScheme.primary
+                                    else
+                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/java/pub/hackers/android/ui/components/ReactionPicker.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/ReactionPicker.kt
@@ -1,0 +1,165 @@
+package pub.hackers.android.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import pub.hackers.android.R
+import pub.hackers.android.domain.model.ReactionGroup
+
+val SUPPORTED_REACTION_EMOJIS = listOf("❤️", "🎉", "😂", "😲", "🤔", "😢", "👀")
+
+@Composable
+fun ReactionPicker(
+    reactionGroups: List<ReactionGroup>,
+    isSubmitting: Boolean,
+    onEmojiSelect: (String) -> Unit,
+    onClose: () -> Unit
+) {
+    val groupsByEmoji = reactionGroups
+        .filter { it.emoji != null }
+        .associateBy { it.emoji!! }
+
+    val selectedGroups = reactionGroups
+        .filter { it.viewerHasReacted }
+        .sortedWith(compareBy { group ->
+            group.emoji?.let { SUPPORTED_REACTION_EMOJIS.indexOf(it).takeIf { i -> i >= 0 } ?: Int.MAX_VALUE }
+                ?: Int.MAX_VALUE
+        })
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.reactions),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+            IconButton(
+                onClick = onClose,
+                modifier = Modifier
+                    .size(30.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Close,
+                    contentDescription = "Close",
+                    modifier = Modifier.size(14.dp)
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(7),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.height(80.dp)
+        ) {
+            items(SUPPORTED_REACTION_EMOJIS) { emoji ->
+                val existingGroup = groupsByEmoji[emoji]
+
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(
+                            if (existingGroup?.viewerHasReacted == true)
+                                MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)
+                            else
+                                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                        )
+                        .clickable(enabled = !isSubmitting) { onEmojiSelect(emoji) }
+                        .padding(vertical = 8.dp)
+                ) {
+                    Text(
+                        text = emoji,
+                        style = MaterialTheme.typography.titleSmall
+                    )
+                    Text(
+                        text = (existingGroup?.count ?: 0).toString(),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+
+        if (selectedGroups.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier.horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                selectedGroups.forEach { group ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(50))
+                            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.2f))
+                            .clickable(enabled = !isSubmitting && group.emoji != null) {
+                                group.emoji?.let { onEmojiSelect(it) }
+                            }
+                            .padding(horizontal = 10.dp, vertical = 6.dp)
+                    ) {
+                        if (group.emoji != null) {
+                            Text(text = group.emoji)
+                        } else if (group.customEmoji != null) {
+                            AsyncImage(
+                                model = group.customEmoji.imageUrl,
+                                contentDescription = group.customEmoji.name,
+                                modifier = Modifier.size(16.dp)
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text = group.count.toString(),
+                            style = MaterialTheme.typography.labelMedium
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.outlined.FormatQuote
 import androidx.compose.material.icons.outlined.Group
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material3.Button
@@ -76,6 +77,7 @@ import kotlin.math.roundToInt
 @Composable
 fun ComposeScreen(
     replyToId: String?,
+    quotedPostId: String? = null,
     onPostSuccess: () -> Unit,
     onNavigateBack: () -> Unit,
     viewModel: ComposeViewModel = hiltViewModel()
@@ -111,6 +113,10 @@ fun ComposeScreen(
         replyToId?.let { viewModel.setReplyTarget(it) }
     }
 
+    LaunchedEffect(quotedPostId) {
+        quotedPostId?.let { viewModel.setQuotedPost(it) }
+    }
+
     LaunchedEffect(uiState.isPosted) {
         if (uiState.isPosted) {
             onPostSuccess()
@@ -128,7 +134,11 @@ fun ComposeScreen(
         contentWindowInsets = WindowInsets(0),
         topBar = {
             CompactTopBar(
-                title = if (replyToId != null) stringResource(R.string.reply) else stringResource(R.string.compose),
+                title = when {
+                    replyToId != null -> stringResource(R.string.reply)
+                    quotedPostId != null -> stringResource(R.string.quoting)
+                    else -> stringResource(R.string.compose)
+                },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(
@@ -168,6 +178,15 @@ fun ComposeScreen(
                     post = uiState.replyTargetPost!!,
                     modifier = Modifier.alpha(0.6f)
                 )
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
+            // Quoted post preview
+            if (uiState.isLoadingQuotedPost) {
+                QuoteIndicator(isLoading = true)
+                Spacer(modifier = Modifier.height(12.dp))
+            } else if (uiState.quotedPost != null) {
+                QuoteIndicator(isLoading = false, post = uiState.quotedPost)
                 Spacer(modifier = Modifier.height(12.dp))
             }
 
@@ -329,6 +348,85 @@ fun ComposeScreen(
                         )
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuoteIndicator(
+    isLoading: Boolean,
+    post: Post? = null
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(10.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.FormatQuote,
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = stringResource(R.string.quoting),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            if (isLoading) {
+                Spacer(modifier = Modifier.height(8.dp))
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp
+                )
+            } else if (post != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    AsyncImage(
+                        model = post.actor.avatarUrl,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(28.dp)
+                            .clip(CircleShape),
+                        contentScale = ContentScale.Crop
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Column {
+                        Text(
+                            text = post.actor.name ?: post.actor.handle,
+                            style = MaterialTheme.typography.labelSmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Text(
+                            text = "@${post.actor.handle}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = post.excerpt,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
         }
     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
@@ -25,6 +25,9 @@ data class ComposeUiState(
     val replyToId: String? = null,
     val replyTargetPost: Post? = null,
     val isLoadingReplyTarget: Boolean = false,
+    val quotedPostId: String? = null,
+    val quotedPost: Post? = null,
+    val isLoadingQuotedPost: Boolean = false,
     val isPosting: Boolean = false,
     val isPosted: Boolean = false,
     val error: String? = null,
@@ -175,6 +178,24 @@ class ComposeViewModel @Inject constructor(
         clearMentionState()
     }
 
+    fun setQuotedPost(postId: String) {
+        _uiState.update { it.copy(quotedPostId = postId, isLoadingQuotedPost = true) }
+        viewModelScope.launch {
+            repository.getPostDetail(postId)
+                .onSuccess { result ->
+                    _uiState.update {
+                        it.copy(
+                            quotedPost = result.post,
+                            isLoadingQuotedPost = false
+                        )
+                    }
+                }
+                .onFailure {
+                    _uiState.update { it.copy(isLoadingQuotedPost = false) }
+                }
+        }
+    }
+
     fun setReplyTarget(postId: String) {
         _uiState.update { it.copy(replyToId = postId, isLoadingReplyTarget = true) }
         viewModelScope.launch {
@@ -236,7 +257,8 @@ class ComposeViewModel @Inject constructor(
             repository.createNote(
                 content = state.content,
                 visibility = state.visibility,
-                replyTargetId = state.replyToId
+                replyTargetId = state.replyToId,
+                quotedPostId = state.quotedPostId
             )
                 .onSuccess {
                     _uiState.update { it.copy(isPosting = false, isPosted = true) }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -19,9 +19,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Reply
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -29,10 +34,15 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import pub.hackers.android.ui.components.CompactTopBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -65,6 +75,53 @@ fun PostDetailScreen(
     viewModel: PostDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    var showDeleteConfirmation by remember { mutableStateOf(false) }
+
+    // Navigate back after successful deletion
+    LaunchedEffect(uiState.isDeleted) {
+        if (uiState.isDeleted) {
+            onNavigateBack()
+        }
+    }
+
+    if (showDeleteConfirmation) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirmation = false },
+            title = { Text(stringResource(R.string.delete_post_confirm_title)) },
+            text = { Text(stringResource(R.string.delete_post_confirm)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteConfirmation = false
+                        viewModel.deletePost()
+                    }
+                ) {
+                    Text(
+                        stringResource(R.string.delete_post),
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirmation = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    if (uiState.deleteError != null) {
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissDeleteError() },
+            title = { Text(stringResource(R.string.action_error)) },
+            text = { Text(uiState.deleteError ?: "") },
+            confirmButton = {
+                TextButton(onClick = { viewModel.dismissDeleteError() }) {
+                    Text(stringResource(R.string.ok))
+                }
+            }
+        )
+    }
 
     Scaffold(
         contentWindowInsets = WindowInsets(0),
@@ -76,6 +133,14 @@ fun PostDetailScreen(
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Back"
+                        )
+                    }
+                },
+                actions = {
+                    if (uiState.canDelete) {
+                        PostDetailActionMenu(
+                            isDeleting = uiState.isDeleting,
+                            onDelete = { showDeleteConfirmation = true }
                         )
                     }
                 }
@@ -126,6 +191,49 @@ fun PostDetailScreen(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun PostDetailActionMenu(
+    isDeleting: Boolean,
+    onDelete: () -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box {
+        IconButton(onClick = { expanded = true }) {
+            Icon(
+                imageVector = Icons.Filled.MoreVert,
+                contentDescription = "More actions"
+            )
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        text = stringResource(R.string.delete_post),
+                        color = MaterialTheme.colorScheme.error
+                    )
+                },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Filled.Delete,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error
+                    )
+                },
+                onClick = {
+                    expanded = false
+                    onDelete()
+                },
+                enabled = !isDeleting
+            )
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.outlined.AddReaction
+import androidx.compose.material.icons.outlined.FormatQuote
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Card
@@ -78,6 +79,7 @@ fun PostDetailScreen(
     onNavigateBack: () -> Unit,
     onProfileClick: (String) -> Unit,
     onReplyClick: (String) -> Unit,
+    onQuoteClick: (String) -> Unit = {},
     onPostClick: (String) -> Unit,
     viewModel: PostDetailViewModel = hiltViewModel()
 ) {
@@ -211,7 +213,8 @@ fun PostDetailScreen(
                             }
                         },
                         onReactionClick = { emoji -> viewModel.toggleReaction(emoji) },
-                        onReactionPickerClick = { viewModel.toggleReactionPicker() }
+                        onReactionPickerClick = { viewModel.toggleReactionPicker() },
+                        onQuoteClick = { onQuoteClick(postId) }
                     )
                 }
             }
@@ -271,7 +274,8 @@ private fun PostDetailContent(
     onPostClick: (String) -> Unit,
     onShareClick: () -> Unit,
     onReactionClick: (String) -> Unit,
-    onReactionPickerClick: () -> Unit
+    onReactionPickerClick: () -> Unit,
+    onQuoteClick: () -> Unit
 ) {
     val dateFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy 'at' h:mm a")
         .withZone(ZoneId.systemDefault())
@@ -450,6 +454,13 @@ private fun PostDetailContent(
                                 MaterialTheme.colorScheme.primary
                             else
                                 MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    IconButton(onClick = onQuoteClick) {
+                        Icon(
+                            imageVector = Icons.Outlined.FormatQuote,
+                            contentDescription = stringResource(R.string.quotes),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -86,6 +86,7 @@ fun PostDetailScreen(
     onReplyClick: (String) -> Unit,
     onQuoteClick: (String) -> Unit = {},
     onPostClick: (String) -> Unit,
+    isLoggedIn: Boolean = true,
     viewModel: PostDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -213,7 +214,7 @@ fun PostDetailScreen(
             )
         },
         floatingActionButton = {
-            if (uiState.post != null) {
+            if (uiState.post != null && isLoggedIn) {
                 FloatingActionButton(
                     onClick = { onReplyClick(postId) }
                 ) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -1,6 +1,7 @@
 package pub.hackers.android.ui.screens.postdetail
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -28,6 +29,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -104,6 +106,42 @@ fun PostDetailScreen(
                 isSubmitting = uiState.isReacting,
                 onEmojiSelect = { viewModel.toggleReaction(it) },
                 onClose = { viewModel.toggleReactionPicker() }
+            )
+        }
+    }
+
+    // Shares bottom sheet
+    if (uiState.showSharesSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { viewModel.dismissSharesSheet() },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        ) {
+            SharesSheet(
+                actors = uiState.shareActors,
+                isLoading = uiState.isLoadingShares,
+                onProfileClick = { handle ->
+                    viewModel.dismissSharesSheet()
+                    onProfileClick(handle)
+                },
+                onClose = { viewModel.dismissSharesSheet() }
+            )
+        }
+    }
+
+    // Quotes bottom sheet
+    if (uiState.showQuotesSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { viewModel.dismissQuotesSheet() },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        ) {
+            QuotesSheet(
+                posts = uiState.quotePosts,
+                isLoading = uiState.isLoadingQuotes,
+                onPostClick = { id ->
+                    viewModel.dismissQuotesSheet()
+                    onPostClick(id)
+                },
+                onClose = { viewModel.dismissQuotesSheet() }
             )
         }
     }
@@ -214,7 +252,9 @@ fun PostDetailScreen(
                         },
                         onReactionClick = { emoji -> viewModel.toggleReaction(emoji) },
                         onReactionPickerClick = { viewModel.toggleReactionPicker() },
-                        onQuoteClick = { onQuoteClick(postId) }
+                        onQuoteClick = { onQuoteClick(postId) },
+                        onSharesClick = { viewModel.showSharesSheet() },
+                        onQuotesClick = { viewModel.showQuotesSheet() }
                     )
                 }
             }
@@ -275,7 +315,9 @@ private fun PostDetailContent(
     onShareClick: () -> Unit,
     onReactionClick: (String) -> Unit,
     onReactionPickerClick: () -> Unit,
-    onQuoteClick: () -> Unit
+    onQuoteClick: () -> Unit,
+    onSharesClick: () -> Unit,
+    onQuotesClick: () -> Unit
 ) {
     val dateFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy 'at' h:mm a")
         .withZone(ZoneId.systemDefault())
@@ -367,24 +409,30 @@ private fun PostDetailContent(
                 Spacer(modifier = Modifier.height(16.dp))
 
                 Row(
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     Text(
                         text = "${post.engagementStats.replies} ${stringResource(R.string.replies)}",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                    Spacer(modifier = Modifier.width(16.dp))
                     Text(
                         text = "${post.engagementStats.shares} ${stringResource(R.string.shares)}",
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.clickable { onSharesClick() }
                     )
-                    Spacer(modifier = Modifier.width(16.dp))
                     Text(
                         text = "${post.engagementStats.reactions} ${stringResource(R.string.reactions)}",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = "${post.engagementStats.quotes} ${stringResource(R.string.quotes)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.clickable { onQuotesClick() }
                     )
                 }
 
@@ -490,6 +538,156 @@ private fun PostDetailContent(
                     onQuotedPostClick = onPostClick
                 )
                 HorizontalDivider(thickness = 0.5.dp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SharesSheet(
+    actors: List<pub.hackers.android.domain.model.Actor>,
+    isLoading: Boolean,
+    onProfileClick: (String) -> Unit,
+    onClose: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.shares),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        if (isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        } else if (actors.isEmpty()) {
+            Text(
+                text = "No shares yet",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(vertical = 24.dp)
+            )
+        } else {
+            actors.forEach { actor ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onProfileClick(actor.handle) }
+                        .padding(vertical = 8.dp)
+                ) {
+                    AsyncImage(
+                        model = actor.avatarUrl,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(40.dp)
+                            .clip(CircleShape),
+                        contentScale = ContentScale.Crop
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column {
+                        Text(
+                            text = actor.name ?: actor.handle,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Text(
+                            text = "@${actor.handle}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuotesSheet(
+    posts: List<Post>,
+    isLoading: Boolean,
+    onPostClick: (String) -> Unit,
+    onClose: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.quotes),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        if (isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        } else if (posts.isEmpty()) {
+            Text(
+                text = "No quotes yet",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(vertical = 24.dp)
+            )
+        } else {
+            posts.forEach { post ->
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onPostClick(post.id) }
+                        .padding(vertical = 8.dp)
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        AsyncImage(
+                            model = post.actor.avatarUrl,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(32.dp)
+                                .clip(CircleShape),
+                            contentScale = ContentScale.Crop
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Column {
+                            Text(
+                                text = post.actor.name ?: post.actor.handle,
+                                style = MaterialTheme.typography.bodySmall,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                            Text(
+                                text = "@${post.actor.handle}",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(4.dp))
+                    HtmlContent(
+                        html = post.content,
+                        maxLines = 3,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
             }
         }
     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.outlined.AddReaction
 import androidx.compose.material.icons.outlined.FormatQuote
+import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Card
@@ -68,6 +69,8 @@ import pub.hackers.android.ui.components.ErrorMessage
 import pub.hackers.android.ui.components.FullScreenLoading
 import pub.hackers.android.ui.components.HtmlContent
 import pub.hackers.android.ui.components.MediaGrid
+import android.content.Intent
+import androidx.compose.ui.platform.LocalContext
 import pub.hackers.android.ui.components.PostCard
 import pub.hackers.android.ui.components.QuotedPostPreview
 import pub.hackers.android.ui.components.ReactionPicker
@@ -86,6 +89,7 @@ fun PostDetailScreen(
     viewModel: PostDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
     var showDeleteConfirmation by remember { mutableStateOf(false) }
 
     // Navigate back after successful deletion
@@ -254,7 +258,19 @@ fun PostDetailScreen(
                         onReactionPickerClick = { viewModel.toggleReactionPicker() },
                         onQuoteClick = { onQuoteClick(postId) },
                         onSharesClick = { viewModel.showSharesSheet() },
-                        onQuotesClick = { viewModel.showQuotesSheet() }
+                        onQuotesClick = { viewModel.showQuotesSheet() },
+                        onExternalShareClick = {
+                            val shareUrl = uiState.post?.url
+                                ?: uiState.post?.iri
+                            if (shareUrl != null) {
+                                val sendIntent = Intent().apply {
+                                    action = Intent.ACTION_SEND
+                                    putExtra(Intent.EXTRA_TEXT, shareUrl)
+                                    type = "text/plain"
+                                }
+                                context.startActivity(Intent.createChooser(sendIntent, null))
+                            }
+                        }
                     )
                 }
             }
@@ -317,7 +333,8 @@ private fun PostDetailContent(
     onReactionPickerClick: () -> Unit,
     onQuoteClick: () -> Unit,
     onSharesClick: () -> Unit,
-    onQuotesClick: () -> Unit
+    onQuotesClick: () -> Unit,
+    onExternalShareClick: () -> Unit
 ) {
     val dateFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy 'at' h:mm a")
         .withZone(ZoneId.systemDefault())
@@ -508,6 +525,13 @@ private fun PostDetailContent(
                         Icon(
                             imageVector = Icons.Outlined.FormatQuote,
                             contentDescription = stringResource(R.string.quotes),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    IconButton(onClick = onExternalShareClick) {
+                        Icon(
+                            imageVector = Icons.Outlined.Share,
+                            contentDescription = stringResource(R.string.share),
                             tint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -22,11 +22,16 @@ import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.outlined.AddReaction
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -62,9 +67,11 @@ import pub.hackers.android.ui.components.HtmlContent
 import pub.hackers.android.ui.components.MediaGrid
 import pub.hackers.android.ui.components.PostCard
 import pub.hackers.android.ui.components.QuotedPostPreview
+import pub.hackers.android.ui.components.ReactionPicker
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PostDetailScreen(
     postId: String,
@@ -81,6 +88,21 @@ fun PostDetailScreen(
     LaunchedEffect(uiState.isDeleted) {
         if (uiState.isDeleted) {
             onNavigateBack()
+        }
+    }
+
+    // Reaction picker bottom sheet
+    if (uiState.showReactionPicker) {
+        ModalBottomSheet(
+            onDismissRequest = { viewModel.toggleReactionPicker() },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        ) {
+            ReactionPicker(
+                reactionGroups = uiState.reactionGroups,
+                isSubmitting = uiState.isReacting,
+                onEmojiSelect = { viewModel.toggleReaction(it) },
+                onClose = { viewModel.toggleReactionPicker() }
+            )
         }
     }
 
@@ -187,7 +209,9 @@ fun PostDetailScreen(
                             } else {
                                 viewModel.sharePost()
                             }
-                        }
+                        },
+                        onReactionClick = { emoji -> viewModel.toggleReaction(emoji) },
+                        onReactionPickerClick = { viewModel.toggleReactionPicker() }
                     )
                 }
             }
@@ -245,7 +269,9 @@ private fun PostDetailContent(
     replies: List<Post>,
     onProfileClick: (String) -> Unit,
     onPostClick: (String) -> Unit,
-    onShareClick: () -> Unit
+    onShareClick: () -> Unit,
+    onReactionClick: (String) -> Unit,
+    onReactionPickerClick: () -> Unit
 ) {
     val dateFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy 'at' h:mm a")
         .withZone(ZoneId.systemDefault())
@@ -363,9 +389,15 @@ private fun PostDetailContent(
                     Row {
                         reactionGroups.forEach { group ->
                             Card(
+                                onClick = {
+                                    group.emoji?.let { onReactionClick(it) }
+                                },
                                 shape = RoundedCornerShape(16.dp),
                                 colors = CardDefaults.cardColors(
-                                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                                    containerColor = if (group.viewerHasReacted)
+                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)
+                                    else
+                                        MaterialTheme.colorScheme.surfaceVariant
                                 ),
                                 modifier = Modifier.padding(end = 8.dp)
                             ) {
@@ -385,7 +417,11 @@ private fun PostDetailContent(
                                     Spacer(modifier = Modifier.width(4.dp))
                                     Text(
                                         text = group.count.toString(),
-                                        style = MaterialTheme.typography.bodySmall
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = if (group.viewerHasReacted)
+                                            MaterialTheme.colorScheme.primary
+                                        else
+                                            MaterialTheme.colorScheme.onSurface
                                     )
                                 }
                             }
@@ -401,6 +437,16 @@ private fun PostDetailContent(
                             imageVector = Icons.Filled.Repeat,
                             contentDescription = stringResource(R.string.share),
                             tint = if (post.viewerHasShared)
+                                MaterialTheme.colorScheme.primary
+                            else
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    IconButton(onClick = onReactionPickerClick) {
+                        Icon(
+                            imageVector = Icons.Outlined.AddReaction,
+                            contentDescription = stringResource(R.string.reactions),
+                            tint = if (reactionGroups.any { it.viewerHasReacted })
                                 MaterialTheme.colorScheme.primary
                             else
                                 MaterialTheme.colorScheme.onSurfaceVariant

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
@@ -25,7 +25,9 @@ data class PostDetailUiState(
     val canDelete: Boolean = false,
     val isDeleting: Boolean = false,
     val deleteError: String? = null,
-    val isDeleted: Boolean = false
+    val isDeleted: Boolean = false,
+    val isReacting: Boolean = false,
+    val showReactionPicker: Boolean = false
 )
 
 @HiltViewModel
@@ -136,5 +138,78 @@ class PostDetailViewModel @Inject constructor(
 
     fun dismissDeleteError() {
         _uiState.update { it.copy(deleteError = null) }
+    }
+
+    fun toggleReactionPicker() {
+        _uiState.update { it.copy(showReactionPicker = !it.showReactionPicker) }
+    }
+
+    fun toggleReaction(emoji: String) {
+        if (_uiState.value.isReacting) return
+
+        val existingGroup = _uiState.value.reactionGroups.find { it.emoji == emoji }
+        val viewerHasReacted = existingGroup?.viewerHasReacted == true
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isReacting = true) }
+
+            val result = if (viewerHasReacted) {
+                repository.removeReactionFromPost(postId, emoji)
+            } else {
+                repository.addReactionToPost(postId, emoji)
+            }
+
+            result
+                .onSuccess {
+                    // Optimistically update local state
+                    _uiState.update { state ->
+                        val updatedGroups = if (viewerHasReacted) {
+                            state.reactionGroups.map { group ->
+                                if (group.emoji == emoji) {
+                                    group.copy(
+                                        count = maxOf(0, group.count - 1),
+                                        viewerHasReacted = false
+                                    )
+                                } else group
+                            }.filter { it.count > 0 || it.viewerHasReacted }
+                        } else {
+                            val existing = state.reactionGroups.find { it.emoji == emoji }
+                            if (existing != null) {
+                                state.reactionGroups.map { group ->
+                                    if (group.emoji == emoji) {
+                                        group.copy(
+                                            count = group.count + 1,
+                                            viewerHasReacted = true
+                                        )
+                                    } else group
+                                }
+                            } else {
+                                state.reactionGroups + ReactionGroup(
+                                    emoji = emoji,
+                                    customEmoji = null,
+                                    count = 1,
+                                    reactors = emptyList(),
+                                    viewerHasReacted = true
+                                )
+                            }
+                        }
+
+                        val totalReactions = updatedGroups.sumOf { it.count }
+
+                        state.copy(
+                            reactionGroups = updatedGroups,
+                            isReacting = false,
+                            post = state.post?.copy(
+                                engagementStats = state.post.engagementStats.copy(
+                                    reactions = totalReactions
+                                )
+                            )
+                        )
+                    }
+                }
+                .onFailure {
+                    _uiState.update { it.copy(isReacting = false) }
+                }
+        }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
@@ -7,8 +7,10 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import pub.hackers.android.data.local.SessionManager
 import pub.hackers.android.data.repository.HackersPubRepository
 import pub.hackers.android.domain.model.Post
 import pub.hackers.android.domain.model.ReactionGroup
@@ -19,12 +21,17 @@ data class PostDetailUiState(
     val reactionGroups: List<ReactionGroup> = emptyList(),
     val replies: List<Post> = emptyList(),
     val isLoading: Boolean = false,
-    val error: String? = null
+    val error: String? = null,
+    val canDelete: Boolean = false,
+    val isDeleting: Boolean = false,
+    val deleteError: String? = null,
+    val isDeleted: Boolean = false
 )
 
 @HiltViewModel
 class PostDetailViewModel @Inject constructor(
     private val repository: HackersPubRepository,
+    private val sessionManager: SessionManager,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -43,12 +50,18 @@ class PostDetailViewModel @Inject constructor(
 
             repository.getPostDetail(id)
                 .onSuccess { result ->
+                    val viewerHandle = sessionManager.userHandle.first()
+                    val canDelete = viewerHandle != null &&
+                        result.post.actor.handle.equals(viewerHandle, ignoreCase = true) &&
+                        result.post.sharedPost == null
+
                     _uiState.update {
                         it.copy(
                             post = result.post,
                             reactionGroups = result.reactionGroups,
                             replies = result.replies,
-                            isLoading = false
+                            isLoading = false,
+                            canDelete = canDelete
                         )
                     }
                 }
@@ -101,5 +114,27 @@ class PostDetailViewModel @Inject constructor(
                     }
                 }
         }
+    }
+
+    fun deletePost() {
+        if (_uiState.value.isDeleting) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isDeleting = true, deleteError = null) }
+
+            repository.deletePost(postId)
+                .onSuccess {
+                    _uiState.update { it.copy(isDeleting = false, isDeleted = true) }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(isDeleting = false, deleteError = error.message)
+                    }
+                }
+        }
+    }
+
+    fun dismissDeleteError() {
+        _uiState.update { it.copy(deleteError = null) }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pub.hackers.android.data.local.SessionManager
 import pub.hackers.android.data.repository.HackersPubRepository
+import pub.hackers.android.domain.model.Actor
 import pub.hackers.android.domain.model.Post
 import pub.hackers.android.domain.model.ReactionGroup
 import javax.inject.Inject
@@ -27,7 +28,13 @@ data class PostDetailUiState(
     val deleteError: String? = null,
     val isDeleted: Boolean = false,
     val isReacting: Boolean = false,
-    val showReactionPicker: Boolean = false
+    val showReactionPicker: Boolean = false,
+    val showSharesSheet: Boolean = false,
+    val shareActors: List<Actor> = emptyList(),
+    val isLoadingShares: Boolean = false,
+    val showQuotesSheet: Boolean = false,
+    val quotePosts: List<Post> = emptyList(),
+    val isLoadingQuotes: Boolean = false
 )
 
 @HiltViewModel
@@ -142,6 +149,44 @@ class PostDetailViewModel @Inject constructor(
 
     fun toggleReactionPicker() {
         _uiState.update { it.copy(showReactionPicker = !it.showReactionPicker) }
+    }
+
+    fun showSharesSheet() {
+        _uiState.update { it.copy(showSharesSheet = true, isLoadingShares = true) }
+        viewModelScope.launch {
+            repository.getPostShares(postId)
+                .onSuccess { result ->
+                    _uiState.update {
+                        it.copy(shareActors = result.actors, isLoadingShares = false)
+                    }
+                }
+                .onFailure {
+                    _uiState.update { it.copy(isLoadingShares = false) }
+                }
+        }
+    }
+
+    fun dismissSharesSheet() {
+        _uiState.update { it.copy(showSharesSheet = false) }
+    }
+
+    fun showQuotesSheet() {
+        _uiState.update { it.copy(showQuotesSheet = true, isLoadingQuotes = true) }
+        viewModelScope.launch {
+            repository.getPostQuotes(postId)
+                .onSuccess { result ->
+                    _uiState.update {
+                        it.copy(quotePosts = result.posts, isLoadingQuotes = false)
+                    }
+                }
+                .onFailure {
+                    _uiState.update { it.copy(isLoadingQuotes = false) }
+                }
+        }
+    }
+
+    fun dismissQuotesSheet() {
+        _uiState.update { it.copy(showQuotesSheet = false) }
     }
 
     fun toggleReaction(emoji: String) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
@@ -1,7 +1,10 @@
 package pub.hackers.android.ui.screens.profile
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,12 +12,21 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -22,6 +34,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import pub.hackers.android.ui.components.CompactTopBar
 import androidx.compose.runtime.Composable
@@ -29,7 +42,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -71,6 +86,19 @@ fun ProfileScreen(
         }
     }
 
+    if (uiState.actionError != null) {
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissActionError() },
+            title = { Text(stringResource(R.string.action_error)) },
+            text = { Text(uiState.actionError ?: "") },
+            confirmButton = {
+                TextButton(onClick = { viewModel.dismissActionError() }) {
+                    Text(stringResource(R.string.ok))
+                }
+            }
+        )
+    }
+
     Scaffold(
         contentWindowInsets = WindowInsets(0),
         topBar = {
@@ -81,6 +109,18 @@ fun ProfileScreen(
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Back"
+                        )
+                    }
+                },
+                actions = {
+                    if (!uiState.isViewer && uiState.actor != null) {
+                        ProfileActionMenu(
+                            followsViewer = uiState.followsViewer,
+                            viewerBlocks = uiState.viewerBlocks,
+                            isPerformingAction = uiState.isPerformingAction,
+                            onRemoveFollower = { viewModel.removeFollower() },
+                            onBlock = { viewModel.blockActor() },
+                            onUnblock = { viewModel.unblockActor() }
                         )
                     }
                 }
@@ -113,7 +153,14 @@ fun ProfileScreen(
                                     avatarUrl = uiState.actor!!.avatarUrl,
                                     name = uiState.actor!!.name,
                                     handle = uiState.actor!!.handle,
-                                    bio = uiState.bio
+                                    bio = uiState.bio,
+                                    isViewer = uiState.isViewer,
+                                    viewerFollows = uiState.viewerFollows,
+                                    followsViewer = uiState.followsViewer,
+                                    viewerBlocks = uiState.viewerBlocks,
+                                    isPerformingAction = uiState.isPerformingAction,
+                                    onFollowClick = { viewModel.followActor() },
+                                    onUnfollowClick = { viewModel.unfollowActor() }
                                 )
                                 HorizontalDivider()
                             }
@@ -145,11 +192,69 @@ fun ProfileScreen(
 }
 
 @Composable
+private fun ProfileActionMenu(
+    followsViewer: Boolean,
+    viewerBlocks: Boolean,
+    isPerformingAction: Boolean,
+    onRemoveFollower: () -> Unit,
+    onBlock: () -> Unit,
+    onUnblock: () -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box {
+        IconButton(onClick = { expanded = true }) {
+            Icon(
+                imageVector = Icons.Filled.MoreVert,
+                contentDescription = "More actions"
+            )
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            if (followsViewer) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.remove_follower)) },
+                    onClick = {
+                        expanded = false
+                        onRemoveFollower()
+                    },
+                    enabled = !isPerformingAction
+                )
+            }
+
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        text = stringResource(if (viewerBlocks) R.string.unblock else R.string.block),
+                        color = if (!viewerBlocks) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface
+                    )
+                },
+                onClick = {
+                    expanded = false
+                    if (viewerBlocks) onUnblock() else onBlock()
+                },
+                enabled = !isPerformingAction
+            )
+        }
+    }
+}
+
+@Composable
 private fun ProfileHeader(
     avatarUrl: String,
     name: String?,
     handle: String,
-    bio: String?
+    bio: String?,
+    isViewer: Boolean,
+    viewerFollows: Boolean,
+    followsViewer: Boolean,
+    viewerBlocks: Boolean,
+    isPerformingAction: Boolean,
+    onFollowClick: () -> Unit,
+    onUnfollowClick: () -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -175,18 +280,108 @@ private fun ProfileHeader(
             textAlign = TextAlign.Center
         )
 
-        Text(
-            text = "@$handle",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center
-        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "@$handle",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+
+            if (!isViewer && (followsViewer || viewerBlocks)) {
+                Spacer(modifier = Modifier.width(8.dp))
+                RelationshipTags(
+                    followsViewer = followsViewer,
+                    viewerBlocks = viewerBlocks
+                )
+            }
+        }
+
+        if (!isViewer) {
+            Spacer(modifier = Modifier.height(12.dp))
+
+            if (viewerFollows) {
+                Button(
+                    onClick = onUnfollowClick,
+                    enabled = !isPerformingAction,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error
+                    ),
+                    modifier = Modifier.width(200.dp)
+                ) {
+                    if (isPerformingAction) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            color = MaterialTheme.colorScheme.onError,
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        Text(stringResource(R.string.unfollow))
+                    }
+                }
+            } else {
+                Button(
+                    onClick = onFollowClick,
+                    enabled = !isPerformingAction,
+                    modifier = Modifier.width(200.dp)
+                ) {
+                    if (isPerformingAction) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        Text(stringResource(R.string.follow))
+                    }
+                }
+            }
+        }
 
         if (!bio.isNullOrBlank()) {
             Spacer(modifier = Modifier.height(12.dp))
             HtmlContent(
                 html = bio,
                 modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+private fun RelationshipTags(
+    followsViewer: Boolean,
+    viewerBlocks: Boolean
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (followsViewer) {
+            Text(
+                text = stringResource(R.string.follows_you),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .background(
+                        MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
+                        RoundedCornerShape(50)
+                    )
+                    .padding(horizontal = 8.dp, vertical = 4.dp)
+            )
+        }
+
+        if (viewerBlocks) {
+            Text(
+                text = stringResource(R.string.blocked),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier
+                    .background(
+                        MaterialTheme.colorScheme.error.copy(alpha = 0.15f),
+                        RoundedCornerShape(50)
+                    )
+                    .padding(horizontal = 8.dp, vertical = 4.dp)
             )
         }
     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
@@ -68,6 +68,7 @@ fun ProfileScreen(
     handle: String,
     onNavigateBack: () -> Unit,
     onPostClick: (String) -> Unit,
+    onProfileClick: (String) -> Unit = {},
     viewModel: ProfileViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -172,7 +173,7 @@ fun ProfileScreen(
                                 PostCard(
                                     post = post,
                                     onClick = { onPostClick(post.sharedPost?.id ?: post.id) },
-                                    onProfileClick = {},
+                                    onProfileClick = onProfileClick,
                                     onQuotedPostClick = onPostClick
                                 )
                                 HorizontalDivider(thickness = 0.5.dp)

--- a/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileViewModel.kt
@@ -23,7 +23,13 @@ data class ProfileUiState(
     val isLoadingMore: Boolean = false,
     val hasNextPage: Boolean = false,
     val endCursor: String? = null,
-    val error: String? = null
+    val error: String? = null,
+    val isViewer: Boolean = false,
+    val viewerFollows: Boolean = false,
+    val followsViewer: Boolean = false,
+    val viewerBlocks: Boolean = false,
+    val isPerformingAction: Boolean = false,
+    val actionError: String? = null
 )
 
 @HiltViewModel
@@ -54,6 +60,10 @@ class ProfileViewModel @Inject constructor(
                             posts = result.posts,
                             hasNextPage = result.hasNextPage,
                             endCursor = result.endCursor,
+                            isViewer = result.isViewer,
+                            viewerFollows = result.viewerFollows,
+                            followsViewer = result.followsViewer,
+                            viewerBlocks = result.viewerBlocks,
                             isLoading = false
                         )
                     }
@@ -82,6 +92,10 @@ class ProfileViewModel @Inject constructor(
                             posts = result.posts,
                             hasNextPage = result.hasNextPage,
                             endCursor = result.endCursor,
+                            isViewer = result.isViewer,
+                            viewerFollows = result.viewerFollows,
+                            followsViewer = result.followsViewer,
+                            viewerBlocks = result.viewerBlocks,
                             isRefreshing = false
                         )
                     }
@@ -119,5 +133,109 @@ class ProfileViewModel @Inject constructor(
                     _uiState.update { it.copy(isLoadingMore = false) }
                 }
         }
+    }
+
+    fun followActor() {
+        val actorId = _uiState.value.actor?.id ?: return
+        if (_uiState.value.isPerformingAction) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPerformingAction = true, actionError = null) }
+
+            repository.followActor(actorId)
+                .onSuccess {
+                    refresh()
+                    _uiState.update { it.copy(isPerformingAction = false) }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(isPerformingAction = false, actionError = error.message)
+                    }
+                }
+        }
+    }
+
+    fun unfollowActor() {
+        val actorId = _uiState.value.actor?.id ?: return
+        if (_uiState.value.isPerformingAction) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPerformingAction = true, actionError = null) }
+
+            repository.unfollowActor(actorId)
+                .onSuccess {
+                    refresh()
+                    _uiState.update { it.copy(isPerformingAction = false) }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(isPerformingAction = false, actionError = error.message)
+                    }
+                }
+        }
+    }
+
+    fun blockActor() {
+        val actorId = _uiState.value.actor?.id ?: return
+        if (_uiState.value.isPerformingAction) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPerformingAction = true, actionError = null) }
+
+            repository.blockActor(actorId)
+                .onSuccess {
+                    refresh()
+                    _uiState.update { it.copy(isPerformingAction = false) }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(isPerformingAction = false, actionError = error.message)
+                    }
+                }
+        }
+    }
+
+    fun unblockActor() {
+        val actorId = _uiState.value.actor?.id ?: return
+        if (_uiState.value.isPerformingAction) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPerformingAction = true, actionError = null) }
+
+            repository.unblockActor(actorId)
+                .onSuccess {
+                    refresh()
+                    _uiState.update { it.copy(isPerformingAction = false) }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(isPerformingAction = false, actionError = error.message)
+                    }
+                }
+        }
+    }
+
+    fun removeFollower() {
+        val actorId = _uiState.value.actor?.id ?: return
+        if (_uiState.value.isPerformingAction) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPerformingAction = true, actionError = null) }
+
+            repository.removeFollower(actorId)
+                .onSuccess {
+                    refresh()
+                    _uiState.update { it.copy(isPerformingAction = false) }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(isPerformingAction = false, actionError = error.message)
+                    }
+                }
+        }
+    }
+
+    fun dismissActionError() {
+        _uiState.update { it.copy(actionError = null) }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="blocked">Blocked</string>
     <string name="action_error">Error</string>
     <string name="ok">OK</string>
+    <string name="quoting">Quoting</string>
     <string name="delete_post">Delete</string>
     <string name="delete_post_confirm">Are you sure you want to delete this post?</string>
     <string name="delete_post_confirm_title">Delete Post</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,20 @@
     <string name="clear_cache">Clear Cache</string>
     <string name="cache_cleared">Cache cleared</string>
 
+    <!-- Profile -->
+    <string name="follow">Follow</string>
+    <string name="unfollow">Unfollow</string>
+    <string name="block">Block</string>
+    <string name="unblock">Unblock</string>
+    <string name="remove_follower">Remove follower</string>
+    <string name="follows_you">Follows you</string>
+    <string name="blocked">Blocked</string>
+    <string name="action_error">Error</string>
+    <string name="ok">OK</string>
+    <string name="delete_post">Delete</string>
+    <string name="delete_post_confirm">Are you sure you want to delete this post?</string>
+    <string name="delete_post_confirm_title">Delete Post</string>
+
     <!-- Errors -->
     <string name="error_generic">Something went wrong</string>
     <string name="error_network">Network error. Please check your connection.</string>


### PR DESCRIPTION
## Summary
- Conditionally show reply FAB in post detail only when authenticated
- Pass `isLoggedIn` state to PostDetailScreen from navigation
- Matches iOS behavior where interactive actions are hidden for unauthenticated users

Stacked on #11

## Test plan
- [ ] Verify reply FAB appears on post detail when logged in
- [ ] Verify reply FAB is hidden on post detail when not logged in (e.g., navigating from Explore)