### PR TITLE
Add F-Droid metadata and release workflow

### DIFF
--- a/.github/workflows/fdroid-release.yml
+++ b/.github/workflows/fdroid-release.yml
@@ -1,0 +1,49 @@
+name: F-Droid Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: echo "$KEYSTORE_BASE64" | base64 -d > ${{ github.workspace }}/release.keystore
+
+      - name: Build signed release APK
+        env:
+          KEYSTORE_FILE: ${{ github.workspace }}/release.keystore
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
+        run: ./gradlew assembleRelease
+
+      - name: Upload APK to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: app/build/outputs/apk/release/app-release.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clean up keystore
+        if: always()
+        run: rm -f ${{ github.workspace }}/release.keystore

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,18 @@ android {
     namespace = "pub.hackers.android"
     compileSdk = 35
 
+    signingConfigs {
+        create("release") {
+            val keystoreFile = System.getenv("KEYSTORE_FILE")
+            if (keystoreFile != null) {
+                storeFile = file(keystoreFile)
+                storePassword = System.getenv("STORE_PASSWORD")
+                keyAlias = System.getenv("KEY_ALIAS")
+                keyPassword = System.getenv("KEY_PASSWORD")
+            }
+        }
+    }
+
     defaultConfig {
         applicationId = "pub.hackers.android"
         minSdk = 26
@@ -28,6 +40,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.findByName("release")
         }
     }
 
@@ -42,6 +55,11 @@ android {
 
     buildFeatures {
         compose = true
+    }
+
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
     }
 }
 

--- a/fastlane/metadata/android/en-US/changelogs/1.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1.txt
@@ -1,0 +1,1 @@
+Initial release of the Hackers' Pub Android client.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,10 @@
+Hackers' Pub is a federated community platform for software engineers, built on ActivityPub. This Android client lets you browse timelines, interact with posts, explore content, and participate in the fediverse from your mobile device.
+
+Features include:
+* Browse your home timeline
+* Explore trending posts and topics
+* View and interact with posts
+* Search for content and users
+* Compose and publish posts
+* View user profiles
+* Receive notifications

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+A client for Hackers' Pub, a federated community for software engineers

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+Hackers' Pub

--- a/metadata/pub.hackers.android.yml
+++ b/metadata/pub.hackers.android.yml
@@ -1,0 +1,40 @@
+Categories:
+  - Internet
+License: AGPL-3.0-only
+AuthorName: Hackers' Pub
+SourceCode: https://github.com/hackers-pub/android
+IssueTracker: https://github.com/hackers-pub/android/issues
+
+Summary: A client for Hackers' Pub, a federated community for software engineers
+
+Description: |-
+  Hackers' Pub is a federated community platform for software engineers,
+  built on ActivityPub. This Android client lets you browse timelines,
+  interact with posts, explore content, and participate in the fediverse
+  from your mobile device.
+
+  Features include:
+  * Browse your home timeline
+  * Explore trending posts and topics
+  * View and interact with posts
+  * Search for content and users
+  * Compose and publish posts
+  * View user profiles
+  * Receive notifications
+
+RepoType: git
+Repo: https://github.com/hackers-pub/android.git
+
+Builds:
+  - versionName: 1.0.0
+    versionCode: 1
+    commit: v1.0.0
+    subdir: app
+    gradle:
+      - yes
+    ndk: r27c
+
+AutoUpdateMode: Version
+UpdateCheckMode: Tags
+CurrentVersion: 1.0.0
+CurrentVersionCode: 1


### PR DESCRIPTION
## Summary

Set up F-Droid publishing infrastructure for the Hackers' Pub Android client:

- Add F-Droid metadata YAML (`metadata/pub.hackers.android.yml`) with proper categories, license, description, and build configuration
- Create Fastlane store listing under `fastlane/metadata/android/en-US/` with title, descriptions, and changelog
- Add GitHub Actions workflow (`.github/workflows/fdroid-release.yml`) that builds a signed release APK and attaches it to GitHub Releases on `v*` tag pushes
- Configure `dependenciesInfo` and release signing in `app/build.gradle.kts` for reproducible builds

## Setup required

The following GitHub Actions secrets need to be configured before tagging a release:
- `KEYSTORE_BASE64` — base64-encoded release keystore
- `KEY_ALIAS` — signing key alias
- `KEY_PASSWORD` — signing key password
- `STORE_PASSWORD` — keystore password