### PR TITLE
Add ML Kit translation support for post cards and post detail views

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,6 +99,10 @@ dependencies {
 
     implementation(libs.coil.compose)
     implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.coroutines.play.services)
+
+    implementation(libs.mlkit.translate)
+    implementation(libs.mlkit.language.id)
 
     implementation("androidx.browser:browser:1.8.0")
 

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -4,6 +4,7 @@ package pub.hackers.android.ui.components
 
 import android.content.Intent
 import android.net.Uri
+import android.text.Html
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -29,9 +30,10 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
 import androidx.compose.material.icons.outlined.Favorite
-import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.outlined.FormatQuote
 import androidx.compose.material.icons.outlined.Repeat
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -40,21 +42,31 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.google.mlkit.common.model.DownloadConditions
+import com.google.mlkit.nl.languageid.LanguageIdentification
+import com.google.mlkit.nl.translate.TranslateLanguage
+import com.google.mlkit.nl.translate.Translation
+import com.google.mlkit.nl.translate.TranslatorOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
 import pub.hackers.android.R
 import pub.hackers.android.domain.model.Post
 import pub.hackers.android.ui.theme.AppShapes
@@ -62,6 +74,7 @@ import pub.hackers.android.ui.theme.LocalAppColors
 import pub.hackers.android.ui.theme.LocalAppTypography
 import java.time.Duration
 import java.time.Instant
+import java.util.Locale
 
 @Composable
 fun PostCard(
@@ -121,6 +134,14 @@ private fun NoteCard(
     val isRepost = post.sharedPost != null
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
+    val context = LocalContext.current
+    val translationFailedText = stringResource(R.string.translation_failed)
+    val scope = rememberCoroutineScope()
+
+    var translatedContent by remember(displayPost.id) { mutableStateOf<String?>(null) }
+    var translationError by remember(displayPost.id) { mutableStateOf<String?>(null) }
+    var isTranslating by remember(displayPost.id) { mutableStateOf(false) }
+    var showTranslated by remember(displayPost.id) { mutableStateOf(false) }
 
     // Step 1: Replace Card with plain Column
     Column(
@@ -226,13 +247,40 @@ private fun NoteCard(
                 }
                 val isTruncated = contentMaxLength > 0 && displayPost.content.length > contentMaxLength
 
-                HtmlContent(
-                    html = truncatedContent,
-                    maxLines = if (contentMaxLength > 0) Int.MAX_VALUE else 10,
-                    modifier = Modifier.fillMaxWidth(),
-                    onMentionClick = onProfileClick,
-                    onTextClick = onClick
-                )
+                if (showTranslated && translatedContent != null) {
+                    Text(
+                        text = translatedContent!!,
+                        style = typography.bodyLarge,
+                        color = colors.textBody,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                } else {
+                    HtmlContent(
+                        html = truncatedContent,
+                        maxLines = if (contentMaxLength > 0) Int.MAX_VALUE else 10,
+                        modifier = Modifier.fillMaxWidth(),
+                        onMentionClick = onProfileClick,
+                        onTextClick = onClick
+                    )
+                }
+
+                if (isTranslating) {
+                    Text(
+                        text = stringResource(R.string.translating),
+                        style = typography.labelMedium,
+                        color = colors.textSecondary,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+
+                if (translationError != null) {
+                    Text(
+                        text = translationError!!,
+                        style = typography.labelMedium,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
 
                 if (isTruncated || (contentMaxLength == 0 && displayPost.content.length > 500)) {
                     Text(
@@ -314,7 +362,42 @@ private fun NoteCard(
                     onShareClick = onShareClick,
                     onQuoteClick = onQuoteClick,
                     onReactionClick = onReactionClick,
-                    onExternalShareClick = onExternalShareClick
+                    onExternalShareClick = onExternalShareClick,
+                    onTranslateClick = {
+                        if (isTranslating) return@EngagementBar
+
+                        if (showTranslated) {
+                            showTranslated = false
+                            return@EngagementBar
+                        }
+
+                        translatedContent?.let {
+                            showTranslated = true
+                            return@EngagementBar
+                        }
+
+                        val targetLanguageTag = androidx.core.os.ConfigurationCompat
+                            .getLocales(context.resources.configuration)
+                            .get(0)?.language ?: Locale.getDefault().language
+                        scope.launch {
+                            isTranslating = true
+                            translationError = null
+                            try {
+                                val translated = translateHtmlContent(
+                                    html = displayPost.content,
+                                    targetLanguageTag = targetLanguageTag
+                                )
+                                translatedContent = translated
+                                showTranslated = true
+                            } catch (_: Exception) {
+                                translationError = translationFailedText
+                            } finally {
+                                isTranslating = false
+                            }
+                        }
+                    },
+                    isTranslating = isTranslating,
+                    isTranslated = showTranslated
                 )
             }
         }
@@ -329,7 +412,10 @@ private fun EngagementBar(
     onShareClick: (() -> Unit)?,
     onQuoteClick: (() -> Unit)? = null,
     onReactionClick: (() -> Unit)? = null,
-    onExternalShareClick: (() -> Unit)? = null
+    onExternalShareClick: (() -> Unit)? = null,
+    onTranslateClick: (() -> Unit)? = null,
+    isTranslating: Boolean = false,
+    isTranslated: Boolean = false
 ) {
     val colors = LocalAppColors.current
     val isReplied = post.engagementStats.replies > 0 && post.replyTarget != null
@@ -378,6 +464,20 @@ private fun EngagementBar(
             onClick = onQuoteClick,
             activeColor = colors.accent,
             isActive = false
+        )
+
+        // Translate
+        EngagementButton(
+            icon = Icons.Outlined.Translate,
+            count = 0,
+            contentDescription = if (isTranslated) {
+                stringResource(R.string.show_original)
+            } else {
+                stringResource(R.string.translate)
+            },
+            onClick = if (isTranslating) null else onTranslateClick,
+            activeColor = colors.accent,
+            isActive = isTranslated
         )
 
         // External share — always textSecondary
@@ -669,5 +769,43 @@ private fun formatCount(count: Int): String {
         count < 1000 -> count.toString()
         count < 1_000_000 -> String.format("%.1fK", count / 1000.0)
         else -> String.format("%.1fM", count / 1_000_000.0)
+    }
+}
+
+private suspend fun translateHtmlContent(
+    html: String,
+    targetLanguageTag: String
+): String = withContext(Dispatchers.IO) {
+    val plainText = Html.fromHtml(html, Html.FROM_HTML_MODE_LEGACY)
+        .toString()
+        .trim()
+
+    if (plainText.isBlank()) {
+        return@withContext ""
+    }
+
+    val languageIdentifier = LanguageIdentification.getClient()
+    val detectedLanguageTag = languageIdentifier.identifyLanguage(plainText).await()
+    val sourceLanguage = TranslateLanguage.fromLanguageTag(detectedLanguageTag)
+    val targetLanguage = TranslateLanguage.fromLanguageTag(targetLanguageTag)
+
+    if (sourceLanguage == null || targetLanguage == null || sourceLanguage == targetLanguage) {
+        languageIdentifier.close()
+        return@withContext plainText
+    }
+
+    val translatorOptions = TranslatorOptions.Builder()
+        .setSourceLanguage(sourceLanguage)
+        .setTargetLanguage(targetLanguage)
+        .build()
+
+    val translator = Translation.getClient(translatorOptions)
+
+    try {
+        translator.downloadModelIfNeeded(DownloadConditions.Builder().build()).await()
+        translator.translate(plainText).await()
+    } finally {
+        translator.close()
+        languageIdentifier.close()
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -87,8 +88,20 @@ import pub.hackers.android.ui.components.ReactionPicker
 import pub.hackers.android.ui.theme.AppShapes
 import pub.hackers.android.ui.theme.LocalAppColors
 import pub.hackers.android.ui.theme.LocalAppTypography
+import android.text.Html
+import androidx.compose.material.icons.outlined.Translate
+import com.google.mlkit.common.model.DownloadConditions
+import com.google.mlkit.nl.languageid.LanguageIdentification
+import com.google.mlkit.nl.translate.TranslateLanguage
+import com.google.mlkit.nl.translate.Translation
+import com.google.mlkit.nl.translate.TranslatorOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -408,6 +421,15 @@ private fun PostDetailContent(
 ) {
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val translationFailedText = stringResource(R.string.translation_failed)
+
+    var translatedContent by remember(post.id) { mutableStateOf<String?>(null) }
+    var translationError by remember(post.id) { mutableStateOf<String?>(null) }
+    var isTranslating by remember(post.id) { mutableStateOf(false) }
+    var showTranslated by remember(post.id) { mutableStateOf(false) }
+
     val dateFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy 'at' h:mm a")
         .withZone(ZoneId.systemDefault())
 
@@ -498,11 +520,38 @@ private fun PostDetailContent(
                     }
                 }
 
-                HtmlContent(
-                    html = post.content,
-                    modifier = Modifier.fillMaxWidth(),
-                    onMentionClick = onProfileClick
-                )
+                if (showTranslated && translatedContent != null) {
+                    Text(
+                        text = translatedContent!!,
+                        style = typography.bodyLarge,
+                        color = colors.textBody,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                } else {
+                    HtmlContent(
+                        html = post.content,
+                        modifier = Modifier.fillMaxWidth(),
+                        onMentionClick = onProfileClick
+                    )
+                }
+
+                if (isTranslating) {
+                    Text(
+                        text = stringResource(R.string.translating),
+                        style = typography.labelMedium,
+                        color = colors.textSecondary,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+
+                if (translationError != null) {
+                    Text(
+                        text = translationError!!,
+                        style = typography.labelMedium,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
 
                 if (post.media.isNotEmpty()) {
                     Spacer(modifier = Modifier.height(12.dp))
@@ -686,6 +735,47 @@ private fun PostDetailContent(
                             imageVector = Icons.Outlined.FormatQuote,
                             contentDescription = stringResource(R.string.quotes),
                             tint = colors.textSecondary
+                        )
+                    }
+                    IconButton(
+                        onClick = {
+                            if (isTranslating) return@IconButton
+                            if (showTranslated) {
+                                showTranslated = false
+                                return@IconButton
+                            }
+                            translatedContent?.let {
+                                showTranslated = true
+                                return@IconButton
+                            }
+                            val targetLanguageTag = androidx.core.os.ConfigurationCompat
+                                .getLocales(context.resources.configuration)
+                                .get(0)?.language ?: Locale.getDefault().language
+                            scope.launch {
+                                isTranslating = true
+                                translationError = null
+                                try {
+                                    val translated = translateDetailContent(
+                                        html = post.content,
+                                        targetLanguageTag = targetLanguageTag
+                                    )
+                                    translatedContent = translated
+                                    showTranslated = true
+                                } catch (_: Exception) {
+                                    translationError = translationFailedText
+                                } finally {
+                                    isTranslating = false
+                                }
+                            }
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Translate,
+                            contentDescription = if (showTranslated)
+                                stringResource(R.string.show_original)
+                            else
+                                stringResource(R.string.translate),
+                            tint = if (showTranslated) colors.accent else colors.textSecondary
                         )
                     }
                     IconButton(onClick = onExternalShareClick) {
@@ -964,5 +1054,36 @@ private fun ReplyTargetPreview(
             Spacer(modifier = Modifier.height(8.dp))
             MediaGrid(media = post.media)
         }
+    }
+}
+
+private suspend fun translateDetailContent(
+    html: String,
+    targetLanguageTag: String
+): String = withContext(Dispatchers.IO) {
+    val plainText = Html.fromHtml(html, Html.FROM_HTML_MODE_LEGACY).toString().trim()
+    if (plainText.isBlank()) return@withContext ""
+
+    val languageIdentifier = LanguageIdentification.getClient()
+    val detectedTag = languageIdentifier.identifyLanguage(plainText).await()
+    val sourceLanguage = TranslateLanguage.fromLanguageTag(detectedTag)
+    val targetLanguage = TranslateLanguage.fromLanguageTag(targetLanguageTag)
+
+    if (sourceLanguage == null || targetLanguage == null || sourceLanguage == targetLanguage) {
+        languageIdentifier.close()
+        return@withContext plainText
+    }
+
+    val options = TranslatorOptions.Builder()
+        .setSourceLanguage(sourceLanguage)
+        .setTargetLanguage(targetLanguage)
+        .build()
+    val translator = Translation.getClient(options)
+    try {
+        translator.downloadModelIfNeeded(DownloadConditions.Builder().build()).await()
+        translator.translate(plainText).await()
+    } finally {
+        translator.close()
+        languageIdentifier.close()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,10 @@
     <string name="replying_to">Replying to</string>
     <string name="read_more">Read more</string>
     <string name="open_in_browser">Open in browser</string>
+    <string name="translate">Translate</string>
+    <string name="show_original">Show original</string>
+    <string name="translating">Translating...</string>
+    <string name="translation_failed">Translation failed</string>
 
     <!-- Settings -->
     <string name="settings">Settings</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ coil = "2.7.0"
 datastore = "1.1.1"
 ksp = "2.1.0-1.0.29"
 coroutines = "1.9.0"
+mlkitTranslate = "17.0.3"
+mlkitLanguageId = "17.0.6"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -40,6 +42,10 @@ apollo-normalized-cache-sqlite = { group = "com.apollographql.apollo", name = "a
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "coroutines" }
+
+mlkit-translate = { group = "com.google.mlkit", name = "translate", version.ref = "mlkitTranslate" }
+mlkit-language-id = { group = "com.google.mlkit", name = "language-id", version.ref = "mlkitLanguageId" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

This PR adds ML Kit-based translation support for posts across the app.

Users can now translate post content from both timeline post cards and post detail screens, and toggle back to the original text after translation.

## Changes

- add ML Kit Translate and Language ID dependencies
- add coroutine Play Services integration for `await()`
- add translation-related string resources
- add translate action to the post card engagement bar
- add translate action to the post detail action row
- detect the user's selected app/device language as the translation target
- show translation loading and error states
- cache translated text in UI state for quick toggling between translated and original content

## Implementation Notes

- post HTML is converted to plain text before translation
- the source language is detected with ML Kit Language Identification
- translation models are downloaded on demand via ML Kit
- if the detected source language matches the target language, the original text is shown

## Tested

- built the app successfully with `./gradlew assembleDebug`
- verified the translation UI is available on both post cards and post detail screens

## Notes

- translated content is currently displayed as plain text, not re-rendered as HTML
- links and mentions in translated output are not preserved as interactive elements