### PR TITLE
Add app bundle (AAB) to release workflow

### DIFF
--- a/.github/workflows/fdroid-release.yml
+++ b/.github/workflows/fdroid-release.yml
@@ -29,18 +29,20 @@ jobs:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
         run: echo "$KEYSTORE_BASE64" | base64 -d > ${{ github.workspace }}/release.keystore
 
-      - name: Build signed release APK
+      - name: Build signed release APK and App Bundle
         env:
           KEYSTORE_FILE: ${{ github.workspace }}/release.keystore
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
-        run: ./gradlew assembleRelease
+        run: ./gradlew assembleRelease bundleRelease
 
-      - name: Upload APK to GitHub Release
+      - name: Upload APK and App Bundle to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: app/build/outputs/apk/release/app-release.apk
+          files: |
+            app/build/outputs/apk/release/app-release.apk
+            app/build/outputs/bundle/release/app-release.aab
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
Add AAB (Android App Bundle) artifact to the release workflow alongside the existing APK. The workflow now runs both `assembleRelease` and `bundleRelease`, and uploads both artifacts to GitHub Releases when a version tag is pushed.