### PR TITLE
Fix auth code input to allow alphanumeric keyboard

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInScreen.kt
@@ -250,7 +250,7 @@ private fun VerificationStep(
             cursorColor = colors.accent,
         ),
         keyboardOptions = KeyboardOptions(
-            keyboardType = KeyboardType.Number,
+            keyboardType = KeyboardType.Ascii,
             imeAction = ImeAction.Done
         ),
         keyboardActions = KeyboardActions(onDone = { onSubmit() }),


### PR DESCRIPTION
## Summary
The verification code contains both letters and numbers, but the input field keyboard type was set to `KeyboardType.Number`, making it impossible to enter the full code. Changed to `KeyboardType.Ascii` to allow alphanumeric input.

Fixes #66