### PR TITLE
Add background notification polling via WorkManager

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,6 +92,9 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)
     implementation(libs.hilt.navigation.compose)
+    implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.hilt.work)
+    ksp(libs.hilt.compiler)
 
     implementation(libs.apollo.runtime)
     implementation(libs.apollo.normalized.cache)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -15,3 +15,6 @@
 
 # Coil
 -dontwarn coil.**
+
+# WorkManager HiltWorker
+-keep class pub.hackers.android.data.worker.NotificationWorker { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".HackersPubApplication"
@@ -28,6 +30,15 @@
                     android:host="verify" />
             </intent-filter>
         </activity>
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                tools:node="remove" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -190,17 +190,20 @@ query Notifications($after: String) {
                     }
                     ... on MentionNotification {
                         post {
-                            ...PostFields
+                            id
+                            content
                         }
                     }
                     ... on ReplyNotification {
                         post {
-                            ...PostFields
+                            id
+                            content
                         }
                     }
                     ... on QuoteNotification {
                         post {
-                            ...PostFields
+                            id
+                            content
                         }
                     }
                     ... on ReactNotification {
@@ -211,12 +214,14 @@ query Notifications($after: String) {
                             imageUrl
                         }
                         post {
-                            ...PostFields
+                            id
+                            content
                         }
                     }
                     ... on ShareNotification {
                         post {
-                            ...PostFields
+                            id
+                            content
                         }
                     }
                 }

--- a/app/src/main/java/pub/hackers/android/HackersPubApplication.kt
+++ b/app/src/main/java/pub/hackers/android/HackersPubApplication.kt
@@ -1,7 +1,42 @@
 package pub.hackers.android
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
-class HackersPubApplication : Application()
+class HackersPubApplication : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            NOTIFICATION_CHANNEL_ID,
+            "Hackers' Pub",
+            NotificationManager.IMPORTANCE_DEFAULT
+        ).apply {
+            description = "Notifications from Hackers' Pub"
+        }
+        val notificationManager = getSystemService(NotificationManager::class.java)
+        notificationManager.createNotificationChannel(channel)
+    }
+
+    companion object {
+        const val NOTIFICATION_CHANNEL_ID = "hackerspub_notifications"
+    }
+}

--- a/app/src/main/java/pub/hackers/android/MainActivity.kt
+++ b/app/src/main/java/pub/hackers/android/MainActivity.kt
@@ -1,20 +1,29 @@
 package pub.hackers.android
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.core.content.ContextCompat
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import pub.hackers.android.data.local.SessionManager
 import pub.hackers.android.ui.HackersPubApp
 import pub.hackers.android.ui.theme.HackersPubTheme
 import pub.hackers.android.ui.theme.LocalAppColors
+import javax.inject.Inject
 
 data class DeepLinkData(
     val token: String,
@@ -26,9 +35,19 @@ class MainActivity : ComponentActivity() {
 
     private var deepLinkData by mutableStateOf<DeepLinkData?>(null)
 
+    @Inject
+    lateinit var sessionManager: SessionManager
+
+    private val requestPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { _: Boolean ->
+        // Permission result — no action needed, worker checks at post time
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         handleDeepLink(intent)
+        requestNotificationPermissionIfNeeded()
         enableEdgeToEdge()
         setContent {
             HackersPubTheme {
@@ -45,6 +64,18 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         handleDeepLink(intent)
+    }
+
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val isLoggedIn = runBlocking { sessionManager.isLoggedIn.first() }
+            if (isLoggedIn && ContextCompat.checkSelfPermission(
+                    this, Manifest.permission.POST_NOTIFICATIONS
+                ) != PackageManager.PERMISSION_GRANTED
+            ) {
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        }
     }
 
     private fun handleDeepLink(intent: Intent?) {

--- a/app/src/main/java/pub/hackers/android/MainActivity.kt
+++ b/app/src/main/java/pub/hackers/android/MainActivity.kt
@@ -30,10 +30,15 @@ data class DeepLinkData(
     val code: String
 )
 
+data class NavigationIntent(
+    val route: String
+)
+
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     private var deepLinkData by mutableStateOf<DeepLinkData?>(null)
+    private var navigationIntent by mutableStateOf<NavigationIntent?>(null)
 
     @Inject
     lateinit var sessionManager: SessionManager
@@ -47,6 +52,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         handleDeepLink(intent)
+        handleNavigationIntent(intent)
         requestNotificationPermissionIfNeeded()
         enableEdgeToEdge()
         setContent {
@@ -55,7 +61,10 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = LocalAppColors.current.background
                 ) {
-                    HackersPubApp(deepLinkData = deepLinkData)
+                    HackersPubApp(
+                        deepLinkData = deepLinkData,
+                        navigationIntent = navigationIntent
+                    )
                 }
             }
         }
@@ -64,6 +73,7 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         handleDeepLink(intent)
+        handleNavigationIntent(intent)
     }
 
     private fun requestNotificationPermissionIfNeeded() {
@@ -76,6 +86,11 @@ class MainActivity : ComponentActivity() {
                 requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
             }
         }
+    }
+
+    private fun handleNavigationIntent(intent: Intent?) {
+        val route = intent?.getStringExtra("navigate_to") ?: return
+        navigationIntent = NavigationIntent(route = route)
     }
 
     private fun handleDeepLink(intent: Intent?) {

--- a/app/src/main/java/pub/hackers/android/data/local/NotificationStateManager.kt
+++ b/app/src/main/java/pub/hackers/android/data/local/NotificationStateManager.kt
@@ -1,0 +1,53 @@
+package pub.hackers.android.data.local
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NotificationStateManager @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) {
+    companion object {
+        private val LAST_SEEN_NOTIFICATION_ID = stringPreferencesKey("last_seen_notification_id")
+        private val LAST_POLLED_NOTIFICATION_ID = stringPreferencesKey("last_polled_notification_id")
+    }
+
+    val hasUnread: Flow<Boolean> = dataStore.data.map { prefs ->
+        val lastSeen = prefs[LAST_SEEN_NOTIFICATION_ID]
+        val lastPolled = prefs[LAST_POLLED_NOTIFICATION_ID]
+        lastPolled != null && lastPolled != lastSeen
+    }
+
+    suspend fun getLastPolledId(): String? {
+        return dataStore.data.map { it[LAST_POLLED_NOTIFICATION_ID] }.first()
+    }
+
+    suspend fun updateLastPolledId(id: String) {
+        dataStore.edit { prefs ->
+            prefs[LAST_POLLED_NOTIFICATION_ID] = id
+        }
+    }
+
+    suspend fun markAsSeen() {
+        dataStore.edit { prefs ->
+            val lastPolled = prefs[LAST_POLLED_NOTIFICATION_ID]
+            if (lastPolled != null) {
+                prefs[LAST_SEEN_NOTIFICATION_ID] = lastPolled
+            }
+        }
+    }
+
+    suspend fun clear() {
+        dataStore.edit { prefs ->
+            prefs.remove(LAST_SEEN_NOTIFICATION_ID)
+            prefs.remove(LAST_POLLED_NOTIFICATION_ID)
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -859,28 +859,28 @@ class HackersPubRepository @Inject constructor(
                 uuid = uuid.toString(),
                 created = created,
                 actors = actors,
-                post = onMentionNotification.post?.postFields?.toPost()
+                post = onMentionNotification.post?.let { NotificationPost(id = it.id, content = it.content.toString()) }
             )
             onReplyNotification != null -> Notification.Reply(
                 id = id,
                 uuid = uuid.toString(),
                 created = created,
                 actors = actors,
-                post = onReplyNotification.post?.postFields?.toPost()
+                post = onReplyNotification.post?.let { NotificationPost(id = it.id, content = it.content.toString()) }
             )
             onQuoteNotification != null -> Notification.Quote(
                 id = id,
                 uuid = uuid.toString(),
                 created = created,
                 actors = actors,
-                post = onQuoteNotification.post?.postFields?.toPost()
+                post = onQuoteNotification.post?.let { NotificationPost(id = it.id, content = it.content.toString()) }
             )
             onShareNotification != null -> Notification.Share(
                 id = id,
                 uuid = uuid.toString(),
                 created = created,
                 actors = actors,
-                post = onShareNotification.post?.postFields?.toPost()
+                post = onShareNotification.post?.let { NotificationPost(id = it.id, content = it.content.toString()) }
             )
             onReactNotification != null -> Notification.React(
                 id = id,
@@ -895,7 +895,7 @@ class HackersPubRepository @Inject constructor(
                         imageUrl = it.imageUrl
                     )
                 },
-                post = onReactNotification.post?.postFields?.toPost()
+                post = onReactNotification.post?.let { NotificationPost(id = it.id, content = it.content.toString()) }
             )
             else -> null
         }

--- a/app/src/main/java/pub/hackers/android/data/worker/NotificationWorker.kt
+++ b/app/src/main/java/pub/hackers/android/data/worker/NotificationWorker.kt
@@ -1,0 +1,142 @@
+package pub.hackers.android.data.worker
+
+import android.Manifest
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.first
+import pub.hackers.android.HackersPubApplication
+import pub.hackers.android.MainActivity
+import pub.hackers.android.R
+import pub.hackers.android.data.local.NotificationStateManager
+import pub.hackers.android.data.local.SessionManager
+import pub.hackers.android.data.repository.HackersPubRepository
+import pub.hackers.android.domain.model.Notification
+
+@HiltWorker
+class NotificationWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val repository: HackersPubRepository,
+    private val sessionManager: SessionManager,
+    private val notificationStateManager: NotificationStateManager
+) : CoroutineWorker(appContext, workerParams) {
+
+    companion object {
+        const val NOTIFICATION_GROUP = "pub.hackers.android.NOTIFICATIONS"
+        const val SUMMARY_NOTIFICATION_ID = 0
+    }
+
+    override suspend fun doWork(): Result {
+        val isLoggedIn = sessionManager.isLoggedIn.first()
+        if (!isLoggedIn) return Result.success()
+
+        val result = repository.getNotifications(refresh = true)
+
+        return result.fold(
+            onSuccess = { notificationsResult ->
+                val notifications = notificationsResult.notifications
+                if (notifications.isEmpty()) return@fold Result.success()
+
+                val newestId = notifications.first().id
+                val previousId = notificationStateManager.getLastPolledId()
+
+                if (newestId != previousId) {
+                    notificationStateManager.updateLastPolledId(newestId)
+                    if (hasNotificationPermission()) {
+                        showNotifications(notifications)
+                    }
+                }
+
+                Result.success()
+            },
+            onFailure = { error ->
+                // Auth errors — don't retry
+                val message = error.message ?: ""
+                if (message.contains("401") || message.contains("403") || message.contains("unauthorized", ignoreCase = true)) {
+                    return@fold Result.success()
+                }
+                // Network errors — retry with exponential backoff
+                Result.retry()
+            }
+        )
+    }
+
+    private fun hasNotificationPermission(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(
+                applicationContext,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+    }
+
+    private fun showNotifications(notifications: List<Notification>) {
+        val notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        val intent = Intent(applicationContext, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra("navigate_to", "notifications")
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            applicationContext,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val channelId = HackersPubApplication.NOTIFICATION_CHANNEL_ID
+
+        // Show individual notifications (up to 5)
+        notifications.take(5).forEachIndexed { index, notification ->
+            val text = buildNotificationText(notification)
+            val builder = NotificationCompat.Builder(applicationContext, channelId)
+                .setSmallIcon(R.drawable.ic_launcher_foreground)
+                .setContentTitle("Hackers' Pub")
+                .setContentText(text)
+                .setAutoCancel(true)
+                .setContentIntent(pendingIntent)
+                .setGroup(NOTIFICATION_GROUP)
+
+            notificationManager.notify(index + 1, builder.build())
+        }
+
+        // Summary notification for grouping
+        if (notifications.size > 1) {
+            val summary = NotificationCompat.Builder(applicationContext, channelId)
+                .setSmallIcon(R.drawable.ic_launcher_foreground)
+                .setContentTitle("Hackers' Pub")
+                .setContentText("${notifications.size} new notifications")
+                .setAutoCancel(true)
+                .setContentIntent(pendingIntent)
+                .setGroup(NOTIFICATION_GROUP)
+                .setGroupSummary(true)
+                .build()
+            notificationManager.notify(SUMMARY_NOTIFICATION_ID, summary)
+        }
+    }
+
+    private fun buildNotificationText(notification: Notification): String {
+        val actorName = notification.actors.firstOrNull()?.name ?: "Someone"
+        return when (notification) {
+            is Notification.Follow -> "$actorName followed you"
+            is Notification.Mention -> "$actorName mentioned you"
+            is Notification.Reply -> "$actorName replied to your post"
+            is Notification.Quote -> "$actorName quoted your post"
+            is Notification.Share -> "$actorName shared your post"
+            is Notification.React -> "$actorName reacted to your post"
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/di/AppModule.kt
+++ b/app/src/main/java/pub/hackers/android/di/AppModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
+import androidx.work.WorkManager
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.cache.normalized.normalizedCache
 import com.apollographql.apollo.cache.normalized.sql.SqlNormalizedCacheFactory
@@ -67,5 +68,11 @@ object AppModule {
             .okHttpClient(okHttpClient)
             .normalizedCache(sqlNormalizedCacheFactory)
             .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideWorkManager(@ApplicationContext context: Context): WorkManager {
+        return WorkManager.getInstance(context)
     }
 }

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -50,6 +50,11 @@ enum class PostVisibility {
     PUBLIC, UNLISTED, FOLLOWERS, DIRECT, NONE
 }
 
+data class NotificationPost(
+    val id: String,
+    val content: String
+)
+
 sealed class Notification {
     abstract val id: String
     abstract val uuid: String
@@ -68,7 +73,7 @@ sealed class Notification {
         override val uuid: String,
         override val created: Instant,
         override val actors: List<Actor>,
-        val post: Post?
+        val post: NotificationPost?
     ) : Notification()
 
     data class Reply(
@@ -76,7 +81,7 @@ sealed class Notification {
         override val uuid: String,
         override val created: Instant,
         override val actors: List<Actor>,
-        val post: Post?
+        val post: NotificationPost?
     ) : Notification()
 
     data class Quote(
@@ -84,7 +89,7 @@ sealed class Notification {
         override val uuid: String,
         override val created: Instant,
         override val actors: List<Actor>,
-        val post: Post?
+        val post: NotificationPost?
     ) : Notification()
 
     data class Share(
@@ -92,7 +97,7 @@ sealed class Notification {
         override val uuid: String,
         override val created: Instant,
         override val actors: List<Actor>,
-        val post: Post?
+        val post: NotificationPost?
     ) : Notification()
 
     data class React(
@@ -102,7 +107,7 @@ sealed class Notification {
         override val actors: List<Actor>,
         val emoji: String?,
         val customEmoji: CustomEmoji?,
-        val post: Post?
+        val post: NotificationPost?
     ) : Notification()
 }
 

--- a/app/src/main/java/pub/hackers/android/ui/AppViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/AppViewModel.kt
@@ -8,15 +8,19 @@ import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import pub.hackers.android.data.local.NotificationStateManager
 import pub.hackers.android.data.local.PreferencesManager
 import pub.hackers.android.data.local.SessionManager
+import pub.hackers.android.data.repository.HackersPubRepository
 import pub.hackers.android.data.worker.NotificationWorker
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -26,17 +30,21 @@ class AppViewModel @Inject constructor(
     private val sessionManager: SessionManager,
     val preferencesManager: PreferencesManager,
     private val notificationStateManager: NotificationStateManager,
-    private val workManager: WorkManager
+    private val workManager: WorkManager,
+    private val repository: HackersPubRepository
 ) : ViewModel() {
 
     companion object {
         const val NOTIFICATION_WORK_NAME = "notification_poll"
+        const val FOREGROUND_POLL_INTERVAL_MS = 60_000L // 1 minute
     }
 
     val isLoggedIn: Flow<Boolean> = sessionManager.isLoggedIn
 
     val hasUnread: StateFlow<Boolean> = notificationStateManager.hasUnread
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    private var foregroundPollJob: Job? = null
 
     init {
         ensureNotificationPolling()
@@ -47,6 +55,7 @@ class AppViewModel @Inject constructor(
             val loggedIn = sessionManager.isLoggedIn.first()
             if (loggedIn) {
                 enqueueNotificationPolling()
+                startForegroundPolling()
             }
         }
     }
@@ -65,5 +74,37 @@ class AppViewModel @Inject constructor(
             ExistingPeriodicWorkPolicy.KEEP,
             workRequest
         )
+    }
+
+    fun startForegroundPolling() {
+        if (foregroundPollJob?.isActive == true) return
+        foregroundPollJob = viewModelScope.launch {
+            while (isActive) {
+                delay(FOREGROUND_POLL_INTERVAL_MS)
+                pollNotifications()
+            }
+        }
+    }
+
+    fun stopForegroundPolling() {
+        foregroundPollJob?.cancel()
+        foregroundPollJob = null
+    }
+
+    private suspend fun pollNotifications() {
+        val loggedIn = sessionManager.isLoggedIn.first()
+        if (!loggedIn) return
+
+        repository.getNotifications(refresh = true)
+            .onSuccess { result ->
+                val notifications = result.notifications
+                if (notifications.isNotEmpty()) {
+                    val newestId = notifications.first().id
+                    val previousId = notificationStateManager.getLastPolledId()
+                    if (newestId != previousId) {
+                        notificationStateManager.updateLastPolledId(newestId)
+                    }
+                }
+            }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/AppViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/AppViewModel.kt
@@ -1,16 +1,69 @@
 package pub.hackers.android.ui
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import pub.hackers.android.data.local.NotificationStateManager
 import pub.hackers.android.data.local.PreferencesManager
 import pub.hackers.android.data.local.SessionManager
+import pub.hackers.android.data.worker.NotificationWorker
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @HiltViewModel
 class AppViewModel @Inject constructor(
-    sessionManager: SessionManager,
-    val preferencesManager: PreferencesManager
+    private val sessionManager: SessionManager,
+    val preferencesManager: PreferencesManager,
+    private val notificationStateManager: NotificationStateManager,
+    private val workManager: WorkManager
 ) : ViewModel() {
+
+    companion object {
+        const val NOTIFICATION_WORK_NAME = "notification_poll"
+    }
+
     val isLoggedIn: Flow<Boolean> = sessionManager.isLoggedIn
+
+    val hasUnread: StateFlow<Boolean> = notificationStateManager.hasUnread
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    init {
+        ensureNotificationPolling()
+    }
+
+    private fun ensureNotificationPolling() {
+        viewModelScope.launch {
+            val loggedIn = sessionManager.isLoggedIn.first()
+            if (loggedIn) {
+                enqueueNotificationPolling()
+            }
+        }
+    }
+
+    fun enqueueNotificationPolling() {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        val workRequest = PeriodicWorkRequestBuilder<NotificationWorker>(
+            15, TimeUnit.MINUTES
+        ).setConstraints(constraints).build()
+
+        workManager.enqueueUniquePeriodicWork(
+            NOTIFICATION_WORK_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            workRequest
+        )
+    }
 }

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -14,9 +14,13 @@ import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
@@ -142,6 +146,26 @@ fun HackersPubApp(
     LaunchedEffect(isLoggedIn) {
         if (isLoggedIn) {
             viewModel.enqueueNotificationPolling()
+            viewModel.startForegroundPolling()
+        } else {
+            viewModel.stopForegroundPolling()
+        }
+    }
+
+    // Start/stop foreground polling based on app lifecycle
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, isLoggedIn) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (!isLoggedIn) return@LifecycleEventObserver
+            when (event) {
+                Lifecycle.Event.ON_START -> viewModel.startForegroundPolling()
+                Lifecycle.Event.ON_STOP -> viewModel.stopForegroundPolling()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
 

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -119,11 +119,19 @@ fun HackersPubApp(
     val isLoggedIn by viewModel.isLoggedIn.collectAsState(initial = false)
 
     val fontSizePercent by viewModel.preferencesManager.fontSizePercent.collectAsState(initial = 100)
+    val hasUnread by viewModel.hasUnread.collectAsState()
 
     // Handle deep link for verification
     LaunchedEffect(deepLinkData) {
         deepLinkData?.let {
             navController.navigate("signin?token=${it.token}&code=${it.code}")
+        }
+    }
+
+    // Enqueue notification polling when user logs in
+    LaunchedEffect(isLoggedIn) {
+        if (isLoggedIn) {
+            viewModel.enqueueNotificationPolling()
         }
     }
 
@@ -149,7 +157,7 @@ fun HackersPubApp(
                 label = stringResource(R.string.nav_notifications),
                 icon = Icons.Outlined.Notifications,
                 selectedIcon = Icons.Filled.Notifications,
-                hasNotificationDot = false, // TODO: wire up unread notification state
+                hasNotificationDot = hasUnread,
             ),
             BottomNavItem(
                 route = Screen.Search.route,

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -113,6 +113,7 @@ sealed class DetailScreen(val route: String) {
 @Composable
 fun HackersPubApp(
     deepLinkData: pub.hackers.android.DeepLinkData? = null,
+    navigationIntent: pub.hackers.android.NavigationIntent? = null,
     viewModel: AppViewModel = hiltViewModel()
 ) {
     val navController = rememberNavController()
@@ -125,6 +126,15 @@ fun HackersPubApp(
     LaunchedEffect(deepLinkData) {
         deepLinkData?.let {
             navController.navigate("signin?token=${it.token}&code=${it.code}")
+        }
+    }
+
+    // Handle navigation intent from system notifications
+    LaunchedEffect(navigationIntent) {
+        navigationIntent?.let {
+            navController.navigate(it.route) {
+                launchSingleTop = true
+            }
         }
     }
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import pub.hackers.android.data.local.NotificationStateManager
 import pub.hackers.android.data.repository.HackersPubRepository
 import pub.hackers.android.domain.model.Notification
 import java.time.Instant
@@ -25,7 +26,8 @@ data class NotificationsUiState(
 
 @HiltViewModel
 class NotificationsViewModel @Inject constructor(
-    private val repository: HackersPubRepository
+    private val repository: HackersPubRepository,
+    private val notificationStateManager: NotificationStateManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(NotificationsUiState())
@@ -49,14 +51,15 @@ class NotificationsViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
 
-            repository.getNotifications()
-                .onSuccess { result ->
+            val result = repository.getNotifications()
+            result
+                .onSuccess { notificationsResult ->
                     lastLoadTime = Instant.now()
                     _uiState.update {
                         it.copy(
-                            notifications = result.notifications,
-                            hasNextPage = result.hasNextPage,
-                            endCursor = result.endCursor,
+                            notifications = notificationsResult.notifications,
+                            hasNextPage = notificationsResult.hasNextPage,
+                            endCursor = notificationsResult.endCursor,
                             isLoading = false
                         )
                     }
@@ -69,6 +72,9 @@ class NotificationsViewModel @Inject constructor(
                         )
                     }
                 }
+            if (result.isSuccess) {
+                notificationStateManager.markAsSeen()
+            }
         }
     }
 
@@ -76,14 +82,15 @@ class NotificationsViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(isRefreshing = true, error = null) }
 
-            repository.getNotifications(refresh = true)
-                .onSuccess { result ->
+            val result = repository.getNotifications(refresh = true)
+            result
+                .onSuccess { notificationsResult ->
                     lastLoadTime = Instant.now()
                     _uiState.update {
                         it.copy(
-                            notifications = result.notifications,
-                            hasNextPage = result.hasNextPage,
-                            endCursor = result.endCursor,
+                            notifications = notificationsResult.notifications,
+                            hasNextPage = notificationsResult.hasNextPage,
+                            endCursor = notificationsResult.endCursor,
                             isRefreshing = false
                         )
                     }
@@ -96,6 +103,9 @@ class NotificationsViewModel @Inject constructor(
                         )
                     }
                 }
+            if (result.isSuccess) {
+                notificationStateManager.markAsSeen()
+            }
         }
     }
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsViewModel.kt
@@ -1,7 +1,11 @@
 package pub.hackers.android.ui.screens.settings
 
+import android.app.NotificationManager
 import android.content.Context
 import androidx.lifecycle.ViewModel
+import androidx.work.WorkManager
+import pub.hackers.android.data.local.NotificationStateManager
+import pub.hackers.android.ui.AppViewModel
 import androidx.lifecycle.viewModelScope
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.cache.normalized.apolloStore
@@ -39,6 +43,8 @@ class SettingsViewModel @Inject constructor(
     private val preferencesManager: PreferencesManager,
     private val repository: HackersPubRepository,
     private val apolloClient: ApolloClient,
+    private val notificationStateManager: NotificationStateManager,
+    private val workManager: WorkManager,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
@@ -130,6 +136,10 @@ class SettingsViewModel @Inject constructor(
             if (sessionId != null) {
                 repository.revokeSession(sessionId)
             }
+            workManager.cancelUniqueWork(AppViewModel.NOTIFICATION_WORK_NAME)
+            notificationStateManager.clear()
+            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.cancelAll()
             sessionManager.clearSession()
             apolloClient.apolloStore.clearAll()
             _uiState.update { it.copy(isSignedOut = true) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,8 @@ ksp = "2.1.0-1.0.29"
 coroutines = "1.9.0"
 mlkitTranslate = "17.0.3"
 mlkitLanguageId = "17.0.6"
+work = "2.10.0"
+hiltWork = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -46,6 +48,10 @@ kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "ko
 
 mlkit-translate = { group = "com.google.mlkit", name = "translate", version.ref = "mlkitTranslate" }
 mlkit-language-id = { group = "com.google.mlkit", name = "language-id", version.ref = "mlkitLanguageId" }
+
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWork" }
+hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltWork" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
Implements background notification polling using WorkManager (15-min interval) and foreground polling via coroutines (1-min interval while app is visible). Users receive Android system notifications for new items and see an unread dot on the bottom nav tab.

Key changes:
- **NotificationStateManager**: Tracks unread state via DataStore (last-seen vs last-polled IDs)
- **NotificationWorker**: `@HiltWorker` that polls the Notifications GraphQL query, compares IDs, and posts grouped system notifications
- **Dual polling strategy**: WorkManager for background (15 min, Android minimum), coroutine timer for foreground (1 min, lifecycle-aware)
- **UI wiring**: Unread dot on bottom nav, mark-as-seen on notifications screen load/refresh
- **Lifecycle management**: Polling enqueued on login, cancelled on sign-out (with system notification dismissal)
- **Simplified Notifications query**: Replaced heavy `PostFields` fragment with just `id` + `content` (the only fields the notifications screen uses)
- **POST_NOTIFICATIONS permission**: Requested on Android 13+, gated on login state

Closes #67

## Test plan
- [ ] Verify unread notification dot appears on bottom nav when new notifications arrive
- [ ] Verify dot clears when opening the notifications screen
- [ ] Verify system notifications appear in background after ~15 minutes
- [ ] Verify tapping a system notification opens the app to notifications screen
- [ ] Verify sign-out cancels polling and dismisses system notifications
- [ ] Verify POST_NOTIFICATIONS permission dialog appears on Android 13+ after login
- [ ] Verify release APK builds without ProGuard issues