### PR TITLE
Fix settings screen to show actual app version

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
@@ -228,7 +228,7 @@ fun SettingsScreen(
                         color = colors.textPrimary
                     )
                     Text(
-                        text = "${stringResource(R.string.version)} 1.0.0",
+                        text = "${stringResource(R.string.version)} ${uiState.appVersion}",
                         style = typography.bodyMedium,
                         color = colors.textSecondary
                     )


### PR DESCRIPTION
## Summary
The settings screen had the version hardcoded as `1.0.0` instead of using `uiState.appVersion` which the ViewModel already populates from `PackageManager`. Now displays the actual version from `build.gradle.kts` (e.g. `1.1.0 (2)`).