### PR TITLE
Refine compose UX flow and post card display

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -1,5 +1,6 @@
 package pub.hackers.android.ui
 
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Explore
@@ -250,7 +251,9 @@ fun HackersPubApp(
         NavHost(
             navController = navController,
             startDestination = if (isLoggedIn) Screen.Timeline.route else Screen.Explore.route,
-            modifier = Modifier.padding(innerPadding)
+            modifier = Modifier
+                .padding(innerPadding)
+                .consumeWindowInsets(innerPadding)
         ) {
             composable(Screen.Timeline.route) {
                 TimelineScreen(

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -255,8 +255,12 @@ fun HackersPubApp(
                 .padding(innerPadding)
                 .consumeWindowInsets(innerPadding)
         ) {
-            composable(Screen.Timeline.route) {
+            composable(Screen.Timeline.route) { backStackEntry ->
+                val postedTimestamp by backStackEntry.savedStateHandle
+                    .getStateFlow<Long>("postedAt", 0L)
+                    .collectAsState()
                 TimelineScreen(
+                    postedAt = postedTimestamp,
                     onPostClick = { postId ->
                         navController.navigate(DetailScreen.PostDetail.createRoute(postId))
                     },
@@ -390,6 +394,9 @@ fun HackersPubApp(
                     replyToId = replyTo,
                     quotedPostId = quoteOf,
                     onPostSuccess = {
+                        navController.previousBackStackEntry
+                            ?.savedStateHandle
+                            ?.set("postedAt", System.currentTimeMillis())
                         navController.popBackStack()
                     },
                     onNavigateBack = {

--- a/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
@@ -72,10 +72,12 @@ fun ArticleCard(
                             modifier = Modifier.size(16.dp)
                         )
                         Spacer(modifier = Modifier.width(4.dp))
-                        Text(
-                            text = "${post.actor.name ?: post.actor.handle} ${stringResource(R.string.share)}d",
+                        RichDisplayName(
+                            name = post.actor.name?.let { "$it ${stringResource(R.string.share)}d" },
+                            fallback = "${post.actor.handle} ${stringResource(R.string.share)}d",
                             style = typography.caption,
-                            color = colors.textSecondary
+                            color = colors.textSecondary,
+                            emojiHeight = 14.dp
                         )
                     }
                 }
@@ -100,12 +102,11 @@ fun ArticleCard(
                         Row(
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            Text(
-                                text = displayPost.actor.name ?: displayPost.actor.handle,
+                            RichDisplayName(
+                                name = displayPost.actor.name,
+                                fallback = displayPost.actor.handle,
                                 style = typography.bodyLargeSemiBold,
                                 color = colors.textPrimary,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
                                 modifier = Modifier
                                     .weight(1f, fill = false)
                                     .clickable { onProfileClick(displayPost.actor.handle) }

--- a/app/src/main/java/pub/hackers/android/ui/components/MentionAutocomplete.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/MentionAutocomplete.kt
@@ -96,12 +96,11 @@ private fun MentionSuggestionItem(
         Spacer(modifier = Modifier.width(12.dp))
 
         Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = actor.name ?: actor.handle.substringBefore("@"),
+            RichDisplayName(
+                name = actor.name,
+                fallback = actor.handle.substringBefore("@"),
                 style = LocalAppTypography.current.bodyLargeSemiBold,
-                color = LocalAppColors.current.textPrimary,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                color = LocalAppColors.current.textPrimary
             )
             Text(
                 text = "@${actor.handle}",

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -33,6 +33,9 @@ import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.FormatQuote
 import androidx.compose.material.icons.outlined.Repeat
 import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.outlined.Group
+import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -69,6 +72,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import pub.hackers.android.R
 import pub.hackers.android.domain.model.Post
+import pub.hackers.android.domain.model.PostVisibility
 import pub.hackers.android.ui.theme.AppShapes
 import pub.hackers.android.ui.theme.LocalAppColors
 import pub.hackers.android.ui.theme.LocalAppTypography
@@ -191,7 +195,7 @@ private fun NoteCard(
             Spacer(modifier = Modifier.width(12.dp))
 
             Column(modifier = Modifier.weight(1f)) {
-                // Step 2: Author row — name + timestamp only (handle removed)
+                // Author row — name left, visibility icon + timestamp right
                 Row(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -202,12 +206,25 @@ private fun NoteCard(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
-                            .weight(1f, fill = false)
+                            .weight(1f)
                             .clickable { onProfileClick(displayPost.actor.handle) }
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Icon(
+                        imageVector = when (displayPost.visibility) {
+                            PostVisibility.PUBLIC -> Icons.Filled.Public
+                            PostVisibility.UNLISTED -> Icons.Outlined.Lock
+                            PostVisibility.FOLLOWERS -> Icons.Outlined.Group
+                            PostVisibility.DIRECT -> Icons.Outlined.Lock
+                            else -> Icons.Filled.Public
+                        },
+                        contentDescription = null,
+                        tint = colors.textSecondary,
+                        modifier = Modifier.size(14.dp)
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = "\u00B7 ${formatRelativeTime(displayPost.published)}",
+                        text = formatRelativeTime(displayPost.published),
                         style = typography.labelMedium,
                         color = colors.textSecondary
                     )

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -170,10 +170,12 @@ private fun NoteCard(
                     contentScale = ContentScale.Crop
                 )
                 Spacer(modifier = Modifier.width(4.dp))
-                Text(
-                    text = "${post.actor.name ?: post.actor.handle} ${stringResource(R.string.share)}d",
+                RichDisplayName(
+                    name = post.actor.name?.let { "$it ${stringResource(R.string.share)}d" },
+                    fallback = "${post.actor.handle} ${stringResource(R.string.share)}d",
                     style = typography.caption,
-                    color = colors.textSecondary
+                    color = colors.textSecondary,
+                    emojiHeight = 14.dp
                 )
             }
         }
@@ -199,12 +201,11 @@ private fun NoteCard(
                 Row(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(
-                        text = displayPost.actor.name ?: displayPost.actor.handle,
+                    RichDisplayName(
+                        name = displayPost.actor.name,
+                        fallback = displayPost.actor.handle,
                         style = typography.bodyLargeSemiBold,
                         color = colors.textPrimary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
                             .weight(1f)
                             .clickable { onProfileClick(displayPost.actor.handle) }
@@ -587,12 +588,11 @@ fun QuotedPostPreview(
 
             Spacer(modifier = Modifier.width(8.dp))
 
-            Text(
-                text = post.actor.name ?: post.actor.handle,
+            RichDisplayName(
+                name = post.actor.name,
+                fallback = post.actor.handle,
                 style = typography.bodyLargeSemiBold,
                 color = colors.textPrimary,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
                     .weight(1f, fill = false)
                     .clickable { onProfileClick(post.actor.handle) }

--- a/app/src/main/java/pub/hackers/android/ui/components/RichDisplayName.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/RichDisplayName.kt
@@ -1,0 +1,160 @@
+package pub.hackers.android.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+
+/**
+ * A segment of a display name: either plain text or an inline image (custom emoji).
+ */
+private sealed class DisplayNameSegment {
+    data class TextSegment(val text: String) : DisplayNameSegment()
+    data class ImageSegment(val src: String, val alt: String) : DisplayNameSegment()
+}
+
+/**
+ * Parses a display name string that may contain <img> tags (custom emojis)
+ * into a list of text and image segments.
+ */
+private fun parseDisplayName(name: String): List<DisplayNameSegment> {
+    val segments = mutableListOf<DisplayNameSegment>()
+    val imgPattern = Regex("""<img\s+[^>]*src=["']([^"']+)["'][^>]*(?:alt=["']([^"']*)["'])?[^>]*/?\s*>|<img\s+[^>]*alt=["']([^"']*)["'][^>]*(?:src=["']([^"']+)["'])[^>]*/?\s*>""")
+    var lastIndex = 0
+
+    for (match in imgPattern.findAll(name)) {
+        // Add text before this img tag
+        if (match.range.first > lastIndex) {
+            val text = name.substring(lastIndex, match.range.first).trim()
+            if (text.isNotEmpty()) {
+                segments.add(DisplayNameSegment.TextSegment(text))
+            }
+        }
+
+        val src = match.groupValues[1].ifEmpty { match.groupValues[4] }
+        val alt = match.groupValues[2].ifEmpty { match.groupValues[3] }
+        if (src.isNotEmpty()) {
+            segments.add(DisplayNameSegment.ImageSegment(src, alt))
+        }
+
+        lastIndex = match.range.last + 1
+    }
+
+    // Add remaining text after last img tag
+    if (lastIndex < name.length) {
+        val text = name.substring(lastIndex).trim()
+        if (text.isNotEmpty()) {
+            segments.add(DisplayNameSegment.TextSegment(text))
+        }
+    }
+
+    return segments
+}
+
+/**
+ * Renders a display name that may contain inline <img> tags (custom emojis).
+ * Images are resized to match the text height. Text is truncated by character
+ * limit to handle overflow.
+ *
+ * @param name The raw display name string, possibly containing <img> tags
+ * @param fallback Fallback text if name is null
+ * @param style Text style for the name
+ * @param color Text color
+ * @param maxChars Maximum number of text characters before truncation (0 = no limit)
+ * @param emojiHeight Height to render inline emojis, should match text line height
+ */
+@Composable
+fun RichDisplayName(
+    name: String?,
+    fallback: String,
+    style: TextStyle,
+    color: androidx.compose.ui.graphics.Color,
+    modifier: Modifier = Modifier,
+    maxChars: Int = 0,
+    emojiHeight: Dp = 18.dp
+) {
+    val displayName = name ?: fallback
+
+    val segments = remember(displayName) { parseDisplayName(displayName) }
+
+    // If no images, render as simple text (fast path)
+    val hasImages = segments.any { it is DisplayNameSegment.ImageSegment }
+    if (!hasImages) {
+        val text = if (maxChars > 0 && displayName.length > maxChars) {
+            displayName.take(maxChars) + "\u2026"
+        } else {
+            displayName
+        }
+        Text(
+            text = text,
+            style = style,
+            color = color,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = modifier
+        )
+        return
+    }
+
+    // Render mixed text + image segments
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+    ) {
+        var charCount = 0
+        var truncated = false
+
+        for (segment in segments) {
+            if (truncated) break
+
+            when (segment) {
+                is DisplayNameSegment.TextSegment -> {
+                    val remaining = if (maxChars > 0) maxChars - charCount else Int.MAX_VALUE
+                    if (remaining <= 0) {
+                        truncated = true
+                        break
+                    }
+                    val text = if (maxChars > 0 && segment.text.length > remaining) {
+                        truncated = true
+                        segment.text.take(remaining) + "\u2026"
+                    } else {
+                        segment.text
+                    }
+                    charCount += segment.text.length
+                    Text(
+                        text = text,
+                        style = style,
+                        color = color,
+                        maxLines = 1,
+                        overflow = TextOverflow.Clip
+                    )
+                }
+                is DisplayNameSegment.ImageSegment -> {
+                    AsyncImage(
+                        model = segment.src,
+                        contentDescription = segment.alt,
+                        modifier = Modifier
+                            .height(emojiHeight)
+                            .padding(horizontal = 1.dp)
+                            .clip(RoundedCornerShape(2.dp)),
+                        contentScale = ContentScale.FillHeight
+                    )
+                    // Count emoji as 1 character for truncation purposes
+                    charCount += 1
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -479,12 +479,12 @@ private fun ReplyTargetPreview(
             Spacer(modifier = Modifier.width(8.dp))
 
             Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = post.actor.name ?: post.actor.handle,
+                pub.hackers.android.ui.components.RichDisplayName(
+                    name = post.actor.name,
+                    fallback = post.actor.handle,
                     style = typography.labelMedium,
                     color = colors.textSecondary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    emojiHeight = 14.dp
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 HtmlContent(

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -151,7 +151,7 @@ fun ComposeScreen(
                         Text(
                             text = stringResource(R.string.cancel),
                             style = typography.bodyLarge,
-                            color = colors.accent
+                            color = colors.composeAccent
                         )
                     }
                 },
@@ -161,9 +161,9 @@ fun ComposeScreen(
                         enabled = postEnabled,
                         shape = RoundedCornerShape(AppShapes.pillRadius),
                         colors = ButtonDefaults.buttonColors(
-                            containerColor = colors.accent,
+                            containerColor = colors.composeAccent,
                             contentColor = Color.White,
-                            disabledContainerColor = colors.accent,
+                            disabledContainerColor = colors.composeAccent,
                             disabledContentColor = Color.White,
                         ),
                         modifier = Modifier.alpha(if (postEnabled) 1f else 0.4f)
@@ -252,7 +252,7 @@ fun ComposeScreen(
                             textStyle = typography.bodyLarge.copy(
                                 color = colors.textBody
                             ),
-                            cursorBrush = SolidColor(colors.accent),
+                            cursorBrush = SolidColor(colors.composeAccent),
                             decorationBox = { innerTextField ->
                                 Box {
                                     if (textFieldValue.text.isEmpty()) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -340,7 +340,11 @@ fun ComposeScreen(
                     .padding(horizontal = 4.dp)
             ) {
                 TextButton(
-                    onClick = { showVisibilityMenu = true }
+                    onClick = { showVisibilityMenu = true },
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                        horizontal = 12.dp,
+                        vertical = 4.dp
+                    )
                 ) {
                     Icon(
                         imageVector = when (uiState.visibility) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -24,6 +25,7 @@ import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -182,8 +184,13 @@ fun ComposeScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .padding(16.dp)
+                .imePadding()
         ) {
+         Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(16.dp)
+         ) {
             // Reply target preview
             if (uiState.isLoadingReplyTarget) {
                 CircularProgressIndicator(
@@ -303,11 +310,16 @@ fun ComposeScreen(
                 }
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+         }
+            // Close inner content Column
 
+            // Visibility toolbar pinned above keyboard
+            HorizontalDivider(color = colors.divider)
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 4.dp)
             ) {
                 TextButton(
                     onClick = { showVisibilityMenu = true }

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -109,6 +110,23 @@ fun ComposeScreen(
     val keyboardController = LocalSoftwareKeyboardController.current
     val density = LocalDensity.current
     val popupHeight = with(density) { 200.dp.toPx() } // Estimated popup height
+    val coroutineScope = rememberCoroutineScope()
+
+    // Auto-scroll to keep cursor visible when text overflows
+    LaunchedEffect(cursorRect) {
+        if (cursorRect != Rect.Zero) {
+            val cursorBottom = cursorRect.bottom.toInt()
+            val cursorTop = cursorRect.top.toInt()
+            val viewportTop = scrollState.value
+            val viewportBottom = viewportTop + scrollState.viewportSize
+
+            if (cursorBottom > viewportBottom) {
+                scrollState.animateScrollTo(cursorBottom - scrollState.viewportSize)
+            } else if (cursorTop < viewportTop) {
+                scrollState.animateScrollTo(cursorTop)
+            }
+        }
+    }
 
     // Sync TextFieldValue with ViewModel state changes (e.g., when mention is selected)
     LaunchedEffect(uiState.content, uiState.cursorPosition) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -19,9 +19,12 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.outlined.Group
 import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -164,37 +167,28 @@ fun ComposeScreen(
     Scaffold(
         contentWindowInsets = WindowInsets(0),
         topBar = {
-            LargeTitleHeader(
-                title = if (replyToId != null) stringResource(R.string.reply) else stringResource(R.string.compose),
-                leadingContent = {
-                    TextButton(onClick = onNavigateBack) {
-                        Text(
-                            text = stringResource(R.string.cancel),
-                            style = typography.bodyLarge,
-                            color = colors.composeAccent
-                        )
-                    }
-                },
-                trailingContent = {
-                    Button(
-                        onClick = { viewModel.post() },
-                        enabled = postEnabled,
-                        shape = RoundedCornerShape(AppShapes.pillRadius),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = colors.composeAccent,
-                            contentColor = Color.White,
-                            disabledContainerColor = colors.composeAccent,
-                            disabledContentColor = Color.White,
-                        ),
-                        modifier = Modifier.alpha(if (postEnabled) 1f else 0.4f)
-                    ) {
-                        Text(
-                            text = stringResource(R.string.post),
-                            color = Color.White
-                        )
-                    }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 4.dp, vertical = 8.dp)
+            ) {
+                IconButton(
+                    onClick = onNavigateBack,
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(R.string.cancel),
+                        tint = colors.textPrimary
+                    )
                 }
-            )
+                Text(
+                    text = if (replyToId != null) stringResource(R.string.reply) else stringResource(R.string.compose),
+                    style = typography.titleLarge,
+                    color = colors.textPrimary,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { paddingValues ->
@@ -337,12 +331,14 @@ fun ComposeScreen(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 4.dp)
+                    .padding(horizontal = 4.dp, vertical = 4.dp)
             ) {
+                Spacer(modifier = Modifier.weight(1f))
+
                 TextButton(
                     onClick = { showVisibilityMenu = true },
                     contentPadding = androidx.compose.foundation.layout.PaddingValues(
-                        horizontal = 12.dp,
+                        horizontal = 8.dp,
                         vertical = 4.dp
                     )
                 ) {
@@ -353,18 +349,19 @@ fun ComposeScreen(
                             PostVisibility.FOLLOWERS -> Icons.Outlined.Group
                             else -> Icons.Filled.Public
                         },
-                        contentDescription = null,
-                        tint = colors.textSecondary
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = when (uiState.visibility) {
+                        contentDescription = when (uiState.visibility) {
                             PostVisibility.PUBLIC -> stringResource(R.string.visibility_public)
                             PostVisibility.UNLISTED -> stringResource(R.string.visibility_unlisted)
                             PostVisibility.FOLLOWERS -> stringResource(R.string.visibility_followers)
                             else -> stringResource(R.string.visibility_public)
                         },
-                        color = colors.textSecondary
+                        tint = colors.textSecondary
+                    )
+                    Icon(
+                        imageVector = Icons.Default.KeyboardArrowDown,
+                        contentDescription = null,
+                        tint = colors.textSecondary,
+                        modifier = Modifier.size(18.dp)
                     )
 
                     DropdownMenu(
@@ -429,6 +426,24 @@ fun ComposeScreen(
                             }
                         )
                     }
+                }
+
+                Button(
+                    onClick = { viewModel.post() },
+                    enabled = postEnabled,
+                    shape = RoundedCornerShape(AppShapes.pillRadius),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = colors.composeAccent,
+                        contentColor = Color.White,
+                        disabledContainerColor = colors.composeAccent,
+                        disabledContentColor = Color.White,
+                    ),
+                    modifier = Modifier.alpha(if (postEnabled) 1f else 0.4f)
+                ) {
+                    Text(
+                        text = stringResource(R.string.post),
+                        color = Color.White
+                    )
                 }
             }
         }

--- a/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsScreen.kt
@@ -237,12 +237,11 @@ private fun NotificationItem(
 
                 Column(modifier = Modifier.weight(1f)) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            text = actor?.name ?: actor?.handle ?: "Someone",
+                        pub.hackers.android.ui.components.RichDisplayName(
+                            name = actor?.name,
+                            fallback = actor?.handle ?: "Someone",
                             style = typography.bodyLargeSemiBold,
                             color = colors.textPrimary,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
                             modifier = Modifier.weight(1f, fill = false)
                         )
                         Spacer(modifier = Modifier.width(4.dp))

--- a/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsScreen.kt
@@ -264,7 +264,8 @@ private fun NotificationItem(
                 HtmlContent(
                     html = post.content,
                     maxLines = 3,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    onTextClick = { onPostClick(post.id) }
                 )
             }
         }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -279,7 +279,7 @@ fun PostDetailScreen(
             if (uiState.post != null && isLoggedIn) {
                 FloatingActionButton(
                     onClick = { onReplyClick(postId) },
-                    containerColor = colors.accent,
+                    containerColor = colors.composeAccent,
                     contentColor = Color.White
                 ) {
                     Icon(

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -489,8 +489,9 @@ private fun PostDetailContent(
                     Column(
                         modifier = Modifier.clickable { onProfileClick(post.actor.handle) }
                     ) {
-                        Text(
-                            text = post.actor.name ?: post.actor.handle,
+                        pub.hackers.android.ui.components.RichDisplayName(
+                            name = post.actor.name,
+                            fallback = post.actor.handle,
                             style = typography.bodyLargeSemiBold,
                             color = colors.textPrimary
                         )
@@ -891,10 +892,10 @@ private fun SharesSheet(
                     )
                     Spacer(modifier = Modifier.width(12.dp))
                     Column {
-                        Text(
-                            text = actor.name ?: actor.handle,
-                            style = typography.bodyMedium,
-                            fontWeight = FontWeight.SemiBold,
+                        pub.hackers.android.ui.components.RichDisplayName(
+                            name = actor.name,
+                            fallback = actor.handle,
+                            style = typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
                             color = colors.textPrimary
                         )
                         Text(
@@ -966,11 +967,12 @@ private fun QuotesSheet(
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Column {
-                            Text(
-                                text = post.actor.name ?: post.actor.handle,
-                                style = typography.labelMedium,
-                                fontWeight = FontWeight.SemiBold,
-                                color = colors.textPrimary
+                            pub.hackers.android.ui.components.RichDisplayName(
+                                name = post.actor.name,
+                                fallback = post.actor.handle,
+                                style = typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
+                                color = colors.textPrimary,
+                                emojiHeight = 14.dp
                             )
                             Text(
                                 text = "@${post.actor.handle}",
@@ -1026,11 +1028,11 @@ private fun ReplyTargetPreview(
             Spacer(modifier = Modifier.width(12.dp))
 
             Column {
-                Text(
-                    text = post.actor.name ?: post.actor.handle,
+                pub.hackers.android.ui.components.RichDisplayName(
+                    name = post.actor.name,
+                    fallback = post.actor.handle,
                     style = typography.bodyLargeSemiBold,
-                    color = colors.textPrimary,
-                    maxLines = 1
+                    color = colors.textPrimary
                 )
                 Text(
                     text = "@${post.actor.handle}",

--- a/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
@@ -349,11 +349,12 @@ private fun ProfileHeader(
 
         Spacer(modifier = Modifier.height(12.dp))
 
-        Text(
-            text = name ?: handle,
+        pub.hackers.android.ui.components.RichDisplayName(
+            name = name,
+            fallback = handle,
             style = typography.titleMedium,
             color = colors.textPrimary,
-            textAlign = TextAlign.Center
+            emojiHeight = 22.dp
         )
 
         Spacer(modifier = Modifier.height(2.dp))

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -107,7 +107,7 @@ fun TimelineScreen(
         floatingActionButton = {
             FloatingActionButton(
                 onClick = { onComposeClick(null) },
-                containerColor = colors.accent,
+                containerColor = colors.composeAccent,
                 contentColor = androidx.compose.ui.graphics.Color.White
             ) {
                 Icon(

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import kotlinx.coroutines.flow.dropWhile
+import kotlinx.coroutines.flow.first
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -51,6 +53,7 @@ fun TimelineScreen(
     onComposeClick: (String?) -> Unit,
     onQuoteClick: (String) -> Unit = {},
     onSettingsClick: () -> Unit,
+    postedAt: Long = 0L,
     userAvatarUrl: String? = null,
     viewModel: TimelineViewModel = hiltViewModel()
 ) {
@@ -58,6 +61,17 @@ fun TimelineScreen(
     val listState = rememberLazyListState()
     val context = LocalContext.current
     val colors = LocalAppColors.current
+
+    LaunchedEffect(postedAt) {
+        if (postedAt > 0L) {
+            viewModel.refresh()
+            // Wait for refresh to start then complete
+            viewModel.uiState
+                .dropWhile { !it.isRefreshing }
+                .first { !it.isRefreshing }
+            listState.scrollToItem(0)
+        }
+    }
 
     val shouldLoadMore by remember {
         derivedStateOf {

--- a/app/src/main/java/pub/hackers/android/ui/theme/Colors.kt
+++ b/app/src/main/java/pub/hackers/android/ui/theme/Colors.kt
@@ -15,6 +15,7 @@ data class AppColorScheme(
     val accentMuted: Color,
     val divider: Color,
     val buttonOutline: Color,
+    val composeAccent: Color,
     val reaction: Color,
     val share: Color,
 )
@@ -29,6 +30,7 @@ val LightAppColors = AppColorScheme(
     accentMuted = Color(0xFF78716C),
     divider = Color(0xFFF2F2F7),
     buttonOutline = Color(0xFFD6D3D1),
+    composeAccent = Color(0xFFEF4444),
     reaction = Color(0xFFE8453C),
     share = Color(0xFF34D399),
 )
@@ -43,6 +45,7 @@ val DarkAppColors = AppColorScheme(
     accentMuted = Color(0xFFA8A29E),
     divider = Color(0xFF262626),
     buttonOutline = Color(0xFF525252),
+    composeAccent = Color(0xFFF87171),
     reaction = Color(0xFFE8453C),
     share = Color(0xFF34D399),
 )


### PR DESCRIPTION
## Summary
- Add a dedicated coral accent color (`composeAccent`) for compose FABs and compose screen elements, making them visually distinct from the general accent
- Redesign the compose screen: X close button with centered title, visibility selector (icon + chevron) and Post button pinned above keyboard in a bottom toolbar
- Auto-scroll the compose text field to follow the cursor on overflow, and fix double bottom padding from edge-to-edge insets
- Add `RichDisplayName` composable to parse and render inline `<img>` tags (custom emojis) in display names across all screens
- Show post visibility icon and right-aligned timestamp on post cards
- Refresh timeline and scroll to top after posting via `savedStateHandle` signal
- Enable navigation to PostDetailScreen when tapping notification card body

## Test plan
- [x] Verify coral-colored compose FAB on timeline and post detail screens (light + dark theme)
- [x] Open compose screen: X button closes, title is centered, visibility + Post button are in bottom toolbar above keyboard
- [x] Type long text in compose and verify auto-scroll follows cursor
- [x] Post a note and verify timeline refreshes and scrolls to top
- [x] Check post cards show visibility icon (globe/lock/group) and right-aligned timestamp
- [x] Verify display names with custom emojis (`<img>` tags) render inline images on post cards, profile, notifications, and post detail
- [x] Tap notification card body to navigate to post detail