### PR TITLE
Refine post card display and add link preview

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -37,6 +37,22 @@ fragment PostFields on Post {
     media {
         ...MediaFields
     }
+    link {
+        title
+        description
+        url
+        siteName
+        author
+        image {
+            url
+            alt
+            width
+            height
+        }
+        creator {
+            ...ActorFields
+        }
+    }
     engagementStats {
         ...EngagementStatsFields
     }

--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -158,6 +158,10 @@ query PersonalTimeline($after: String) {
     personalTimeline(first: 20, after: $after) {
         edges {
             cursor
+            lastSharer {
+                ...ActorFields
+            }
+            sharersCount
             node {
                 ...PostFields
                 visibility

--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -144,6 +144,10 @@ query PersonalTimeline($after: String) {
             cursor
             node {
                 ...PostFields
+                visibility
+                replyTarget {
+                    ...PostFields
+                }
                 sharedPost {
                     ...SharedPostFields
                 }

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -111,7 +111,9 @@ class HackersPubRepository @Inject constructor(
                             edge.node.postFields.toPost(
                                 sharedPost = edge.node.sharedPost?.sharedPostFields?.toPost(),
                                 replyTarget = edge.node.replyTarget?.postFields?.toPost(),
-                                visibility = edge.node.visibility.toPostVisibility()
+                                visibility = edge.node.visibility.toPostVisibility(),
+                                lastSharer = edge.lastSharer?.actorFields?.toActor(),
+                                sharersCount = edge.sharersCount
                             )
                         } ?: emptyList(),
                         hasNextPage = data?.pageInfo?.hasNextPage ?: false,
@@ -753,7 +755,9 @@ class HackersPubRepository @Inject constructor(
     private fun PostFields.toPost(
         sharedPost: Post? = null,
         replyTarget: Post? = null,
-        visibility: PostVisibility = PostVisibility.PUBLIC
+        visibility: PostVisibility = PostVisibility.PUBLIC,
+        lastSharer: Actor? = null,
+        sharersCount: Int = 0
     ): Post {
         return Post(
             id = id,
@@ -788,6 +792,8 @@ class HackersPubRepository @Inject constructor(
             },
             engagementStats = engagementStats.engagementStatsFields.toEngagementStats(),
             mentions = mentions.edges.map { it.node.handle },
+            lastSharer = lastSharer,
+            sharersCount = sharersCount,
             sharedPost = sharedPost,
             replyTarget = replyTarget,
             quotedPost = quotedPost?.sharedPostFields?.toPost(),

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -768,6 +768,24 @@ class HackersPubRepository @Inject constructor(
             viewerHasShared = viewerHasShared,
             actor = actor.actorFields.toActor(),
             media = media.map { it.mediaFields.toMedia() },
+            link = link?.let { l ->
+                PostLink(
+                    title = l.title,
+                    description = l.description,
+                    url = l.url.toString(),
+                    siteName = l.siteName,
+                    author = l.author,
+                    image = l.image?.let { img ->
+                        PostLinkImage(
+                            url = img.url.toString(),
+                            alt = img.alt,
+                            width = img.width,
+                            height = img.height
+                        )
+                    },
+                    creator = l.creator?.actorFields?.toActor()
+                )
+            },
             engagementStats = engagementStats.engagementStatsFields.toEngagementStats(),
             mentions = mentions.edges.map { it.node.handle },
             sharedPost = sharedPost,

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -108,7 +108,11 @@ class HackersPubRepository @Inject constructor(
                 Result.success(
                     TimelineResult(
                         posts = data?.edges?.mapNotNull { edge ->
-                            edge.node.postFields.toPost(edge.node.sharedPost?.sharedPostFields?.toPost())
+                            edge.node.postFields.toPost(
+                                sharedPost = edge.node.sharedPost?.sharedPostFields?.toPost(),
+                                replyTarget = edge.node.replyTarget?.postFields?.toPost(),
+                                visibility = edge.node.visibility.toPostVisibility()
+                            )
                         } ?: emptyList(),
                         hasNextPage = data?.pageInfo?.hasNextPage ?: false,
                         endCursor = data?.pageInfo?.endCursor

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -24,6 +24,23 @@ data class EngagementStats(
     val quotes: Int
 )
 
+data class PostLinkImage(
+    val url: String,
+    val alt: String?,
+    val width: Int?,
+    val height: Int?
+)
+
+data class PostLink(
+    val title: String?,
+    val description: String?,
+    val url: String,
+    val siteName: String?,
+    val author: String?,
+    val image: PostLinkImage?,
+    val creator: Actor?
+)
+
 data class Post(
     val id: String,
     val typename: String,
@@ -37,6 +54,7 @@ data class Post(
     val viewerHasShared: Boolean,
     val actor: Actor,
     val media: List<Media>,
+    val link: PostLink? = null,
     val engagementStats: EngagementStats,
     val mentions: List<String>,
     val sharedPost: Post? = null,

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -57,6 +57,8 @@ data class Post(
     val link: PostLink? = null,
     val engagementStats: EngagementStats,
     val mentions: List<String>,
+    val lastSharer: Actor? = null,
+    val sharersCount: Int = 0,
     val sharedPost: Post? = null,
     val replyTarget: Post? = null,
     val quotedPost: Post? = null,

--- a/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
@@ -120,7 +120,7 @@ fun ArticleCard(
                         }
 
                         Text(
-                            text = "@${displayPost.actor.handle}",
+                            text = displayPost.actor.handle,
                             style = typography.labelMedium,
                             color = colors.textSecondary,
                             maxLines = 1,

--- a/app/src/main/java/pub/hackers/android/ui/components/LinkPreviewCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/LinkPreviewCard.kt
@@ -1,0 +1,202 @@
+package pub.hackers.android.ui.components
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import pub.hackers.android.domain.model.PostLink
+import pub.hackers.android.ui.theme.AppShapes
+import pub.hackers.android.ui.theme.LocalAppColors
+import pub.hackers.android.ui.theme.LocalAppTypography
+import java.net.URI
+
+@Composable
+fun LinkPreviewCard(
+    link: PostLink,
+    modifier: Modifier = Modifier,
+    onProfileClick: ((String) -> Unit)? = null
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+    val context = LocalContext.current
+    val domain = try {
+        URI(link.url).host?.removePrefix("www.") ?: link.url
+    } catch (_: Exception) {
+        link.url
+    }
+
+    val isWideImage = link.image?.let { img ->
+        val w = img.width ?: 0
+        val h = img.height ?: 1
+        w > 0 && h > 0 && w.toFloat() / h > 1.5f
+    } ?: false
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(AppShapes.mediaRadius))
+            .clickable {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(link.url))
+                context.startActivity(intent)
+            }
+            .then(
+                Modifier
+                    .clip(RoundedCornerShape(AppShapes.mediaRadius))
+            )
+    ) {
+        if (link.image != null && isWideImage) {
+            // Wide image: full width on top
+            AsyncImage(
+                model = link.image.url,
+                contentDescription = link.image.alt,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(160.dp)
+                    .clip(RoundedCornerShape(topStart = AppShapes.mediaRadius, topEnd = AppShapes.mediaRadius)),
+                contentScale = ContentScale.Crop
+            )
+        }
+
+        if (link.image != null && !isWideImage) {
+            // Compact: image left, content right
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp)
+            ) {
+                AsyncImage(
+                    model = link.image.url,
+                    contentDescription = link.image.alt,
+                    modifier = Modifier
+                        .size(80.dp)
+                        .clip(RoundedCornerShape(6.dp)),
+                    contentScale = ContentScale.Crop
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                LinkTextContent(
+                    link = link,
+                    domain = domain,
+                    typography = typography,
+                    colors = colors,
+                    onProfileClick = onProfileClick
+                )
+            }
+        } else {
+            // No image or wide image: text below
+            Column(
+                modifier = Modifier.padding(8.dp)
+            ) {
+                LinkTextContent(
+                    link = link,
+                    domain = domain,
+                    typography = typography,
+                    colors = colors,
+                    onProfileClick = onProfileClick
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LinkTextContent(
+    link: PostLink,
+    domain: String,
+    typography: pub.hackers.android.ui.theme.AppTextStyles,
+    colors: pub.hackers.android.ui.theme.AppColorScheme,
+    onProfileClick: ((String) -> Unit)?
+) {
+    Column {
+        if (!link.title.isNullOrBlank()) {
+            Text(
+                text = link.title,
+                style = typography.bodyLargeSemiBold,
+                color = colors.textPrimary,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        if (!link.description.isNullOrBlank()) {
+            Spacer(modifier = Modifier.height(2.dp))
+            val descriptionText = if (!link.author.isNullOrBlank() && !link.author.startsWith("http")) {
+                "${link.author} — ${link.description}"
+            } else {
+                link.description
+            }
+            Text(
+                text = descriptionText,
+                style = typography.labelMedium,
+                color = colors.textSecondary,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = domain,
+                style = typography.labelMedium,
+                color = colors.textSecondary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, fill = false)
+            )
+            if (!link.siteName.isNullOrBlank()) {
+                Text(
+                    text = " · ${link.siteName}",
+                    style = typography.labelMedium,
+                    color = colors.textSecondary,
+                    maxLines = 1
+                )
+            }
+        }
+
+        if (link.creator != null && onProfileClick != null) {
+            Spacer(modifier = Modifier.height(6.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.clickable { onProfileClick(link.creator.handle) }
+            ) {
+                AsyncImage(
+                    model = link.creator.avatarUrl,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape),
+                    contentScale = ContentScale.Crop
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                RichDisplayName(
+                    name = link.creator.name,
+                    fallback = link.creator.handle,
+                    style = typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = colors.textSecondary,
+                    emojiHeight = 14.dp
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/components/LinkPreviewCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/LinkPreviewCard.kt
@@ -2,6 +2,7 @@ package pub.hackers.android.ui.components
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -54,15 +55,16 @@ fun LinkPreviewCard(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .border(
+                width = 1.dp,
+                color = colors.divider,
+                shape = RoundedCornerShape(AppShapes.mediaRadius)
+            )
             .clip(RoundedCornerShape(AppShapes.mediaRadius))
             .clickable {
                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse(link.url))
                 context.startActivity(intent)
             }
-            .then(
-                Modifier
-                    .clip(RoundedCornerShape(AppShapes.mediaRadius))
-            )
     ) {
         if (link.image != null && isWideImage) {
             // Wide image: full width on top

--- a/app/src/main/java/pub/hackers/android/ui/components/MentionAutocomplete.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/MentionAutocomplete.kt
@@ -103,7 +103,7 @@ private fun MentionSuggestionItem(
                 color = LocalAppColors.current.textPrimary
             )
             Text(
-                text = "@${actor.handle}",
+                text = actor.handle,
                 style = LocalAppTypography.current.labelMedium,
                 color = LocalAppColors.current.textSecondary,
                 maxLines = 1,

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -177,6 +178,42 @@ private fun NoteCard(
                     color = colors.textSecondary,
                     emojiHeight = 14.dp
                 )
+            }
+        }
+
+        // Reply target preview (faded)
+        if (displayPost.replyTarget != null) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .alpha(0.5f)
+                    .padding(bottom = 8.dp),
+                verticalAlignment = Alignment.Top
+            ) {
+                AsyncImage(
+                    model = displayPost.replyTarget!!.actor.avatarUrl,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(AppShapes.avatarRepost)
+                        .clip(CircleShape)
+                        .clickable { onProfileClick(displayPost.replyTarget!!.actor.handle) },
+                    contentScale = ContentScale.Crop
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    RichDisplayName(
+                        name = displayPost.replyTarget!!.actor.name,
+                        fallback = displayPost.replyTarget!!.actor.handle,
+                        style = typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
+                        color = colors.textPrimary
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    HtmlContent(
+                        html = displayPost.replyTarget!!.content,
+                        maxLines = 2,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -136,7 +136,7 @@ private fun NoteCard(
     modifier: Modifier = Modifier
 ) {
     val displayPost = post.sharedPost ?: post
-    val isRepost = post.sharedPost != null
+    val isRepost = post.lastSharer != null
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
     val context = LocalContext.current
@@ -155,15 +155,17 @@ private fun NoteCard(
             .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 12.dp)
     ) {
-        // Step 7: Repost indicator
-        if (isRepost) {
+        // Repost indicator
+        if (isRepost && post.lastSharer != null) {
+            val sharer = post.lastSharer!!
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
                     .padding(start = 54.dp, bottom = 8.dp)
+                    .clickable { onProfileClick(sharer.handle) }
             ) {
                 AsyncImage(
-                    model = post.actor.avatarUrl,
+                    model = sharer.avatarUrl,
                     contentDescription = null,
                     modifier = Modifier
                         .size(AppShapes.avatarRepost)
@@ -171,12 +173,29 @@ private fun NoteCard(
                     contentScale = ContentScale.Crop
                 )
                 Spacer(modifier = Modifier.width(4.dp))
-                RichDisplayName(
-                    name = post.actor.name?.let { "$it ${stringResource(R.string.share)}d" },
-                    fallback = "${post.actor.handle} ${stringResource(R.string.share)}d",
+                if (sharer.name != null) {
+                    RichDisplayName(
+                        name = sharer.name,
+                        fallback = sharer.handle,
+                        style = typography.caption.copy(fontWeight = FontWeight.SemiBold),
+                        color = colors.textSecondary,
+                        emojiHeight = 14.dp
+                    )
+                    Spacer(modifier = Modifier.width(2.dp))
+                }
+                Text(
+                    text = sharer.handle,
                     style = typography.caption,
                     color = colors.textSecondary,
-                    emojiHeight = 14.dp
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false)
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = stringResource(R.string.share) + "d",
+                    style = typography.caption,
+                    color = colors.textSecondary
                 )
             }
         }

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -367,6 +367,15 @@ private fun NoteCard(
                     MediaGrid(media = displayPost.media)
                 }
 
+                // Link preview (only when no media and no quoted post)
+                if (displayPost.media.isEmpty() && displayPost.quotedPost == null && displayPost.link != null) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    LinkPreviewCard(
+                        link = displayPost.link!!,
+                        onProfileClick = onProfileClick
+                    )
+                }
+
                 // Quoted post
                 if (displayPost.quotedPost != null) {
                     Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -154,51 +155,6 @@ private fun NoteCard(
             .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 12.dp)
     ) {
-        // Repost indicator
-        if (isRepost && post.lastSharer != null) {
-            val sharer = post.lastSharer!!
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .padding(start = 54.dp, bottom = 8.dp)
-                    .clickable { onProfileClick(sharer.handle) }
-            ) {
-                AsyncImage(
-                    model = sharer.avatarUrl,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(AppShapes.avatarRepost)
-                        .clip(CircleShape),
-                    contentScale = ContentScale.Crop
-                )
-                Spacer(modifier = Modifier.width(4.dp))
-                if (sharer.name != null) {
-                    RichDisplayName(
-                        name = sharer.name,
-                        fallback = sharer.handle,
-                        style = typography.caption.copy(fontWeight = FontWeight.SemiBold),
-                        color = colors.textSecondary,
-                        emojiHeight = 14.dp
-                    )
-                    Spacer(modifier = Modifier.width(2.dp))
-                }
-                Text(
-                    text = sharer.handle,
-                    style = typography.caption,
-                    color = colors.textSecondary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f, fill = false)
-                )
-                Spacer(modifier = Modifier.width(4.dp))
-                Text(
-                    text = stringResource(R.string.share) + "d",
-                    style = typography.caption,
-                    color = colors.textSecondary
-                )
-            }
-        }
-
         // Reply target preview (faded)
         if (displayPost.replyTarget != null) {
             Row(
@@ -232,6 +188,49 @@ private fun NoteCard(
                         modifier = Modifier.fillMaxWidth()
                     )
                 }
+            }
+        }
+
+        // Repost indicator
+        if (isRepost && post.lastSharer != null) {
+            val sharer = post.lastSharer!!
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .padding(start = 54.dp, bottom = 8.dp)
+                    .clickable { onProfileClick(sharer.handle) }
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Repeat,
+                    contentDescription = null,
+                    tint = colors.share,
+                    modifier = Modifier.size(14.dp)
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                if (sharer.name != null) {
+                    RichDisplayName(
+                        name = sharer.name,
+                        fallback = sharer.handle,
+                        style = typography.caption.copy(fontStyle = FontStyle.Italic),
+                        color = colors.textSecondary,
+                        emojiHeight = 14.dp
+                    )
+                    Spacer(modifier = Modifier.width(2.dp))
+                }
+                Text(
+                    text = sharer.handle,
+                    style = typography.caption.copy(fontStyle = FontStyle.Italic),
+                    color = colors.textSecondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false)
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = stringResource(R.string.share) + "d",
+                    style = typography.caption.copy(fontStyle = FontStyle.Italic),
+                    color = colors.textSecondary
+                )
             }
         }
 

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -217,7 +217,7 @@ private fun NoteCard(
                         )
                         Spacer(modifier = Modifier.width(4.dp))
                         Text(
-                            text = "@${displayPost.actor.handle}",
+                            text = displayPost.actor.handle,
                             style = typography.labelMedium,
                             color = colors.textSecondary,
                             maxLines = 1,
@@ -616,7 +616,7 @@ fun QuotedPostPreview(
             Spacer(modifier = Modifier.width(4.dp))
 
             Text(
-                text = "@${post.actor.handle}",
+                text = post.actor.handle,
                 style = typography.labelMedium,
                 color = colors.textSecondary,
                 maxLines = 1,

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -36,7 +36,6 @@ import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.outlined.Group
 import androidx.compose.material.icons.outlined.Lock
-import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -371,6 +370,48 @@ private fun NoteCard(
                     )
                 }
 
+                // Inline translate link
+                if (!isTranslating && translationError == null) {
+                    Text(
+                        text = if (showTranslated) stringResource(R.string.show_original) else stringResource(R.string.translate),
+                        style = typography.labelMedium,
+                        color = colors.textSecondary,
+                        modifier = Modifier
+                            .padding(top = 4.dp)
+                            .clickable {
+                                if (showTranslated) {
+                                    showTranslated = false
+                                    return@clickable
+                                }
+
+                                translatedContent?.let {
+                                    showTranslated = true
+                                    return@clickable
+                                }
+
+                                val targetLanguageTag = androidx.core.os.ConfigurationCompat
+                                    .getLocales(context.resources.configuration)
+                                    .get(0)?.language ?: Locale.getDefault().language
+                                scope.launch {
+                                    isTranslating = true
+                                    translationError = null
+                                    try {
+                                        val translated = translateHtmlContent(
+                                            html = displayPost.content,
+                                            targetLanguageTag = targetLanguageTag
+                                        )
+                                        translatedContent = translated
+                                        showTranslated = true
+                                    } catch (_: Exception) {
+                                        translationError = translationFailedText
+                                    } finally {
+                                        isTranslating = false
+                                    }
+                                }
+                            }
+                    )
+                }
+
                 if (isTruncated || (contentMaxLength == 0 && displayPost.content.length > 500)) {
                     Text(
                         text = stringResource(R.string.read_more),
@@ -460,42 +501,7 @@ private fun NoteCard(
                     onShareClick = onShareClick,
                     onQuoteClick = onQuoteClick,
                     onReactionClick = onReactionClick,
-                    onExternalShareClick = onExternalShareClick,
-                    onTranslateClick = {
-                        if (isTranslating) return@EngagementBar
-
-                        if (showTranslated) {
-                            showTranslated = false
-                            return@EngagementBar
-                        }
-
-                        translatedContent?.let {
-                            showTranslated = true
-                            return@EngagementBar
-                        }
-
-                        val targetLanguageTag = androidx.core.os.ConfigurationCompat
-                            .getLocales(context.resources.configuration)
-                            .get(0)?.language ?: Locale.getDefault().language
-                        scope.launch {
-                            isTranslating = true
-                            translationError = null
-                            try {
-                                val translated = translateHtmlContent(
-                                    html = displayPost.content,
-                                    targetLanguageTag = targetLanguageTag
-                                )
-                                translatedContent = translated
-                                showTranslated = true
-                            } catch (_: Exception) {
-                                translationError = translationFailedText
-                            } finally {
-                                isTranslating = false
-                            }
-                        }
-                    },
-                    isTranslating = isTranslating,
-                    isTranslated = showTranslated
+                    onExternalShareClick = onExternalShareClick
                 )
             }
         }
@@ -510,10 +516,7 @@ private fun EngagementBar(
     onShareClick: (() -> Unit)?,
     onQuoteClick: (() -> Unit)? = null,
     onReactionClick: (() -> Unit)? = null,
-    onExternalShareClick: (() -> Unit)? = null,
-    onTranslateClick: (() -> Unit)? = null,
-    isTranslating: Boolean = false,
-    isTranslated: Boolean = false
+    onExternalShareClick: (() -> Unit)? = null
 ) {
     val colors = LocalAppColors.current
     val isReplied = post.engagementStats.replies > 0 && post.replyTarget != null
@@ -562,20 +565,6 @@ private fun EngagementBar(
             onClick = onQuoteClick,
             activeColor = colors.accent,
             isActive = false
-        )
-
-        // Translate
-        EngagementButton(
-            icon = Icons.Outlined.Translate,
-            count = 0,
-            contentDescription = if (isTranslated) {
-                stringResource(R.string.show_original)
-            } else {
-                stringResource(R.string.translate)
-            },
-            onClick = if (isTranslating) null else onTranslateClick,
-            activeColor = colors.accent,
-            isActive = isTranslated
         )
 
         // External share — always textSecondary

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -199,17 +199,32 @@ private fun NoteCard(
             Column(modifier = Modifier.weight(1f)) {
                 // Author row — name left, visibility icon + timestamp right
                 Row(
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
                 ) {
-                    RichDisplayName(
-                        name = displayPost.actor.name,
-                        fallback = displayPost.actor.handle,
-                        style = typography.bodyLargeSemiBold,
-                        color = colors.textPrimary,
-                        modifier = Modifier
-                            .weight(1f)
-                            .clickable { onProfileClick(displayPost.actor.handle) }
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        RichDisplayName(
+                            name = displayPost.actor.name,
+                            fallback = displayPost.actor.handle,
+                            style = typography.bodyLargeSemiBold,
+                            color = colors.textPrimary,
+                            modifier = Modifier
+                                .weight(1f, fill = false)
+                                .clickable { onProfileClick(displayPost.actor.handle) }
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = "@${displayPost.actor.handle}",
+                            style = typography.labelMedium,
+                            color = colors.textSecondary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(2f, fill = false)
+                        )
+                    }
                     Spacer(modifier = Modifier.width(8.dp))
                     Icon(
                         imageVector = when (displayPost.visibility) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -496,7 +496,7 @@ private fun PostDetailContent(
                             color = colors.textPrimary
                         )
                         Text(
-                            text = "@${post.actor.handle}",
+                            text = post.actor.handle,
                             style = typography.labelMedium,
                             color = colors.textSecondary
                         )
@@ -899,7 +899,7 @@ private fun SharesSheet(
                             color = colors.textPrimary
                         )
                         Text(
-                            text = "@${actor.handle}",
+                            text = actor.handle,
                             style = typography.labelMedium,
                             color = colors.textSecondary
                         )
@@ -975,7 +975,7 @@ private fun QuotesSheet(
                                 emojiHeight = 14.dp
                             )
                             Text(
-                                text = "@${post.actor.handle}",
+                                text = post.actor.handle,
                                 style = typography.labelSmall,
                                 color = colors.textSecondary
                             )
@@ -1035,7 +1035,7 @@ private fun ReplyTargetPreview(
                     color = colors.textPrimary
                 )
                 Text(
-                    text = "@${post.actor.handle}",
+                    text = post.actor.handle,
                     style = typography.labelMedium,
                     color = colors.textSecondary,
                     maxLines = 1

--- a/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
@@ -360,7 +360,7 @@ private fun ProfileHeader(
         Spacer(modifier = Modifier.height(2.dp))
 
         Text(
-            text = "@$handle",
+            text = handle,
             style = typography.bodyMedium,
             color = colors.textSecondary,
             textAlign = TextAlign.Center

--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
@@ -134,7 +134,7 @@ fun SettingsScreen(
                             color = colors.textPrimary
                         )
                         Text(
-                            text = "@${uiState.userHandle ?: ""}",
+                            text = uiState.userHandle ?: "",
                             style = typography.bodyMedium,
                             color = colors.textSecondary
                         )

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -161,7 +161,7 @@ fun TimelineScreen(
                         ) {
                             items(
                                 items = uiState.posts,
-                                key = { it.id }
+                                key = { "${it.id}_${it.sharedPost?.id.orEmpty()}" }
                             ) { post ->
                                 PostCard(
                                     post = post,


### PR DESCRIPTION
## Summary
- Add handle display next to author name in post cards with proper weight priority so handles truncate last
- Remove `@` prefix from handle display across all screens (PostCard, ArticleCard, PostDetailScreen, ProfileScreen, SettingsScreen, MentionAutocomplete)
- Show faded reply target preview above posts that are replies, with replyTarget and visibility fetched from the PersonalTimeline GraphQL query
- Add OpenGraph link preview card (title, description, image, site name, creator) for posts without media attachments, with bordered card layout
- Fix sharer display by using `lastSharer` and `sharersCount` from the timeline edge instead of `sharedPost` on the node
- Style repost indicator with green share icon and italic text, ordered after reply target
- Move translate button from engagement bar to an inline text link below post content using textSecondary color
- Fix duplicate LazyColumn key crash for shared posts

## Test plan
- [x] Verify handle appears next to display name without `@` prefix on all post cards
- [x] Check posts with replies show faded reply target preview above the post
- [x] Verify shared posts show green share icon with italic sharer name/handle
- [x] Confirm link preview cards appear for posts without media, with border and OG metadata
- [x] Tap translate link below post content and verify translation works
- [x] Verify no crashes when scrolling timeline with shared posts