### PR TITLE
Add debug app flavor for side-by-side install

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,7 +34,12 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix = ".dev"
+            resValue("string", "app_name", "Hackers\\' Pub Dev")
+        }
         release {
+            resValue("string", "app_name", "Hackers\\' Pub")
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Hackers\' Pub</string>
-
     <!-- Navigation -->
     <string name="nav_timeline">Timeline</string>
     <string name="nav_notifications">Notifications</string>


### PR DESCRIPTION
## Summary
Add `applicationIdSuffix` ".dev" to debug builds so debug and release versions can be installed as separate apps on the same device. Debug builds show "Hackers' Pub Dev" as the app name to distinguish them in the launcher.

## Test plan
- [x] Install debug build and verify app shows as "Hackers' Pub Dev"
- [x] Install release build alongside debug and verify both coexist
- [x] Verify app_name displays correctly in both build types