### PR TITLE
Fix media deduplication and add image borders

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -6,6 +6,7 @@ fragment ActorFields on Actor {
 }
 
 fragment MediaFields on PostMedium {
+    id
     url
     thumbnailUrl
     alt

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -788,6 +788,7 @@ private fun MediaImage(
     alt: String?,
     modifier: Modifier = Modifier
 ) {
+    val colors = LocalAppColors.current
     val context = LocalContext.current
     var showMenu by remember { mutableStateOf(false) }
 
@@ -795,7 +796,13 @@ private fun MediaImage(
         AsyncImage(
             model = url,
             contentDescription = alt,
-            modifier = modifier.combinedClickable(
+            modifier = modifier
+                .border(
+                    width = 1.dp,
+                    color = colors.divider,
+                    shape = RoundedCornerShape(AppShapes.mediaRadius)
+                )
+                .combinedClickable(
                 onClick = {
                     // Open image in browser/viewer
                     val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))


### PR DESCRIPTION
## Summary
Add `id` to the `MediaFields` GraphQL fragment so Apollo's normalized cache can distinguish multiple media items per post, fixing a bug where only one image was displayed. Add a divider-colored border to each image in the media grid for visual separation.

## Test plan
- [x] Clear app data or reinstall, then verify posts with multiple images show all attachments
- [x] Verify each image has a visible border in both light and dark themes