### PR TITLE
Add HTTPS deep link support for hackers.pub URLs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,33 @@
                     android:scheme="hackerspub"
                     android:host="verify" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="hackers.pub"
+                    android:pathPattern="/@.*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="hackers.pub"
+                    android:pathPrefix="/sign/in/" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="hackers.pub"
+                    android:pathPrefix="/tags/" />
+            </intent-filter>
         </activity>
         <provider
             android:name="androidx.startup.InitializationProvider"

--- a/app/src/main/java/pub/hackers/android/MainActivity.kt
+++ b/app/src/main/java/pub/hackers/android/MainActivity.kt
@@ -20,6 +20,9 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import pub.hackers.android.data.local.SessionManager
+import pub.hackers.android.navigation.HackersPubRoute
+import pub.hackers.android.navigation.HackersPubUrlRouter
+import pub.hackers.android.navigation.toNavRoute
 import pub.hackers.android.ui.HackersPubApp
 import pub.hackers.android.ui.theme.HackersPubTheme
 import pub.hackers.android.ui.theme.LocalAppColors
@@ -95,12 +98,27 @@ class MainActivity : ComponentActivity() {
 
     private fun handleDeepLink(intent: Intent?) {
         val data = intent?.data ?: return
+
+        // Handle legacy custom scheme
         if (data.scheme == "hackerspub" && data.host == "verify") {
             val token = data.getQueryParameter("token")
             val code = data.getQueryParameter("code")
             if (token != null && code != null) {
                 deepLinkData = DeepLinkData(token = token, code = code)
             }
+            return
+        }
+
+        // Handle HTTPS web links
+        val url = data.toString()
+        when (val route = HackersPubUrlRouter.resolve(url)) {
+            is HackersPubRoute.SignInVerification -> {
+                deepLinkData = DeepLinkData(token = route.token, code = route.code)
+            }
+            is HackersPubRoute.Profile, is HackersPubRoute.NoteDetail, is HackersPubRoute.TagSearch -> {
+                navigationIntent = NavigationIntent(route = route.toNavRoute())
+            }
+            null -> { /* Not a recognized URL, ignore */ }
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/navigation/HackersPubUrlRouter.kt
+++ b/app/src/main/java/pub/hackers/android/navigation/HackersPubUrlRouter.kt
@@ -1,0 +1,97 @@
+package pub.hackers.android.navigation
+
+import android.util.Base64
+import pub.hackers.android.ui.DetailScreen
+import pub.hackers.android.ui.Screen
+import java.net.URI
+
+sealed class HackersPubRoute {
+    data class Profile(val handle: String) : HackersPubRoute()
+    data class NoteDetail(val globalId: String) : HackersPubRoute()
+    data class SignInVerification(val token: String, val code: String) : HackersPubRoute()
+    data class TagSearch(val tag: String) : HackersPubRoute()
+}
+
+object HackersPubUrlRouter {
+
+    private const val HOST = "hackers.pub"
+    private val UUID_REGEX = Regex(
+        "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+        RegexOption.IGNORE_CASE
+    )
+
+    fun resolve(url: String): HackersPubRoute? {
+        val uri = try {
+            URI(url)
+        } catch (_: Exception) {
+            return null
+        }
+
+        if (uri.host != HOST) return null
+        if (uri.scheme != "https" && uri.scheme != "http") return null
+
+        val path = uri.path?.trimEnd('/') ?: return null
+        val segments = path.split('/').filter { it.isNotEmpty() }
+
+        return when {
+            // /tags/<tag>
+            segments.size == 2 && segments[0] == "tags" -> {
+                HackersPubRoute.TagSearch(segments[1])
+            }
+
+            // /sign/in/<token>?code=<code>
+            segments.size >= 3 && segments[0] == "sign" && segments[1] == "in" -> {
+                val token = segments[2]
+                val query = uri.query ?: return null
+                val code = parseQueryParam(query, "code") ?: return null
+                HackersPubRoute.SignInVerification(token, code)
+            }
+
+            // /@<handle>/<noteId> where noteId is a UUID
+            segments.size == 2 && segments[0].startsWith("@") && UUID_REGEX.matches(segments[1]) -> {
+                val handle = segments[0].removePrefix("@")
+                val noteId = segments[1]
+                val globalId = encodeRelayId("Note", noteId)
+                HackersPubRoute.NoteDetail(globalId)
+            }
+
+            // /@<handle>
+            segments.size == 1 && segments[0].startsWith("@") -> {
+                val username = segments[0].removePrefix("@")
+                val handle = if ("@" in username) username else "$username@$HOST"
+                HackersPubRoute.Profile(handle)
+            }
+
+            else -> null
+        }
+    }
+
+    fun isHackersPubUrl(url: String): Boolean {
+        return try {
+            URI(url).host == HOST
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun encodeRelayId(typeName: String, rawId: String): String {
+        val raw = "$typeName:$rawId"
+        return Base64.encodeToString(raw.toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
+    }
+
+    private fun parseQueryParam(query: String, key: String): String? {
+        return query.split('&')
+            .map { it.split('=', limit = 2) }
+            .firstOrNull { it[0] == key }
+            ?.getOrNull(1)
+    }
+}
+
+fun HackersPubRoute.toNavRoute(): String {
+    return when (this) {
+        is HackersPubRoute.Profile -> DetailScreen.Profile.createRoute(handle)
+        is HackersPubRoute.NoteDetail -> DetailScreen.PostDetail.createRoute(globalId)
+        is HackersPubRoute.SignInVerification -> DetailScreen.SignIn.createRoute(token, code)
+        is HackersPubRoute.TagSearch -> Screen.Search.createRoute(tag)
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -77,11 +77,19 @@ sealed class Screen(
         Icons.Outlined.Explore
     )
     data object Search : Screen(
-        "search",
+        "search?initialQuery={initialQuery}",
         R.string.nav_search,
         Icons.Filled.Search,
         Icons.Outlined.Search
-    )
+    ) {
+        val baseRoute = "search"
+        fun createRoute(initialQuery: String? = null): String {
+            return if (initialQuery != null) {
+                val encoded = android.net.Uri.encode(initialQuery)
+                "search?initialQuery=$encoded"
+            } else "search"
+        }
+    }
     data object Settings : Screen(
         "settings",
         R.string.nav_settings,
@@ -170,7 +178,12 @@ fun HackersPubApp(
         }
     }
 
-    ProvideInAppBrowserUriHandler(preferencesManager = viewModel.preferencesManager) {
+    ProvideInAppBrowserUriHandler(
+        preferencesManager = viewModel.preferencesManager,
+        onInternalNavigate = { route ->
+            navController.navigate(route) { launchSingleTop = true }
+        }
+    ) {
     CompositionLocalProvider(LocalFontScale provides (fontSizePercent / 100f)) {
 
     val bottomNavItems = if (isLoggedIn) {
@@ -195,7 +208,7 @@ fun HackersPubApp(
                 hasNotificationDot = hasUnread,
             ),
             BottomNavItem(
-                route = Screen.Search.route,
+                route = Screen.Search.baseRoute,
                 label = stringResource(R.string.nav_search),
                 icon = Icons.Outlined.Search,
                 selectedIcon = Icons.Filled.Search,
@@ -210,7 +223,7 @@ fun HackersPubApp(
                 selectedIcon = Icons.Filled.Explore,
             ),
             BottomNavItem(
-                route = Screen.Search.route,
+                route = Screen.Search.baseRoute,
                 label = stringResource(R.string.nav_search),
                 icon = Icons.Outlined.Search,
                 selectedIcon = Icons.Filled.Search,
@@ -227,14 +240,15 @@ fun HackersPubApp(
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
     val currentRoute = currentDestination?.route
-    val showBottomBar = bottomNavItems.any { it.route == currentRoute }
+    val currentBaseRoute = currentRoute?.substringBefore('?')
+    val showBottomBar = bottomNavItems.any { it.route == currentBaseRoute }
 
     Scaffold(
         bottomBar = {
             if (showBottomBar) {
                 BottomNavBar(
                     items = bottomNavItems,
-                    selectedRoute = currentRoute ?: "",
+                    selectedRoute = currentBaseRoute ?: "",
                     onItemSelected = { item ->
                         navController.navigate(item.route) {
                             popUpTo(navController.graph.findStartDestination().id) {
@@ -311,8 +325,19 @@ fun HackersPubApp(
                 )
             }
 
-            composable(Screen.Search.route) {
+            composable(
+                route = Screen.Search.route,
+                arguments = listOf(
+                    navArgument("initialQuery") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    }
+                )
+            ) { backStackEntry ->
+                val initialQuery = backStackEntry.arguments?.getString("initialQuery")
                 SearchScreen(
+                    initialQuery = initialQuery,
                     onPostClick = { postId ->
                         navController.navigate(DetailScreen.PostDetail.createRoute(postId))
                     },

--- a/app/src/main/java/pub/hackers/android/ui/components/InAppBrowserUriHandler.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/InAppBrowserUriHandler.kt
@@ -11,12 +11,20 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
 import pub.hackers.android.data.local.PreferencesManager
+import pub.hackers.android.navigation.HackersPubUrlRouter
+import pub.hackers.android.navigation.toNavRoute
 
 class InAppBrowserUriHandler(
     private val context: Context,
-    private val useInAppBrowser: Boolean
+    private val useInAppBrowser: Boolean,
+    private val onInternalNavigate: ((route: String) -> Unit)? = null
 ) : UriHandler {
     override fun openUri(uri: String) {
+        val route = HackersPubUrlRouter.resolve(uri)
+        if (route != null && onInternalNavigate != null) {
+            onInternalNavigate.invoke(route.toNavRoute())
+            return
+        }
         openUrl(context, uri, useInAppBrowser)
     }
 }
@@ -24,11 +32,12 @@ class InAppBrowserUriHandler(
 @Composable
 fun ProvideInAppBrowserUriHandler(
     preferencesManager: PreferencesManager,
+    onInternalNavigate: ((route: String) -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
     val useInAppBrowser by preferencesManager.useInAppBrowser.collectAsState(initial = true)
     val context = LocalContext.current
-    val uriHandler = InAppBrowserUriHandler(context, useInAppBrowser)
+    val uriHandler = InAppBrowserUriHandler(context, useInAppBrowser, onInternalNavigate)
 
     CompositionLocalProvider(LocalUriHandler provides uriHandler) {
         content()

--- a/app/src/main/java/pub/hackers/android/ui/components/LinkPreviewCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/LinkPreviewCard.kt
@@ -1,7 +1,5 @@
 package pub.hackers.android.ui.components
 
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -20,7 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -39,7 +37,7 @@ fun LinkPreviewCard(
 ) {
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
-    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
     val domain = try {
         URI(link.url).host?.removePrefix("www.") ?: link.url
     } catch (_: Exception) {
@@ -62,8 +60,7 @@ fun LinkPreviewCard(
             )
             .clip(RoundedCornerShape(AppShapes.mediaRadius))
             .clickable {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(link.url))
-                context.startActivity(intent)
+                uriHandler.openUri(link.url)
             }
     ) {
         if (link.image != null && isWideImage) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -49,6 +50,7 @@ fun SearchScreen(
     onProfileClick: (String) -> Unit,
     onReplyClick: (String) -> Unit = {},
     onQuoteClick: (String) -> Unit = {},
+    initialQuery: String? = null,
     viewModel: SearchViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -56,6 +58,13 @@ fun SearchScreen(
     val context = LocalContext.current
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
+
+    LaunchedEffect(initialQuery) {
+        if (initialQuery != null && !uiState.hasSearched) {
+            viewModel.updateQuery(initialQuery)
+            viewModel.search()
+        }
+    }
 
     Scaffold(
         contentWindowInsets = WindowInsets(0),


### PR DESCRIPTION
## Summary

Support opening `hackers.pub` web links directly in the Android app instead of the browser. Handles profile URLs (`/@username`), note detail URLs (`/@username/<noteId>`), sign-in verification URLs (`/sign/in/<token>?code=<code>`), and tag URLs (`/tags/<tag>` → search screen).

Also intercepts `hackers.pub` links clicked within the app (post content, link previews) for in-app navigation, and fixes `LinkPreviewCard` to route through the shared `UriHandler` instead of raw intents.