### PR TITLE
Add assetlinks.json and enable autoVerify for deep links

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
                     android:scheme="hackerspub"
                     android:host="verify" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -38,7 +38,7 @@
                     android:host="hackers.pub"
                     android:pathPattern="/@.*" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -47,7 +47,7 @@
                     android:host="hackers.pub"
                     android:pathPrefix="/sign/in/" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/docs/.well-known/assetlinks.json
+++ b/docs/.well-known/assetlinks.json
@@ -1,0 +1,15 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "pub.hackers.app",
+      "sha256_cert_fingerprints": [
+        "52:A0:14:21:02:CD:30:FD:8B:29:A3:ED:80:2B:0A:BE:AF:AB:37:29:79:39:84:1A:B7:9E:39:05:AF:64:D5:1A"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Add Digital Asset Links file (`docs/.well-known/assetlinks.json`) with `handle_all_urls` and `get_login_creds` relations for Android App Links and future passkey support
- Enable `android:autoVerify="true"` on all HTTPS intent filters so links to `hackers.pub` open directly in the app without a chooser dialog

> **Note**: The `assetlinks.json` file needs to be deployed server-side at `https://hackers.pub/.well-known/assetlinks.json` for auto-verify to work.