### PR TITLE
User feedback fixes from closed test phase 1

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -12,6 +12,7 @@ fragment MediaFields on PostMedium {
     alt
     height
     width
+    type
 }
 
 fragment EngagementStatsFields on PostEngagementStats {

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -858,7 +858,8 @@ class HackersPubRepository @Inject constructor(
             thumbnailUrl = thumbnailUrl,
             alt = alt,
             height = height,
-            width = width
+            width = width,
+            mediaType = type?.toString()
         )
     }
 

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -172,7 +172,7 @@ class HackersPubRepository @Inject constructor(
         return try {
             val response = apolloClient.query(
                 PostDetailQuery(id, Optional.presentIfNotNull(repliesAfter))
-            ).execute()
+            ).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
             if (response.hasErrors()) {
                 Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -14,8 +14,11 @@ data class Media(
     val thumbnailUrl: String?,
     val alt: String?,
     val height: Int?,
-    val width: Int?
-)
+    val width: Int?,
+    val mediaType: String? = null
+) {
+    val isVideo: Boolean get() = mediaType?.startsWith("video/") == true
+}
 
 data class EngagementStats(
     val replies: Int,

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -250,12 +250,19 @@ fun HackersPubApp(
                     items = bottomNavItems,
                     selectedRoute = currentBaseRoute ?: "",
                     onItemSelected = { item ->
-                        navController.navigate(item.route) {
-                            popUpTo(navController.graph.findStartDestination().id) {
-                                saveState = true
+                        if (item.route == (currentBaseRoute ?: "")) {
+                            // Re-tap on current tab: signal scroll-to-top / refresh
+                            navController.currentBackStackEntry
+                                ?.savedStateHandle
+                                ?.set("tabRetapped", System.currentTimeMillis())
+                        } else {
+                            navController.navigate(item.route) {
+                                popUpTo(navController.graph.findStartDestination().id) {
+                                    saveState = true
+                                }
+                                launchSingleTop = true
+                                restoreState = true
                             }
-                            launchSingleTop = true
-                            restoreState = true
                         }
                     },
                 )
@@ -273,8 +280,12 @@ fun HackersPubApp(
                 val postedTimestamp by backStackEntry.savedStateHandle
                     .getStateFlow<Long>("postedAt", 0L)
                     .collectAsState()
+                val tabRetapped by backStackEntry.savedStateHandle
+                    .getStateFlow<Long>("tabRetapped", 0L)
+                    .collectAsState()
                 TimelineScreen(
                     postedAt = postedTimestamp,
+                    tabRetapped = tabRetapped,
                     onPostClick = { postId ->
                         navController.navigate(DetailScreen.PostDetail.createRoute(postId))
                     },

--- a/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
@@ -225,6 +226,10 @@ private fun parseHtmlToAnnotatedString(
         val listStack = mutableListOf<ListContext>()
         var insideListItem = false
 
+        // Ruby state
+        var insideRt = false
+        var insideRp = false
+
         var hasContent = false
         var pos = 0
         val source = html.trim()
@@ -238,7 +243,7 @@ private fun parseHtmlToAnnotatedString(
                 val rawText = source.substring(pos, textEnd)
                 val decoded = decodeHtmlEntities(rawText)
 
-                if (!insideInvisibleSpan && decoded.isNotEmpty()) {
+                if (!insideInvisibleSpan && !insideRp && decoded.isNotEmpty()) {
                     if (preDepth > 0) {
                         // Preserve all whitespace in preformatted blocks
                         appendStyledText(this, decoded, currentLinkType, linkColor, mentionBg)
@@ -392,6 +397,21 @@ private fun parseHtmlToAnnotatedString(
                             }
                         }
 
+                        // Ruby annotations
+                        "ruby" -> {
+                            // No special action needed for opening <ruby>
+                        }
+                        "rt" -> {
+                            insideRt = true
+                            pushStyle(SpanStyle(
+                                fontSize = 0.6.em,
+                                baselineShift = BaselineShift.Superscript
+                            ))
+                        }
+                        "rp" -> {
+                            insideRp = true
+                        }
+
                         // Invisible spans
                         "span" -> {
                             val classes = attrs["class"] ?: ""
@@ -476,6 +496,19 @@ private fun parseHtmlToAnnotatedString(
                                 hasAnnotation = false
                             }
                             currentLinkType = null
+                        }
+
+                        "ruby" -> {
+                            // No special action needed for closing </ruby>
+                        }
+                        "rt" -> {
+                            if (insideRt) {
+                                pop()
+                                insideRt = false
+                            }
+                        }
+                        "rp" -> {
+                            insideRp = false
                         }
 
                         "span" -> {

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -824,64 +826,148 @@ fun QuotedPostPreview(
 // Step 6: MediaGrid with 8dp radius
 @Composable
 fun MediaGrid(media: List<pub.hackers.android.domain.model.Media>) {
+    val gridHeight = 200.dp
+    val gap = 4.dp
+
     when (media.size) {
+        0 -> {}
         1 -> {
             MediaImage(
                 url = media[0].url,
                 alt = media[0].alt,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(200.dp)
+                    .height(gridHeight)
                     .clip(RoundedCornerShape(AppShapes.mediaRadius))
             )
         }
         2 -> {
+            // a | b
             Row(
-                horizontalArrangement = Arrangement.spacedBy(4.dp)
+                horizontalArrangement = Arrangement.spacedBy(gap),
+                modifier = Modifier.fillMaxWidth()
             ) {
-                media.forEach { item ->
+                MediaImage(
+                    url = media[0].url,
+                    alt = media[0].alt,
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(gridHeight)
+                        .clip(RoundedCornerShape(AppShapes.mediaRadius))
+                )
+                MediaImage(
+                    url = media[1].url,
+                    alt = media[1].alt,
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(gridHeight)
+                        .clip(RoundedCornerShape(AppShapes.mediaRadius))
+                )
+            }
+        }
+        3 -> {
+            // a | (b / c)
+            val halfHeight = (gridHeight - gap) / 2
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(gap),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                MediaImage(
+                    url = media[0].url,
+                    alt = media[0].alt,
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(gridHeight)
+                        .clip(RoundedCornerShape(AppShapes.mediaRadius))
+                )
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(gap),
+                    modifier = Modifier.weight(1f)
+                ) {
                     MediaImage(
-                        url = item.url,
-                        alt = item.alt,
+                        url = media[1].url,
+                        alt = media[1].alt,
                         modifier = Modifier
-                            .weight(1f)
-                            .height(150.dp)
+                            .fillMaxWidth()
+                            .height(halfHeight)
+                            .clip(RoundedCornerShape(AppShapes.mediaRadius))
+                    )
+                    MediaImage(
+                        url = media[2].url,
+                        alt = media[2].alt,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(halfHeight)
                             .clip(RoundedCornerShape(AppShapes.mediaRadius))
                     )
                 }
             }
         }
         else -> {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(4.dp)
+            // (a / c) | (b / d+)
+            val remaining = media.size - 4
+            val halfHeight = (gridHeight - gap) / 2
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(gap),
+                modifier = Modifier.fillMaxWidth()
             ) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(gap),
+                    modifier = Modifier.weight(1f)
                 ) {
-                    media.take(2).forEach { item ->
-                        MediaImage(
-                            url = item.url,
-                            alt = item.alt,
-                            modifier = Modifier
-                                .weight(1f)
-                                .height(100.dp)
-                                .clip(RoundedCornerShape(AppShapes.mediaRadius))
-                        )
-                    }
+                    MediaImage(
+                        url = media[0].url,
+                        alt = media[0].alt,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(halfHeight)
+                            .clip(RoundedCornerShape(AppShapes.mediaRadius))
+                    )
+                    MediaImage(
+                        url = media[2].url,
+                        alt = media[2].alt,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(halfHeight)
+                            .clip(RoundedCornerShape(AppShapes.mediaRadius))
+                    )
                 }
-                if (media.size > 2) {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(gap),
+                    modifier = Modifier.weight(1f)
+                ) {
+                    MediaImage(
+                        url = media[1].url,
+                        alt = media[1].alt,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(halfHeight)
+                            .clip(RoundedCornerShape(AppShapes.mediaRadius))
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(halfHeight)
+                            .clip(RoundedCornerShape(AppShapes.mediaRadius))
                     ) {
-                        media.drop(2).take(2).forEach { item ->
-                            MediaImage(
-                                url = item.url,
-                                alt = item.alt,
+                        MediaImage(
+                            url = media[3].url,
+                            alt = media[3].alt,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                        if (remaining > 0) {
+                            Box(
+                                contentAlignment = Alignment.Center,
                                 modifier = Modifier
-                                    .weight(1f)
-                                    .height(100.dp)
-                                    .clip(RoundedCornerShape(AppShapes.mediaRadius))
-                            )
+                                    .fillMaxSize()
+                                    .background(Color.Black.copy(alpha = 0.5f))
+                            ) {
+                                Text(
+                                    text = "+$remaining",
+                                    color = Color.White,
+                                    style = LocalAppTypography.current.titleLarge
+                                )
+                            }
                         }
                     }
                 }
@@ -891,7 +977,7 @@ fun MediaGrid(media: List<pub.hackers.android.domain.model.Media>) {
 }
 
 @Composable
-private fun MediaImage(
+fun MediaImage(
     url: String,
     alt: String?,
     modifier: Modifier = Modifier
@@ -900,11 +986,12 @@ private fun MediaImage(
     val context = LocalContext.current
     var showMenu by remember { mutableStateOf(false) }
 
-    Box {
+    Box(modifier = modifier) {
         AsyncImage(
             model = url,
             contentDescription = alt,
-            modifier = modifier
+            modifier = Modifier
+                .fillMaxSize()
                 .border(
                     width = 1.dp,
                     color = colors.divider,

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -626,9 +626,15 @@ private fun ShareEngagementButton(
         Row(
             verticalAlignment = Alignment.CenterVertically
         ) {
-            IconButton(
-                onClick = { if (onShareClick != null) showMenu = true },
-                enabled = onShareClick != null
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .combinedClickable(
+                        onClick = { onShareClick?.invoke() },
+                        onLongClick = { if (onQuoteClick != null) showMenu = true }
+                    )
             ) {
                 Icon(
                     imageVector = if (isShared) Icons.Filled.Repeat else Icons.Outlined.Repeat,

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -11,6 +11,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,7 +21,11 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -28,6 +35,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
@@ -46,6 +54,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -983,8 +995,7 @@ fun MediaImage(
     modifier: Modifier = Modifier
 ) {
     val colors = LocalAppColors.current
-    val context = LocalContext.current
-    var showMenu by remember { mutableStateOf(false) }
+    var showPreview by remember { mutableStateOf(false) }
 
     Box(modifier = modifier) {
         AsyncImage(
@@ -997,41 +1008,110 @@ fun MediaImage(
                     color = colors.divider,
                     shape = RoundedCornerShape(AppShapes.mediaRadius)
                 )
-                .combinedClickable(
-                onClick = {
-                    // Open image in browser/viewer
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-                    context.startActivity(intent)
-                },
-                onLongClick = { showMenu = true }
-            ),
+                .clickable { showPreview = true },
             contentScale = ContentScale.Crop
         )
+    }
 
-        DropdownMenu(
-            expanded = showMenu,
-            onDismissRequest = { showMenu = false }
+    if (showPreview) {
+        MediaPreviewDialog(
+            url = url,
+            alt = alt,
+            onDismiss = { showPreview = false }
+        )
+    }
+}
+
+@Composable
+private fun MediaPreviewDialog(
+    url: String,
+    alt: String?,
+    onDismiss: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+
+    var scale by remember { mutableFloatStateOf(1f) }
+    var offsetX by remember { mutableFloatStateOf(0f) }
+    var offsetY by remember { mutableFloatStateOf(0f) }
+    val transformState = rememberTransformableState { zoomChange, panChange, _ ->
+        scale = (scale * zoomChange).coerceIn(1f, 5f)
+        if (scale > 1f) {
+            offsetX += panChange.x
+            offsetY += panChange.y
+        } else {
+            offsetX = 0f
+            offsetY = 0f
+        }
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false
+        )
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.9f))
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null
+                ) { if (scale <= 1f) onDismiss() }
         ) {
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.share)) },
-                onClick = {
-                    showMenu = false
-                    val sendIntent = Intent().apply {
-                        action = Intent.ACTION_SEND
-                        putExtra(Intent.EXTRA_TEXT, url)
-                        type = "text/plain"
-                    }
-                    context.startActivity(Intent.createChooser(sendIntent, null))
-                }
+            // Close button
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(16.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(R.string.cancel),
+                    tint = Color.White
+                )
+            }
+
+            // Zoomable image
+            AsyncImage(
+                model = url,
+                contentDescription = alt,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.Center)
+                    .padding(16.dp)
+                    .graphicsLayer(
+                        scaleX = scale,
+                        scaleY = scale,
+                        translationX = offsetX,
+                        translationY = offsetY
+                    )
+                    .transformable(state = transformState),
+                contentScale = ContentScale.Fit
             )
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.open_in_browser)) },
-                onClick = {
-                    showMenu = false
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-                    context.startActivity(intent)
+
+            // Alt text
+            if (!alt.isNullOrBlank()) {
+                Surface(
+                    shape = RoundedCornerShape(8.dp),
+                    color = Color.Black.copy(alpha = 0.7f),
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .windowInsetsPadding(WindowInsets.statusBars)
+                        .padding(start = 16.dp, end = 64.dp, top = 16.dp)
+                        .fillMaxWidth()
+                ) {
+                    Text(
+                        text = alt,
+                        style = typography.bodyMedium,
+                        color = Color.White,
+                        modifier = Modifier.padding(12.dp)
+                    )
                 }
-            )
+            }
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -541,14 +541,12 @@ private fun EngagementBar(
             isActive = isReplied
         )
 
-        // Share/Repost
-        EngagementButton(
-            icon = if (isShared) Icons.Filled.Repeat else Icons.Outlined.Repeat,
+        // Share/Repost — tap to show repost/quote menu
+        ShareEngagementButton(
+            isShared = isShared,
             count = post.engagementStats.shares,
-            contentDescription = stringResource(R.string.shares),
-            onClick = onShareClick,
-            activeColor = colors.share,
-            isActive = isShared
+            onShareClick = onShareClick,
+            onQuoteClick = onQuoteClick
         )
 
         // Heart/React — tap to toggle ❤️, long-press for emoji picker
@@ -557,16 +555,6 @@ private fun EngagementBar(
             count = post.engagementStats.reactions,
             onClick = onReactionClick,
             onLongClick = onReactionLongPress
-        )
-
-        // Quote
-        EngagementButton(
-            icon = Icons.Outlined.FormatQuote,
-            count = post.engagementStats.quotes,
-            contentDescription = stringResource(R.string.quotes),
-            onClick = onQuoteClick,
-            activeColor = colors.accent,
-            isActive = false
         )
 
         // External share — always textSecondary
@@ -618,6 +606,80 @@ private fun EngagementButton(
                 style = typography.labelMedium,
                 color = tint
             )
+        }
+    }
+}
+
+@Composable
+private fun ShareEngagementButton(
+    isShared: Boolean,
+    count: Int,
+    onShareClick: (() -> Unit)?,
+    onQuoteClick: (() -> Unit)? = null
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+    val tint = if (isShared) colors.share else colors.textSecondary
+    var showMenu by remember { mutableStateOf(false) }
+
+    Box {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(
+                onClick = { if (onShareClick != null) showMenu = true },
+                enabled = onShareClick != null
+            ) {
+                Icon(
+                    imageVector = if (isShared) Icons.Filled.Repeat else Icons.Outlined.Repeat,
+                    contentDescription = stringResource(R.string.shares),
+                    tint = tint,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+            if (count > 0) {
+                Text(
+                    text = formatCount(count),
+                    style = typography.labelMedium,
+                    color = tint
+                )
+            }
+        }
+
+        DropdownMenu(
+            expanded = showMenu,
+            onDismissRequest = { showMenu = false }
+        ) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.share)) },
+                onClick = {
+                    showMenu = false
+                    onShareClick?.invoke()
+                },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.Repeat,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            )
+            if (onQuoteClick != null) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.quotes)) },
+                    onClick = {
+                        showMenu = false
+                        onQuoteClick()
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Outlined.FormatQuote,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.fillMaxSize
@@ -550,7 +551,9 @@ private fun EngagementBar(
     val isReacted = post.reactionGroups.any { it.viewerHasReacted }
 
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .offset(x = (-14).dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         // Reply
@@ -581,10 +584,11 @@ private fun EngagementBar(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        // External share — always textSecondary
+        // External share — always textSecondary, offset back to align right edge
         if (onExternalShareClick != null) {
             IconButton(
-                onClick = onExternalShareClick
+                onClick = onExternalShareClick,
+                modifier = Modifier.offset(x = 14.dp)
             ) {
                 Icon(
                     imageVector = Icons.Outlined.Share,

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -90,6 +90,7 @@ fun PostCard(
     onShareClick: (() -> Unit)? = null,
     onQuoteClick: (() -> Unit)? = null,
     onReactionClick: (() -> Unit)? = null,
+    onReactionLongPress: (() -> Unit)? = null,
     onExternalShareClick: (() -> Unit)? = null,
     onQuotedPostClick: ((String) -> Unit)? = null,
     contentMaxLength: Int = 0,
@@ -113,6 +114,7 @@ fun PostCard(
             onShareClick = onShareClick,
             onQuoteClick = onQuoteClick,
             onReactionClick = onReactionClick,
+            onReactionLongPress = onReactionLongPress,
             onExternalShareClick = onExternalShareClick,
             onQuotedPostClick = onQuotedPostClick,
             contentMaxLength = contentMaxLength,
@@ -130,6 +132,7 @@ private fun NoteCard(
     onShareClick: (() -> Unit)? = null,
     onQuoteClick: (() -> Unit)? = null,
     onReactionClick: (() -> Unit)? = null,
+    onReactionLongPress: (() -> Unit)? = null,
     onExternalShareClick: (() -> Unit)? = null,
     onQuotedPostClick: ((String) -> Unit)? = null,
     contentMaxLength: Int = 0,
@@ -500,6 +503,7 @@ private fun NoteCard(
                     onShareClick = onShareClick,
                     onQuoteClick = onQuoteClick,
                     onReactionClick = onReactionClick,
+                    onReactionLongPress = onReactionLongPress,
                     onExternalShareClick = onExternalShareClick
                 )
             }
@@ -515,6 +519,7 @@ private fun EngagementBar(
     onShareClick: (() -> Unit)?,
     onQuoteClick: (() -> Unit)? = null,
     onReactionClick: (() -> Unit)? = null,
+    onReactionLongPress: (() -> Unit)? = null,
     onExternalShareClick: (() -> Unit)? = null
 ) {
     val colors = LocalAppColors.current
@@ -546,14 +551,12 @@ private fun EngagementBar(
             isActive = isShared
         )
 
-        // Heart/React
-        EngagementButton(
-            icon = if (isReacted) Icons.Filled.Favorite else Icons.Outlined.Favorite,
+        // Heart/React — tap to toggle ❤️, long-press for emoji picker
+        ReactionEngagementButton(
+            isReacted = isReacted,
             count = post.engagementStats.reactions,
-            contentDescription = stringResource(R.string.reactions),
             onClick = onReactionClick,
-            activeColor = colors.reaction,
-            isActive = isReacted
+            onLongClick = onReactionLongPress
         )
 
         // Quote
@@ -605,6 +608,47 @@ private fun EngagementButton(
             Icon(
                 imageVector = icon,
                 contentDescription = contentDescription,
+                tint = tint,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+        if (count > 0) {
+            Text(
+                text = formatCount(count),
+                style = typography.labelMedium,
+                color = tint
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReactionEngagementButton(
+    isReacted: Boolean,
+    count: Int,
+    onClick: (() -> Unit)?,
+    onLongClick: (() -> Unit)? = null
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+    val tint = if (isReacted) colors.reaction else colors.textSecondary
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(48.dp)
+                .clip(CircleShape)
+                .combinedClickable(
+                    onClick = { onClick?.invoke() },
+                    onLongClick = { onLongClick?.invoke() }
+                )
+        ) {
+            Icon(
+                imageVector = if (isReacted) Icons.Filled.Favorite else Icons.Outlined.Favorite,
+                contentDescription = stringResource(R.string.reactions),
                 tint = tint,
                 modifier = Modifier.size(20.dp)
             )

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Repeat
@@ -1005,10 +1006,12 @@ private fun MediaPreviewDialog(
 ) {
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
+    val context = LocalContext.current
 
     var scale by remember { mutableFloatStateOf(1f) }
     var offsetX by remember { mutableFloatStateOf(0f) }
     var offsetY by remember { mutableFloatStateOf(0f) }
+    var showMenu by remember { mutableStateOf(false) }
     val transformState = rememberTransformableState { zoomChange, panChange, _ ->
         scale = (scale * zoomChange).coerceIn(1f, 5f)
         if (scale > 1f) {
@@ -1051,22 +1054,78 @@ private fun MediaPreviewDialog(
             }
 
             // Zoomable image
-            AsyncImage(
-                model = url,
-                contentDescription = alt,
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .align(Alignment.Center)
                     .padding(16.dp)
-                    .graphicsLayer(
-                        scaleX = scale,
-                        scaleY = scale,
-                        translationX = offsetX,
-                        translationY = offsetY
+            ) {
+                AsyncImage(
+                    model = url,
+                    contentDescription = alt,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .graphicsLayer(
+                            scaleX = scale,
+                            scaleY = scale,
+                            translationX = offsetX,
+                            translationY = offsetY
+                        )
+                        .transformable(state = transformState)
+                        .combinedClickable(
+                            onClick = {},
+                            onLongClick = { showMenu = true }
+                        ),
+                    contentScale = ContentScale.Fit
+                )
+
+                DropdownMenu(
+                    expanded = showMenu,
+                    onDismissRequest = { showMenu = false }
+                ) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.download)) },
+                        onClick = {
+                            showMenu = false
+                            val request = android.app.DownloadManager.Request(Uri.parse(url))
+                                .setNotificationVisibility(
+                                    android.app.DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED
+                                )
+                                .setDestinationInExternalPublicDir(
+                                    android.os.Environment.DIRECTORY_DOWNLOADS,
+                                    url.substringAfterLast('/')
+                                )
+                            val dm = context.getSystemService(android.content.Context.DOWNLOAD_SERVICE)
+                                as android.app.DownloadManager
+                            dm.enqueue(request)
+                        },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Default.Download,
+                                contentDescription = null
+                            )
+                        }
                     )
-                    .transformable(state = transformState),
-                contentScale = ContentScale.Fit
-            )
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.share)) },
+                        onClick = {
+                            showMenu = false
+                            val sendIntent = Intent().apply {
+                                action = Intent.ACTION_SEND
+                                putExtra(Intent.EXTRA_TEXT, url)
+                                type = "text/plain"
+                            }
+                            context.startActivity(Intent.createChooser(sendIntent, null))
+                        },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Outlined.Share,
+                                contentDescription = null
+                            )
+                        }
+                    )
+                }
+            }
 
             // Alt text
             if (!alt.isNullOrBlank()) {

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -529,7 +529,7 @@ private fun EngagementBar(
 
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween
+        verticalAlignment = Alignment.CenterVertically
     ) {
         // Reply
         EngagementButton(
@@ -556,6 +556,8 @@ private fun EngagementBar(
             onClick = onReactionClick,
             onLongClick = onReactionLongPress
         )
+
+        Spacer(modifier = Modifier.weight(1f))
 
         // External share — always textSecondary
         if (onExternalShareClick != null) {
@@ -600,13 +602,11 @@ private fun EngagementButton(
                 modifier = Modifier.size(20.dp)
             )
         }
-        if (count > 0) {
-            Text(
-                text = formatCount(count),
-                style = typography.labelMedium,
-                color = tint
-            )
-        }
+        Text(
+            text = formatCount(count),
+            style = typography.labelMedium,
+            color = tint
+        )
     }
 }
 
@@ -637,13 +637,11 @@ private fun ShareEngagementButton(
                     modifier = Modifier.size(20.dp)
                 )
             }
-            if (count > 0) {
-                Text(
-                    text = formatCount(count),
-                    style = typography.labelMedium,
-                    color = tint
-                )
-            }
+            Text(
+                text = formatCount(count),
+                style = typography.labelMedium,
+                color = tint
+            )
         }
 
         DropdownMenu(
@@ -715,13 +713,11 @@ private fun ReactionEngagementButton(
                 modifier = Modifier.size(20.dp)
             )
         }
-        if (count > 0) {
-            Text(
-                text = formatCount(count),
-                style = typography.labelMedium,
-                color = tint
-            )
-        }
+        Text(
+            text = formatCount(count),
+            style = typography.labelMedium,
+            color = tint
+        )
     }
 }
 

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -180,7 +180,10 @@ private fun NoteCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .alpha(0.5f)
-                    .padding(bottom = 8.dp),
+                    .padding(bottom = 8.dp)
+                    .clickable {
+                        onQuotedPostClick?.invoke(displayPost.replyTarget!!.id)
+                    },
                 verticalAlignment = Alignment.Top
             ) {
                 AsyncImage(
@@ -204,7 +207,10 @@ private fun NoteCard(
                     HtmlContent(
                         html = displayPost.replyTarget!!.content,
                         maxLines = 2,
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier.fillMaxWidth(),
+                        onTextClick = {
+                            onQuotedPostClick?.invoke(displayPost.replyTarget!!.id)
+                        }
                     )
                 }
             }

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
@@ -835,6 +836,17 @@ fun QuotedPostPreview(
     }
 }
 
+@Composable
+private fun GridMediaItem(item: pub.hackers.android.domain.model.Media, modifier: Modifier) {
+    MediaImage(
+        url = item.url,
+        alt = item.alt,
+        modifier = modifier,
+        isVideo = item.isVideo,
+        thumbnailUrl = item.thumbnailUrl
+    )
+}
+
 // Step 6: MediaGrid with 8dp radius
 @Composable
 fun MediaGrid(media: List<pub.hackers.android.domain.model.Media>) {
@@ -844,14 +856,10 @@ fun MediaGrid(media: List<pub.hackers.android.domain.model.Media>) {
     when (media.size) {
         0 -> {}
         1 -> {
-            MediaImage(
-                url = media[0].url,
-                alt = media[0].alt,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(gridHeight)
-                    .clip(RoundedCornerShape(AppShapes.mediaRadius))
-            )
+            GridMediaItem(media[0], Modifier
+                .fillMaxWidth()
+                .height(gridHeight)
+                .clip(RoundedCornerShape(AppShapes.mediaRadius)))
         }
         2 -> {
             // a | b
@@ -859,22 +867,8 @@ fun MediaGrid(media: List<pub.hackers.android.domain.model.Media>) {
                 horizontalArrangement = Arrangement.spacedBy(gap),
                 modifier = Modifier.fillMaxWidth()
             ) {
-                MediaImage(
-                    url = media[0].url,
-                    alt = media[0].alt,
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(gridHeight)
-                        .clip(RoundedCornerShape(AppShapes.mediaRadius))
-                )
-                MediaImage(
-                    url = media[1].url,
-                    alt = media[1].alt,
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(gridHeight)
-                        .clip(RoundedCornerShape(AppShapes.mediaRadius))
-                )
+                GridMediaItem(media[0], Modifier.weight(1f).height(gridHeight).clip(RoundedCornerShape(AppShapes.mediaRadius)))
+                GridMediaItem(media[1], Modifier.weight(1f).height(gridHeight).clip(RoundedCornerShape(AppShapes.mediaRadius)))
             }
         }
         3 -> {
@@ -884,34 +878,13 @@ fun MediaGrid(media: List<pub.hackers.android.domain.model.Media>) {
                 horizontalArrangement = Arrangement.spacedBy(gap),
                 modifier = Modifier.fillMaxWidth()
             ) {
-                MediaImage(
-                    url = media[0].url,
-                    alt = media[0].alt,
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(gridHeight)
-                        .clip(RoundedCornerShape(AppShapes.mediaRadius))
-                )
+                GridMediaItem(media[0], Modifier.weight(1f).height(gridHeight).clip(RoundedCornerShape(AppShapes.mediaRadius)))
                 Column(
                     verticalArrangement = Arrangement.spacedBy(gap),
                     modifier = Modifier.weight(1f)
                 ) {
-                    MediaImage(
-                        url = media[1].url,
-                        alt = media[1].alt,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(halfHeight)
-                            .clip(RoundedCornerShape(AppShapes.mediaRadius))
-                    )
-                    MediaImage(
-                        url = media[2].url,
-                        alt = media[2].alt,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(halfHeight)
-                            .clip(RoundedCornerShape(AppShapes.mediaRadius))
-                    )
+                    GridMediaItem(media[1], Modifier.fillMaxWidth().height(halfHeight).clip(RoundedCornerShape(AppShapes.mediaRadius)))
+                    GridMediaItem(media[2], Modifier.fillMaxWidth().height(halfHeight).clip(RoundedCornerShape(AppShapes.mediaRadius)))
                 }
             }
         }
@@ -927,46 +900,21 @@ fun MediaGrid(media: List<pub.hackers.android.domain.model.Media>) {
                     verticalArrangement = Arrangement.spacedBy(gap),
                     modifier = Modifier.weight(1f)
                 ) {
-                    MediaImage(
-                        url = media[0].url,
-                        alt = media[0].alt,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(halfHeight)
-                            .clip(RoundedCornerShape(AppShapes.mediaRadius))
-                    )
-                    MediaImage(
-                        url = media[2].url,
-                        alt = media[2].alt,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(halfHeight)
-                            .clip(RoundedCornerShape(AppShapes.mediaRadius))
-                    )
+                    GridMediaItem(media[0], Modifier.fillMaxWidth().height(halfHeight).clip(RoundedCornerShape(AppShapes.mediaRadius)))
+                    GridMediaItem(media[2], Modifier.fillMaxWidth().height(halfHeight).clip(RoundedCornerShape(AppShapes.mediaRadius)))
                 }
                 Column(
                     verticalArrangement = Arrangement.spacedBy(gap),
                     modifier = Modifier.weight(1f)
                 ) {
-                    MediaImage(
-                        url = media[1].url,
-                        alt = media[1].alt,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(halfHeight)
-                            .clip(RoundedCornerShape(AppShapes.mediaRadius))
-                    )
+                    GridMediaItem(media[1], Modifier.fillMaxWidth().height(halfHeight).clip(RoundedCornerShape(AppShapes.mediaRadius)))
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(halfHeight)
                             .clip(RoundedCornerShape(AppShapes.mediaRadius))
                     ) {
-                        MediaImage(
-                            url = media[3].url,
-                            alt = media[3].alt,
-                            modifier = Modifier.fillMaxSize()
-                        )
+                        GridMediaItem(media[3], Modifier.fillMaxSize())
                         if (remaining > 0) {
                             Box(
                                 contentAlignment = Alignment.Center,
@@ -992,14 +940,17 @@ fun MediaGrid(media: List<pub.hackers.android.domain.model.Media>) {
 fun MediaImage(
     url: String,
     alt: String?,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isVideo: Boolean = false,
+    thumbnailUrl: String? = null
 ) {
     val colors = LocalAppColors.current
+    val context = LocalContext.current
     var showPreview by remember { mutableStateOf(false) }
 
     Box(modifier = modifier) {
         AsyncImage(
-            model = url,
+            model = if (isVideo) (thumbnailUrl ?: url) else url,
             contentDescription = alt,
             modifier = Modifier
                 .fillMaxSize()
@@ -1008,9 +959,33 @@ fun MediaImage(
                     color = colors.divider,
                     shape = RoundedCornerShape(AppShapes.mediaRadius)
                 )
-                .clickable { showPreview = true },
+                .clickable {
+                    if (isVideo) {
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                        intent.setDataAndType(Uri.parse(url), "video/*")
+                        context.startActivity(intent)
+                    } else {
+                        showPreview = true
+                    }
+                },
             contentScale = ContentScale.Crop
         )
+
+        if (isVideo) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.3f))
+            ) {
+                Icon(
+                    imageVector = Icons.Default.PlayArrow,
+                    contentDescription = "Play video",
+                    tint = Color.White,
+                    modifier = Modifier.size(48.dp)
+                )
+            }
+        }
     }
 
     if (showPreview) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -163,6 +163,10 @@ fun ComposeScreen(
         }
     }
 
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
     val postEnabled = uiState.content.isNotBlank() && !uiState.isPosting
 
     Scaffold(

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.outlined.FormatQuote
 import androidx.compose.material.icons.outlined.Group
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material3.IconButton
@@ -322,6 +323,18 @@ fun ComposeScreen(
                 }
             }
 
+            // Quoted post preview
+            if (uiState.isLoadingQuotedPost) {
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .size(24.dp)
+                        .align(Alignment.CenterHorizontally)
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+            } else if (uiState.quotedPost != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                QuotedPostPreview(post = uiState.quotedPost!!)
+            }
          }
             // Close inner content Column
 
@@ -486,6 +499,65 @@ private fun ReplyTargetPreview(
                     color = colors.textSecondary,
                     emojiHeight = 14.dp
                 )
+                Spacer(modifier = Modifier.height(4.dp))
+                HtmlContent(
+                    html = post.content,
+                    maxLines = 3,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuotedPostPreview(
+    post: Post,
+    modifier: Modifier = Modifier
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(8.dp),
+        color = colors.surface,
+        border = BorderStroke(1.dp, colors.divider)
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.FormatQuote,
+                contentDescription = null,
+                tint = colors.textSecondary,
+                modifier = Modifier.size(20.dp)
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    AsyncImage(
+                        model = post.actor.avatarUrl,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(20.dp)
+                            .clip(CircleShape),
+                        contentScale = ContentScale.Crop
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    pub.hackers.android.ui.components.RichDisplayName(
+                        name = post.actor.name,
+                        fallback = post.actor.handle,
+                        style = typography.labelMedium,
+                        color = colors.textSecondary,
+                        emojiHeight = 14.dp
+                    )
+                }
                 Spacer(modifier = Modifier.height(4.dp))
                 HtmlContent(
                     html = post.content,

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
@@ -217,7 +217,8 @@ class ComposeViewModel @Inject constructor(
                         it.copy(
                             replyTargetPost = post,
                             isLoadingReplyTarget = false,
-                            content = mentionPrefix
+                            content = mentionPrefix,
+                            cursorPosition = mentionPrefix.length
                         )
                     }
                 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreScreen.kt
@@ -15,10 +15,12 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -38,6 +40,7 @@ import pub.hackers.android.ui.components.FullScreenLoading
 import pub.hackers.android.ui.components.LargeTitleHeader
 import pub.hackers.android.ui.components.LoadingItem
 import pub.hackers.android.ui.components.PostCard
+import pub.hackers.android.ui.components.ReactionPicker
 import pub.hackers.android.ui.theme.LocalAppColors
 import pub.hackers.android.ui.theme.LocalAppTypography
 
@@ -73,6 +76,26 @@ fun ExploreScreen(
 
     LaunchedEffect(uiState.selectedTab) {
         listState.scrollToItem(0)
+    }
+
+    // Reaction picker bottom sheet
+    val pickerPostId = uiState.reactionPickerPostId
+    if (pickerPostId != null) {
+        val pickerPost = uiState.posts.find {
+            it.id == pickerPostId || it.sharedPost?.id == pickerPostId
+        }
+        val targetPost = pickerPost?.sharedPost ?: pickerPost
+        ModalBottomSheet(
+            onDismissRequest = { viewModel.hideReactionPicker() },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        ) {
+            ReactionPicker(
+                reactionGroups = targetPost?.reactionGroups ?: emptyList(),
+                isSubmitting = false,
+                onEmojiSelect = { emoji -> viewModel.toggleReaction(pickerPostId, emoji) },
+                onClose = { viewModel.hideReactionPicker() }
+            )
+        }
     }
 
     Scaffold(
@@ -185,7 +208,12 @@ fun ExploreScreen(
                                         onQuoteClick = if (isLoggedIn) {
                                             { onQuoteClick(post.sharedPost?.id ?: post.id) }
                                         } else null,
-                                        onReactionClick = { onPostClick(post.sharedPost?.id ?: post.id) },
+                                        onReactionClick = if (isLoggedIn) {
+                                            { viewModel.toggleFavourite(post.sharedPost?.id ?: post.id) }
+                                        } else null,
+                                        onReactionLongPress = if (isLoggedIn) {
+                                            { viewModel.showReactionPicker(post.sharedPost?.id ?: post.id) }
+                                        } else null,
                                         onExternalShareClick = {
                                             val displayPost = post.sharedPost ?: post
                                             val shareUrl = displayPost.url ?: displayPost.iri

--- a/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreViewModel.kt
@@ -160,17 +160,31 @@ class ExploreViewModel @Inject constructor(
     }
 
     fun sharePost(postId: String) {
+        _uiState.update { state ->
+            state.copy(
+                posts = state.posts.map { post ->
+                    if (post.id == postId) {
+                        post.copy(
+                            viewerHasShared = true,
+                            engagementStats = post.engagementStats.copy(
+                                shares = post.engagementStats.shares + 1
+                            )
+                        )
+                    } else post
+                }
+            )
+        }
         viewModelScope.launch {
             repository.sharePost(postId)
-                .onSuccess {
+                .onFailure {
                     _uiState.update { state ->
                         state.copy(
                             posts = state.posts.map { post ->
                                 if (post.id == postId) {
                                     post.copy(
-                                        viewerHasShared = true,
+                                        viewerHasShared = false,
                                         engagementStats = post.engagementStats.copy(
-                                            shares = post.engagementStats.shares + 1
+                                            shares = maxOf(0, post.engagementStats.shares - 1)
                                         )
                                     )
                                 } else post
@@ -182,17 +196,31 @@ class ExploreViewModel @Inject constructor(
     }
 
     fun unsharePost(postId: String) {
+        _uiState.update { state ->
+            state.copy(
+                posts = state.posts.map { post ->
+                    if (post.id == postId) {
+                        post.copy(
+                            viewerHasShared = false,
+                            engagementStats = post.engagementStats.copy(
+                                shares = maxOf(0, post.engagementStats.shares - 1)
+                            )
+                        )
+                    } else post
+                }
+            )
+        }
         viewModelScope.launch {
             repository.unsharePost(postId)
-                .onSuccess {
+                .onFailure {
                     _uiState.update { state ->
                         state.copy(
                             posts = state.posts.map { post ->
                                 if (post.id == postId) {
                                     post.copy(
-                                        viewerHasShared = false,
+                                        viewerHasShared = true,
                                         engagementStats = post.engagementStats.copy(
-                                            shares = maxOf(0, post.engagementStats.shares - 1)
+                                            shares = post.engagementStats.shares + 1
                                         )
                                     )
                                 } else post
@@ -215,6 +243,29 @@ class ExploreViewModel @Inject constructor(
         val existingGroup = targetPost.reactionGroups.find { it.emoji == emoji }
         val viewerHasReacted = existingGroup?.viewerHasReacted == true
 
+        _uiState.update { state ->
+            state.copy(
+                posts = state.posts.map { p ->
+                    val target = p.sharedPost ?: p
+                    if (target.id == targetPost.id) {
+                        val updatedGroups = updateReactionGroups(
+                            target.reactionGroups, emoji, viewerHasReacted
+                        )
+                        val totalReactions = updatedGroups.sumOf { it.count }
+                        val updatedTarget = target.copy(
+                            reactionGroups = updatedGroups,
+                            engagementStats = target.engagementStats.copy(
+                                reactions = totalReactions
+                            )
+                        )
+                        if (p.sharedPost != null) p.copy(sharedPost = updatedTarget)
+                        else updatedTarget
+                    } else p
+                },
+                reactionPickerPostId = null
+            )
+        }
+
         viewModelScope.launch {
             val result = if (viewerHasReacted) {
                 repository.removeReactionFromPost(targetPost.id, emoji)
@@ -222,27 +273,26 @@ class ExploreViewModel @Inject constructor(
                 repository.addReactionToPost(targetPost.id, emoji)
             }
 
-            result.onSuccess {
+            result.onFailure {
                 _uiState.update { state ->
                     state.copy(
                         posts = state.posts.map { p ->
                             val target = p.sharedPost ?: p
                             if (target.id == targetPost.id) {
-                                val updatedGroups = updateReactionGroups(
-                                    target.reactionGroups, emoji, viewerHasReacted
+                                val revertedGroups = updateReactionGroups(
+                                    target.reactionGroups, emoji, !viewerHasReacted
                                 )
-                                val totalReactions = updatedGroups.sumOf { it.count }
-                                val updatedTarget = target.copy(
-                                    reactionGroups = updatedGroups,
+                                val totalReactions = revertedGroups.sumOf { it.count }
+                                val revertedTarget = target.copy(
+                                    reactionGroups = revertedGroups,
                                     engagementStats = target.engagementStats.copy(
                                         reactions = totalReactions
                                     )
                                 )
-                                if (p.sharedPost != null) p.copy(sharedPost = updatedTarget)
-                                else updatedTarget
+                                if (p.sharedPost != null) p.copy(sharedPost = revertedTarget)
+                                else revertedTarget
                             } else p
-                        },
-                        reactionPickerPostId = null
+                        }
                     )
                 }
             }

--- a/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pub.hackers.android.data.repository.HackersPubRepository
 import pub.hackers.android.domain.model.Post
+import pub.hackers.android.domain.model.ReactionGroup
 import java.time.Instant
 import javax.inject.Inject
 
@@ -25,7 +26,8 @@ data class ExploreUiState(
     val isLoadingMore: Boolean = false,
     val hasNextPage: Boolean = false,
     val endCursor: String? = null,
-    val error: String? = null
+    val error: String? = null,
+    val reactionPickerPostId: String? = null
 )
 
 @HiltViewModel
@@ -198,6 +200,88 @@ class ExploreViewModel @Inject constructor(
                         )
                     }
                 }
+        }
+    }
+
+    fun toggleFavourite(postId: String) {
+        toggleReaction(postId, "❤️")
+    }
+
+    fun toggleReaction(postId: String, emoji: String) {
+        val post = _uiState.value.posts.find {
+            it.id == postId || it.sharedPost?.id == postId
+        } ?: return
+        val targetPost = post.sharedPost ?: post
+        val existingGroup = targetPost.reactionGroups.find { it.emoji == emoji }
+        val viewerHasReacted = existingGroup?.viewerHasReacted == true
+
+        viewModelScope.launch {
+            val result = if (viewerHasReacted) {
+                repository.removeReactionFromPost(targetPost.id, emoji)
+            } else {
+                repository.addReactionToPost(targetPost.id, emoji)
+            }
+
+            result.onSuccess {
+                _uiState.update { state ->
+                    state.copy(
+                        posts = state.posts.map { p ->
+                            val target = p.sharedPost ?: p
+                            if (target.id == targetPost.id) {
+                                val updatedGroups = updateReactionGroups(
+                                    target.reactionGroups, emoji, viewerHasReacted
+                                )
+                                val totalReactions = updatedGroups.sumOf { it.count }
+                                val updatedTarget = target.copy(
+                                    reactionGroups = updatedGroups,
+                                    engagementStats = target.engagementStats.copy(
+                                        reactions = totalReactions
+                                    )
+                                )
+                                if (p.sharedPost != null) p.copy(sharedPost = updatedTarget)
+                                else updatedTarget
+                            } else p
+                        },
+                        reactionPickerPostId = null
+                    )
+                }
+            }
+        }
+    }
+
+    fun showReactionPicker(postId: String) {
+        _uiState.update { it.copy(reactionPickerPostId = postId) }
+    }
+
+    fun hideReactionPicker() {
+        _uiState.update { it.copy(reactionPickerPostId = null) }
+    }
+
+    private fun updateReactionGroups(
+        groups: List<ReactionGroup>,
+        emoji: String,
+        wasReacted: Boolean
+    ): List<ReactionGroup> {
+        return if (wasReacted) {
+            groups.map { group ->
+                if (group.emoji == emoji) {
+                    group.copy(count = maxOf(0, group.count - 1), viewerHasReacted = false)
+                } else group
+            }.filter { it.count > 0 || it.viewerHasReacted }
+        } else {
+            val existing = groups.find { it.emoji == emoji }
+            if (existing != null) {
+                groups.map { group ->
+                    if (group.emoji == emoji) {
+                        group.copy(count = group.count + 1, viewerHasReacted = true)
+                    } else group
+                }
+            } else {
+                groups + ReactionGroup(
+                    emoji = emoji, customEmoji = null,
+                    count = 1, reactors = emptyList(), viewerHasReacted = true
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -452,7 +452,9 @@ private fun PostDetailContent(
 
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(vertical = 4.dp)
+                        modifier = Modifier
+                            .padding(vertical = 4.dp)
+                            .clickable { onPostClick(post.replyTarget!!.id) }
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.Reply,
@@ -1052,7 +1054,8 @@ private fun ReplyTargetPreview(
             html = post.content,
             maxLines = 3,
             modifier = Modifier.fillMaxWidth(),
-            onMentionClick = onProfileClick
+            onMentionClick = onProfileClick,
+            onTextClick = onClick
         )
 
         if (post.media.isNotEmpty()) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -554,6 +554,45 @@ private fun PostDetailContent(
                     )
                 }
 
+                if (!isTranslating && translationError == null) {
+                    Text(
+                        text = if (showTranslated) stringResource(R.string.show_original) else stringResource(R.string.translate),
+                        style = typography.labelMedium,
+                        color = colors.textSecondary,
+                        modifier = Modifier
+                            .padding(top = 4.dp)
+                            .clickable {
+                                if (showTranslated) {
+                                    showTranslated = false
+                                    return@clickable
+                                }
+                                translatedContent?.let {
+                                    showTranslated = true
+                                    return@clickable
+                                }
+                                val targetLanguageTag = androidx.core.os.ConfigurationCompat
+                                    .getLocales(context.resources.configuration)
+                                    .get(0)?.language ?: Locale.getDefault().language
+                                scope.launch {
+                                    isTranslating = true
+                                    translationError = null
+                                    try {
+                                        val translated = translateDetailContent(
+                                            html = post.content,
+                                            targetLanguageTag = targetLanguageTag
+                                        )
+                                        translatedContent = translated
+                                        showTranslated = true
+                                    } catch (_: Exception) {
+                                        translationError = translationFailedText
+                                    } finally {
+                                        isTranslating = false
+                                    }
+                                }
+                            }
+                    )
+                }
+
                 if (post.media.isNotEmpty()) {
                     Spacer(modifier = Modifier.height(12.dp))
                     MediaGrid(media = post.media)
@@ -739,47 +778,6 @@ private fun PostDetailContent(
                             imageVector = Icons.Outlined.FormatQuote,
                             contentDescription = stringResource(R.string.quotes),
                             tint = colors.textSecondary
-                        )
-                    }
-                    IconButton(
-                        onClick = {
-                            if (isTranslating) return@IconButton
-                            if (showTranslated) {
-                                showTranslated = false
-                                return@IconButton
-                            }
-                            translatedContent?.let {
-                                showTranslated = true
-                                return@IconButton
-                            }
-                            val targetLanguageTag = androidx.core.os.ConfigurationCompat
-                                .getLocales(context.resources.configuration)
-                                .get(0)?.language ?: Locale.getDefault().language
-                            scope.launch {
-                                isTranslating = true
-                                translationError = null
-                                try {
-                                    val translated = translateDetailContent(
-                                        html = post.content,
-                                        targetLanguageTag = targetLanguageTag
-                                    )
-                                    translatedContent = translated
-                                    showTranslated = true
-                                } catch (_: Exception) {
-                                    translationError = translationFailedText
-                                } finally {
-                                    isTranslating = false
-                                }
-                            }
-                        }
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Translate,
-                            contentDescription = if (showTranslated)
-                                stringResource(R.string.show_original)
-                            else
-                                stringResource(R.string.translate),
-                            tint = if (showTranslated) colors.accent else colors.textSecondary
                         )
                     }
                     IconButton(onClick = onExternalShareClick) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -1071,6 +1071,8 @@ private fun MediaCarousel(media: List<pub.hackers.android.domain.model.Media>) {
         MediaImage(
             url = media[0].url,
             alt = media[0].alt,
+            isVideo = media[0].isVideo,
+            thumbnailUrl = media[0].thumbnailUrl,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(250.dp)
@@ -1087,6 +1089,8 @@ private fun MediaCarousel(media: List<pub.hackers.android.domain.model.Media>) {
                 MediaImage(
                     url = item.url,
                     alt = item.alt,
+                    isVideo = item.isVideo,
+                    thumbnailUrl = item.thumbnailUrl,
                     modifier = Modifier
                         .height(250.dp)
                         .width(300.dp)

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -702,7 +702,10 @@ private fun PostDetailContent(
                 HorizontalDivider(color = colors.divider)
 
                 Row(
-                    modifier = Modifier.padding(vertical = 4.dp)
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
+                    horizontalArrangement = Arrangement.SpaceAround
                 ) {
                     IconButton(onClick = onReplyClick) {
                         Icon(

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -2,6 +2,8 @@ package pub.hackers.android.ui.screens.postdetail
 
 import android.content.Intent
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -81,7 +83,7 @@ import pub.hackers.android.ui.components.FullScreenLoading
 import pub.hackers.android.ui.components.HtmlContent
 import pub.hackers.android.ui.components.LargeTitleHeader
 import pub.hackers.android.ui.components.LoadingItem
-import pub.hackers.android.ui.components.MediaGrid
+import pub.hackers.android.ui.components.MediaImage
 import pub.hackers.android.ui.components.PostCard
 import pub.hackers.android.ui.components.QuotedPostPreview
 import pub.hackers.android.ui.components.ReactionPicker
@@ -595,7 +597,7 @@ private fun PostDetailContent(
 
                 if (post.media.isNotEmpty()) {
                     Spacer(modifier = Modifier.height(12.dp))
-                    MediaGrid(media = post.media)
+                    MediaCarousel(media = post.media)
                 }
 
                 if (post.quotedPost != null) {
@@ -1055,8 +1057,52 @@ private fun ReplyTargetPreview(
 
         if (post.media.isNotEmpty()) {
             Spacer(modifier = Modifier.height(8.dp))
-            MediaGrid(media = post.media)
+            MediaCarousel(media = post.media)
         }
+    }
+}
+
+@Composable
+private fun MediaCarousel(media: List<pub.hackers.android.domain.model.Media>) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+
+    if (media.size == 1) {
+        MediaImage(
+            url = media[0].url,
+            alt = media[0].alt,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(250.dp)
+                .clip(RoundedCornerShape(AppShapes.mediaRadius))
+        )
+    } else {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+        ) {
+            media.forEach { item ->
+                MediaImage(
+                    url = item.url,
+                    alt = item.alt,
+                    modifier = Modifier
+                        .height(250.dp)
+                        .width(300.dp)
+                        .clip(RoundedCornerShape(AppShapes.mediaRadius))
+                )
+            }
+        }
+    }
+
+    if (media.size > 1) {
+        Text(
+            text = "${media.size} images",
+            style = typography.labelSmall,
+            color = colors.textSecondary,
+            modifier = Modifier.padding(top = 4.dp)
+        )
     }
 }
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
@@ -221,7 +221,7 @@ fun ProfileScreen(
                                         }
                                     },
                                     onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
-                                    onReactionClick = { onPostClick(post.sharedPost?.id ?: post.id) },
+                                    onReactionClick = null,
                                     onExternalShareClick = {
                                         val displayPost = post.sharedPost ?: post
                                         val shareUrl = displayPost.url ?: displayPost.iri

--- a/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
@@ -160,7 +160,7 @@ fun SearchScreen(
                                     onProfileClick = onProfileClick,
                                     onReplyClick = { onReplyClick(post.sharedPost?.id ?: post.id) },
                                     onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
-                                    onReactionClick = { onPostClick(post.sharedPost?.id ?: post.id) },
+                                    onReactionClick = null,
                                     onExternalShareClick = {
                                         val displayPost = post.sharedPost ?: post
                                         val shareUrl = displayPost.url ?: displayPost.iri

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -26,8 +26,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -54,6 +56,7 @@ fun TimelineScreen(
     onQuoteClick: (String) -> Unit = {},
     onSettingsClick: () -> Unit,
     postedAt: Long = 0L,
+    tabRetapped: Long = 0L,
     userAvatarUrl: String? = null,
     viewModel: TimelineViewModel = hiltViewModel()
 ) {
@@ -61,6 +64,7 @@ fun TimelineScreen(
     val listState = rememberLazyListState()
     val context = LocalContext.current
     val colors = LocalAppColors.current
+    val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(postedAt) {
         if (postedAt > 0L) {
@@ -70,6 +74,16 @@ fun TimelineScreen(
                 .dropWhile { !it.isRefreshing }
                 .first { !it.isRefreshing }
             listState.scrollToItem(0)
+        }
+    }
+
+    LaunchedEffect(tabRetapped) {
+        if (tabRetapped > 0L) {
+            if (listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0) {
+                viewModel.refresh()
+            } else {
+                listState.animateScrollToItem(0)
+            }
         }
     }
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -18,8 +18,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -45,6 +47,7 @@ import pub.hackers.android.ui.components.FullScreenLoading
 import pub.hackers.android.ui.components.LargeTitleHeader
 import pub.hackers.android.ui.components.LoadingItem
 import pub.hackers.android.ui.components.PostCard
+import pub.hackers.android.ui.components.ReactionPicker
 import pub.hackers.android.ui.theme.LocalAppColors
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -97,6 +100,26 @@ fun TimelineScreen(
     LaunchedEffect(shouldLoadMore) {
         if (shouldLoadMore && uiState.hasNextPage && !uiState.isLoadingMore) {
             viewModel.loadMore()
+        }
+    }
+
+    // Reaction picker bottom sheet
+    val pickerPostId = uiState.reactionPickerPostId
+    if (pickerPostId != null) {
+        val pickerPost = uiState.posts.find {
+            it.id == pickerPostId || it.sharedPost?.id == pickerPostId
+        }
+        val targetPost = pickerPost?.sharedPost ?: pickerPost
+        ModalBottomSheet(
+            onDismissRequest = { viewModel.hideReactionPicker() },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        ) {
+            ReactionPicker(
+                reactionGroups = targetPost?.reactionGroups ?: emptyList(),
+                isSubmitting = false,
+                onEmojiSelect = { emoji -> viewModel.toggleReaction(pickerPostId, emoji) },
+                onClose = { viewModel.hideReactionPicker() }
+            )
         }
     }
 
@@ -190,7 +213,8 @@ fun TimelineScreen(
                                         }
                                     },
                                     onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
-                                    onReactionClick = { onPostClick(post.sharedPost?.id ?: post.id) },
+                                    onReactionClick = { viewModel.toggleFavourite(post.sharedPost?.id ?: post.id) },
+                                    onReactionLongPress = { viewModel.showReactionPicker(post.sharedPost?.id ?: post.id) },
                                     onExternalShareClick = {
                                         val displayPost = post.sharedPost ?: post
                                         val shareUrl = displayPost.url ?: displayPost.iri

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import pub.hackers.android.data.local.PreferencesManager
 import pub.hackers.android.data.repository.HackersPubRepository
 import pub.hackers.android.domain.model.Post
+import pub.hackers.android.domain.model.ReactionGroup
 import java.time.Instant
 import javax.inject.Inject
 
@@ -21,7 +22,8 @@ data class TimelineUiState(
     val isLoadingMore: Boolean = false,
     val hasNextPage: Boolean = false,
     val endCursor: String? = null,
-    val error: String? = null
+    val error: String? = null,
+    val reactionPickerPostId: String? = null
 )
 
 @HiltViewModel
@@ -166,6 +168,88 @@ class TimelineViewModel @Inject constructor(
                         )
                     }
                 }
+        }
+    }
+
+    fun toggleFavourite(postId: String) {
+        toggleReaction(postId, "❤️")
+    }
+
+    fun toggleReaction(postId: String, emoji: String) {
+        val post = _uiState.value.posts.find {
+            it.id == postId || it.sharedPost?.id == postId
+        } ?: return
+        val targetPost = post.sharedPost ?: post
+        val existingGroup = targetPost.reactionGroups.find { it.emoji == emoji }
+        val viewerHasReacted = existingGroup?.viewerHasReacted == true
+
+        viewModelScope.launch {
+            val result = if (viewerHasReacted) {
+                repository.removeReactionFromPost(targetPost.id, emoji)
+            } else {
+                repository.addReactionToPost(targetPost.id, emoji)
+            }
+
+            result.onSuccess {
+                _uiState.update { state ->
+                    state.copy(
+                        posts = state.posts.map { p ->
+                            val target = p.sharedPost ?: p
+                            if (target.id == targetPost.id) {
+                                val updatedGroups = updateReactionGroups(
+                                    target.reactionGroups, emoji, viewerHasReacted
+                                )
+                                val totalReactions = updatedGroups.sumOf { it.count }
+                                val updatedTarget = target.copy(
+                                    reactionGroups = updatedGroups,
+                                    engagementStats = target.engagementStats.copy(
+                                        reactions = totalReactions
+                                    )
+                                )
+                                if (p.sharedPost != null) p.copy(sharedPost = updatedTarget)
+                                else updatedTarget
+                            } else p
+                        },
+                        reactionPickerPostId = null
+                    )
+                }
+            }
+        }
+    }
+
+    fun showReactionPicker(postId: String) {
+        _uiState.update { it.copy(reactionPickerPostId = postId) }
+    }
+
+    fun hideReactionPicker() {
+        _uiState.update { it.copy(reactionPickerPostId = null) }
+    }
+
+    private fun updateReactionGroups(
+        groups: List<ReactionGroup>,
+        emoji: String,
+        wasReacted: Boolean
+    ): List<ReactionGroup> {
+        return if (wasReacted) {
+            groups.map { group ->
+                if (group.emoji == emoji) {
+                    group.copy(count = maxOf(0, group.count - 1), viewerHasReacted = false)
+                } else group
+            }.filter { it.count > 0 || it.viewerHasReacted }
+        } else {
+            val existing = groups.find { it.emoji == emoji }
+            if (existing != null) {
+                groups.map { group ->
+                    if (group.emoji == emoji) {
+                        group.copy(count = group.count + 1, viewerHasReacted = true)
+                    } else group
+                }
+            } else {
+                groups + ReactionGroup(
+                    emoji = emoji, customEmoji = null,
+                    count = 1, reactors = emptyList(), viewerHasReacted = true
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
@@ -128,17 +128,33 @@ class TimelineViewModel @Inject constructor(
     }
 
     fun sharePost(postId: String) {
+        // Optimistic update
+        _uiState.update { state ->
+            state.copy(
+                posts = state.posts.map { post ->
+                    if (post.id == postId) {
+                        post.copy(
+                            viewerHasShared = true,
+                            engagementStats = post.engagementStats.copy(
+                                shares = post.engagementStats.shares + 1
+                            )
+                        )
+                    } else post
+                }
+            )
+        }
         viewModelScope.launch {
             repository.sharePost(postId)
-                .onSuccess {
+                .onFailure {
+                    // Revert on failure
                     _uiState.update { state ->
                         state.copy(
                             posts = state.posts.map { post ->
                                 if (post.id == postId) {
                                     post.copy(
-                                        viewerHasShared = true,
+                                        viewerHasShared = false,
                                         engagementStats = post.engagementStats.copy(
-                                            shares = post.engagementStats.shares + 1
+                                            shares = maxOf(0, post.engagementStats.shares - 1)
                                         )
                                     )
                                 } else post
@@ -150,17 +166,33 @@ class TimelineViewModel @Inject constructor(
     }
 
     fun unsharePost(postId: String) {
+        // Optimistic update
+        _uiState.update { state ->
+            state.copy(
+                posts = state.posts.map { post ->
+                    if (post.id == postId) {
+                        post.copy(
+                            viewerHasShared = false,
+                            engagementStats = post.engagementStats.copy(
+                                shares = maxOf(0, post.engagementStats.shares - 1)
+                            )
+                        )
+                    } else post
+                }
+            )
+        }
         viewModelScope.launch {
             repository.unsharePost(postId)
-                .onSuccess {
+                .onFailure {
+                    // Revert on failure
                     _uiState.update { state ->
                         state.copy(
                             posts = state.posts.map { post ->
                                 if (post.id == postId) {
                                     post.copy(
-                                        viewerHasShared = false,
+                                        viewerHasShared = true,
                                         engagementStats = post.engagementStats.copy(
-                                            shares = maxOf(0, post.engagementStats.shares - 1)
+                                            shares = post.engagementStats.shares + 1
                                         )
                                     )
                                 } else post
@@ -183,6 +215,30 @@ class TimelineViewModel @Inject constructor(
         val existingGroup = targetPost.reactionGroups.find { it.emoji == emoji }
         val viewerHasReacted = existingGroup?.viewerHasReacted == true
 
+        // Optimistic update
+        _uiState.update { state ->
+            state.copy(
+                posts = state.posts.map { p ->
+                    val target = p.sharedPost ?: p
+                    if (target.id == targetPost.id) {
+                        val updatedGroups = updateReactionGroups(
+                            target.reactionGroups, emoji, viewerHasReacted
+                        )
+                        val totalReactions = updatedGroups.sumOf { it.count }
+                        val updatedTarget = target.copy(
+                            reactionGroups = updatedGroups,
+                            engagementStats = target.engagementStats.copy(
+                                reactions = totalReactions
+                            )
+                        )
+                        if (p.sharedPost != null) p.copy(sharedPost = updatedTarget)
+                        else updatedTarget
+                    } else p
+                },
+                reactionPickerPostId = null
+            )
+        }
+
         viewModelScope.launch {
             val result = if (viewerHasReacted) {
                 repository.removeReactionFromPost(targetPost.id, emoji)
@@ -190,27 +246,27 @@ class TimelineViewModel @Inject constructor(
                 repository.addReactionToPost(targetPost.id, emoji)
             }
 
-            result.onSuccess {
+            result.onFailure {
+                // Revert on failure
                 _uiState.update { state ->
                     state.copy(
                         posts = state.posts.map { p ->
                             val target = p.sharedPost ?: p
                             if (target.id == targetPost.id) {
-                                val updatedGroups = updateReactionGroups(
-                                    target.reactionGroups, emoji, viewerHasReacted
+                                val revertedGroups = updateReactionGroups(
+                                    target.reactionGroups, emoji, !viewerHasReacted
                                 )
-                                val totalReactions = updatedGroups.sumOf { it.count }
-                                val updatedTarget = target.copy(
-                                    reactionGroups = updatedGroups,
+                                val totalReactions = revertedGroups.sumOf { it.count }
+                                val revertedTarget = target.copy(
+                                    reactionGroups = revertedGroups,
                                     engagementStats = target.engagementStats.copy(
                                         reactions = totalReactions
                                     )
                                 )
-                                if (p.sharedPost != null) p.copy(sharedPost = updatedTarget)
-                                else updatedTarget
+                                if (p.sharedPost != null) p.copy(sharedPost = revertedTarget)
+                                else revertedTarget
                             } else p
-                        },
-                        reactionPickerPostId = null
+                        }
                     )
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,7 @@
     <string name="replying_to">Replying to</string>
     <string name="read_more">Read more</string>
     <string name="open_in_browser">Open in browser</string>
+    <string name="download">Download</string>
     <string name="translate">Translate</string>
     <string name="show_original">Show original</string>
     <string name="translating">Translating...</string>


### PR DESCRIPTION
## Summary

A comprehensive set of UX improvements based on user feedback from the first closed testing phase. Key changes include:

- **Engagement bar**: Tap heart to favourite (❤️), long-press for emoji picker. Tap repost to share, long-press for repost/quote menu. Optimistic UI updates for both.
- **Media**: Redesigned grid layout (1/2/3/4+ images), horizontal carousel in post detail, zoomable fullscreen preview with alt text, video attachment support with play overlay, download option on long-press.
- **Post detail**: Evenly spaced action icons, inline translate text, network-first fetch for fresh reply counts, clickable reply target text.
- **Compose**: Quoted post preview with quote icon, auto-focus text field, cursor placed at end of mention prefix.
- **Navigation**: Scroll-to-top/refresh on home tab re-tap.
- **Rendering**: Ruby tag (furigana) support for East Asian text.