### PR TITLE
Fix assetlinks package name and fingerprint

### DIFF
--- a/docs/.well-known/assetlinks.json
+++ b/docs/.well-known/assetlinks.json
@@ -6,9 +6,9 @@
     ],
     "target": {
       "namespace": "android_app",
-      "package_name": "pub.hackers.app",
+      "package_name": "pub.hackers.android",
       "sha256_cert_fingerprints": [
-        "52:A0:14:21:02:CD:30:FD:8B:29:A3:ED:80:2B:0A:BE:AF:AB:37:29:79:39:84:1A:B7:9E:39:05:AF:64:D5:1A"
+        "AD:C6:2C:B4:7B:C0:7D:26:48:D5:C8:E5:51:88:BF:1E:82:33:B4:CC:5A:A3:74:49:25:D0:C4:3C:32:D7:12:BB"
       ]
     }
   }


### PR DESCRIPTION
## Summary

Update `assetlinks.json` with the correct package name (`pub.hackers.android`) and SHA256 release signing fingerprint to enable Android App Links verification for deep linking.