### PR TITLE
Add passkey (WebAuthn) authentication

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,6 +113,8 @@ dependencies {
     implementation(libs.mlkit.language.id)
 
     implementation("androidx.browser:browser:1.8.0")
+    implementation("androidx.credentials:credentials:1.5.0-rc01")
+    implementation("androidx.credentials:credentials-play-services-auth:1.5.0-rc01")
 
     debugImplementation(libs.androidx.ui.tooling)
 }

--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -398,6 +398,59 @@ mutation CompleteLoginChallenge($token: UUID!, $code: String!) {
     }
 }
 
+mutation GetPasskeyAuthenticationOptions($sessionId: UUID!) {
+    getPasskeyAuthenticationOptions(sessionId: $sessionId)
+}
+
+mutation LoginByPasskey($sessionId: UUID!, $authenticationResponse: JSON!, $platform: String = "android") {
+    loginByPasskey(sessionId: $sessionId, authenticationResponse: $authenticationResponse, platform: $platform) {
+        id
+        account {
+            id
+            username
+            name
+            avatarUrl
+            handle
+        }
+    }
+}
+
+mutation GetPasskeyRegistrationOptions($accountId: ID!) {
+    getPasskeyRegistrationOptions(accountId: $accountId)
+}
+
+mutation VerifyPasskeyRegistration($accountId: ID!, $name: String!, $registrationResponse: JSON!, $platform: String = "android") {
+    verifyPasskeyRegistration(accountId: $accountId, name: $name, registrationResponse: $registrationResponse, platform: $platform) {
+        verified
+        passkey {
+            id
+            name
+            created
+            lastUsed
+        }
+    }
+}
+
+mutation RevokePasskey($passkeyId: ID!) {
+    revokePasskey(passkeyId: $passkeyId)
+}
+
+query ViewerPasskeys {
+    viewer {
+        id
+        passkeys(first: 50) {
+            edges {
+                node {
+                    id
+                    name
+                    created
+                    lastUsed
+                }
+            }
+        }
+    }
+}
+
 mutation CreateNote($content: Markdown!, $language: Locale!, $visibility: PostVisibility!, $replyTargetId: ID, $quotedPostId: ID) {
     createNote(input: { content: $content, language: $language, visibility: $visibility, replyTargetId: $replyTargetId, quotedPostId: $quotedPostId }) {
         ... on CreateNotePayload {

--- a/app/src/main/graphql/pub/hackers/android/schema.graphqls
+++ b/app/src/main/graphql/pub/hackers/android/schema.graphqls
@@ -626,6 +626,8 @@ type Mutation {
 
     """Temporary session ID used for authentication options."""
     sessionId: UUID!
+
+    platform: String = "web"
   ): Session
   loginByUsername(
     """The locale for the sign-in email."""
@@ -658,7 +660,7 @@ type Mutation {
   unsharePost(input: UnsharePostInput!): UnsharePostResult!
   updateAccount(input: UpdateAccountInput!): UpdateAccountPayload!
   uploadMedia(input: UploadMediaInput!): UploadMediaResult!
-  verifyPasskeyRegistration(accountId: ID!, name: String!, registrationResponse: JSON!): PasskeyRegistrationResult!
+  verifyPasskeyRegistration(accountId: ID!, name: String!, registrationResponse: JSON!, platform: String = "web"): PasskeyRegistrationResult!
 }
 
 interface Node {

--- a/app/src/main/java/pub/hackers/android/FeatureFlags.kt
+++ b/app/src/main/java/pub/hackers/android/FeatureFlags.kt
@@ -1,0 +1,5 @@
+package pub.hackers.android
+
+object FeatureFlags {
+    const val PASSKEY_AUTH_ENABLED = false
+}

--- a/app/src/main/java/pub/hackers/android/data/auth/PasskeyManager.kt
+++ b/app/src/main/java/pub/hackers/android/data/auth/PasskeyManager.kt
@@ -1,0 +1,52 @@
+package pub.hackers.android.data.auth
+
+import android.app.Activity
+import android.content.Context
+import androidx.credentials.CreatePublicKeyCredentialRequest
+import androidx.credentials.CreatePublicKeyCredentialResponse
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.PublicKeyCredential
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PasskeyManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val credentialManager = CredentialManager.create(context)
+
+    suspend fun authenticate(optionsJson: String, activity: Activity): String {
+        android.util.Log.d("PasskeyAuth", "authenticate: creating request with options: ${optionsJson.take(200)}")
+        val request = GetCredentialRequest(
+            listOf(GetPublicKeyCredentialOption(optionsJson))
+        )
+        android.util.Log.d("PasskeyAuth", "authenticate: calling getCredential")
+        try {
+            val result = credentialManager.getCredential(activity, request)
+            android.util.Log.d("PasskeyAuth", "authenticate: got result, credential type=${result.credential.type}")
+            val credential = result.credential as PublicKeyCredential
+            android.util.Log.d("PasskeyAuth", "authenticate: success")
+            return credential.authenticationResponseJson
+        } catch (e: Exception) {
+            android.util.Log.e("PasskeyAuth", "authenticate: failed", e)
+            throw e
+        }
+    }
+
+    suspend fun register(optionsJson: String, activity: Activity): String {
+        android.util.Log.d("PasskeyAuth", "register: creating request")
+        val request = CreatePublicKeyCredentialRequest(optionsJson)
+        try {
+            val result = credentialManager.createCredential(activity, request)
+            android.util.Log.d("PasskeyAuth", "register: success")
+            val credential = result as CreatePublicKeyCredentialResponse
+            return credential.registrationResponseJson
+        } catch (e: Exception) {
+            android.util.Log.e("PasskeyAuth", "register: failed", e)
+            throw e
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -11,8 +11,11 @@ import pub.hackers.android.graphql.BlockActorMutation
 import pub.hackers.android.graphql.CompleteLoginChallengeMutation
 import pub.hackers.android.graphql.CreateNoteMutation
 import pub.hackers.android.graphql.DeletePostMutation
+import pub.hackers.android.graphql.GetPasskeyAuthenticationOptionsMutation
+import pub.hackers.android.graphql.GetPasskeyRegistrationOptionsMutation
 import pub.hackers.android.graphql.FollowActorMutation
 import pub.hackers.android.graphql.LocalTimelineQuery
+import pub.hackers.android.graphql.LoginByPasskeyMutation
 import pub.hackers.android.graphql.LoginByUsernameMutation
 import pub.hackers.android.graphql.NotificationsQuery
 import pub.hackers.android.graphql.PersonalTimelineQuery
@@ -22,7 +25,10 @@ import pub.hackers.android.graphql.PostDetailQuery
 import pub.hackers.android.graphql.PublicTimelineQuery
 import pub.hackers.android.graphql.RemoveFollowerMutation
 import pub.hackers.android.graphql.RemoveReactionFromPostMutation
+import pub.hackers.android.graphql.RevokePasskeyMutation
 import pub.hackers.android.graphql.RevokeSessionMutation
+import pub.hackers.android.graphql.ViewerPasskeysQuery
+import pub.hackers.android.graphql.VerifyPasskeyRegistrationMutation
 import pub.hackers.android.graphql.SearchActorsByHandleQuery
 import pub.hackers.android.graphql.SearchObjectQuery
 import pub.hackers.android.graphql.SearchPostQuery
@@ -352,6 +358,167 @@ class HackersPubRepository @Inject constructor(
                         )
                     )
                 )
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getPasskeyAuthenticationOptions(sessionId: String): Result<String> {
+        return try {
+            val response = apolloClient.mutation(
+                GetPasskeyAuthenticationOptionsMutation(sessionId = sessionId)
+            ).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val options = response.data?.getPasskeyAuthenticationOptions
+                    ?: return Result.failure(Exception("Failed to get passkey options"))
+                Result.success(toJsonString(options))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun loginByPasskey(sessionId: String, authenticationResponse: Any): Result<Session> {
+        return try {
+            val response = apolloClient.mutation(
+                LoginByPasskeyMutation(
+                    sessionId = sessionId,
+                    authenticationResponse = authenticationResponse,
+                    platform = Optional.present("android")
+                )
+            ).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val session = response.data?.loginByPasskey
+                    ?: return Result.failure(Exception("Passkey authentication failed"))
+
+                Result.success(
+                    Session(
+                        id = session.id.toString(),
+                        account = Account(
+                            id = session.account.id,
+                            username = session.account.username,
+                            name = session.account.name,
+                            avatarUrl = session.account.avatarUrl.toString(),
+                            handle = session.account.handle
+                        )
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getPasskeyRegistrationOptions(accountId: String): Result<String> {
+        return try {
+            val response = apolloClient.mutation(
+                GetPasskeyRegistrationOptionsMutation(accountId = accountId)
+            ).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val options = response.data?.getPasskeyRegistrationOptions
+                    ?: return Result.failure(Exception("Failed to get registration options"))
+                Result.success(toJsonString(options))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun verifyPasskeyRegistration(
+        accountId: String,
+        name: String,
+        registrationResponse: Any
+    ): Result<PasskeyRegistrationResult> {
+        return try {
+            val response = apolloClient.mutation(
+                VerifyPasskeyRegistrationMutation(
+                    accountId = accountId,
+                    name = name,
+                    registrationResponse = registrationResponse,
+                    platform = Optional.present("android")
+                )
+            ).execute()
+
+            if (response.hasErrors()) {
+                val errors = response.errors?.map { "${it.message} path=${it.path}" }
+                android.util.Log.e("PasskeyAuth", "verifyPasskeyRegistration errors: $errors")
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.verifyPasskeyRegistration
+                    ?: return Result.failure(Exception("Registration verification failed"))
+
+                Result.success(
+                    PasskeyRegistrationResult(
+                        verified = result.verified,
+                        passkey = result.passkey?.let {
+                            Passkey(
+                                id = it.id,
+                                name = it.name,
+                                created = it.created.toString(),
+                                lastUsed = it.lastUsed?.toString()
+                            )
+                        }
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun revokePasskey(passkeyId: String): Result<String?> {
+        return try {
+            val response = apolloClient.mutation(
+                RevokePasskeyMutation(passkeyId = passkeyId)
+            ).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                Result.success(response.data?.revokePasskey)
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    data class PasskeysResult(
+        val accountId: String,
+        val passkeys: List<Passkey>
+    )
+
+    suspend fun getPasskeys(): Result<PasskeysResult> {
+        return try {
+            val response = apolloClient.query(ViewerPasskeysQuery())
+                .fetchPolicy(FetchPolicy.NetworkOnly)
+                .execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val viewer = response.data?.viewer
+                    ?: return Result.failure(Exception("Not authenticated"))
+
+                val passkeys = viewer.passkeys.edges.map { edge ->
+                    Passkey(
+                        id = edge.node.id,
+                        name = edge.node.name,
+                        created = edge.node.created.toString(),
+                        lastUsed = edge.node.lastUsed?.toString()
+                    )
+                }
+
+                Result.success(PasskeysResult(accountId = viewer.id, passkeys = passkeys))
             }
         } catch (e: Exception) {
             Result.failure(e)
@@ -938,6 +1105,39 @@ class HackersPubRepository @Inject constructor(
             GqlPostVisibility.DIRECT -> PostVisibility.DIRECT
             GqlPostVisibility.NONE -> PostVisibility.NONE
             else -> PostVisibility.PUBLIC
+        }
+    }
+
+    private fun toJsonString(obj: Any?): String {
+        return when (obj) {
+            is Map<*, *> -> {
+                val jsonObj = org.json.JSONObject()
+                obj.forEach { (k, v) -> jsonObj.put(k.toString(), toJsonValue(v)) }
+                jsonObj.toString()
+            }
+            is List<*> -> {
+                val jsonArr = org.json.JSONArray()
+                obj.forEach { jsonArr.put(toJsonValue(it)) }
+                jsonArr.toString()
+            }
+            else -> obj.toString()
+        }
+    }
+
+    private fun toJsonValue(value: Any?): Any? {
+        return when (value) {
+            null -> org.json.JSONObject.NULL
+            is Map<*, *> -> {
+                val jsonObj = org.json.JSONObject()
+                value.forEach { (k, v) -> jsonObj.put(k.toString(), toJsonValue(v)) }
+                jsonObj
+            }
+            is List<*> -> {
+                val jsonArr = org.json.JSONArray()
+                value.forEach { jsonArr.put(toJsonValue(it)) }
+                jsonArr
+            }
+            else -> value
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -174,6 +174,18 @@ data class Account(
     val handle: String
 )
 
+data class Passkey(
+    val id: String,
+    val name: String,
+    val created: String,
+    val lastUsed: String?
+)
+
+data class PasskeyRegistrationResult(
+    val verified: Boolean,
+    val passkey: Passkey?
+)
+
 data class TimelineResult(
     val posts: List<Post>,
     val hasNextPage: Boolean,

--- a/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInScreen.kt
@@ -96,7 +96,6 @@ fun SignInScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            val activity = LocalContext.current as Activity
             if (uiState.step == SignInStep.USERNAME) {
                 UsernameStep(
                     username = uiState.username,
@@ -105,10 +104,13 @@ fun SignInScreen(
                         keyboardController?.hide()
                         viewModel.sendVerificationCode()
                     },
-                    onPasskeySignIn = {
-                        keyboardController?.hide()
-                        viewModel.signInWithPasskey(activity)
-                    },
+                    onPasskeySignIn = if (pub.hackers.android.FeatureFlags.PASSKEY_AUTH_ENABLED) {
+                        val activity = LocalContext.current as Activity
+                        {
+                            keyboardController?.hide()
+                            viewModel.signInWithPasskey(activity)
+                        }
+                    } else null,
                     isLoading = uiState.isLoading
                 )
             } else {
@@ -132,7 +134,7 @@ private fun UsernameStep(
     username: String,
     onUsernameChange: (String) -> Unit,
     onSubmit: () -> Unit,
-    onPasskeySignIn: () -> Unit = {},
+    onPasskeySignIn: (() -> Unit)? = null,
     isLoading: Boolean
 ) {
     val colors = LocalAppColors.current
@@ -214,42 +216,44 @@ private fun UsernameStep(
         }
     }
 
-    Spacer(modifier = Modifier.height(16.dp))
+    if (onPasskeySignIn != null) {
+        Spacer(modifier = Modifier.height(16.dp))
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        HorizontalDivider(modifier = Modifier.weight(1f), color = colors.divider)
-        Text(
-            text = stringResource(R.string.or),
-            style = typography.labelMedium,
-            color = colors.textSecondary,
-            modifier = Modifier.padding(horizontal = 16.dp)
-        )
-        HorizontalDivider(modifier = Modifier.weight(1f), color = colors.divider)
-    }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            HorizontalDivider(modifier = Modifier.weight(1f), color = colors.divider)
+            Text(
+                text = stringResource(R.string.or),
+                style = typography.labelMedium,
+                color = colors.textSecondary,
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+            HorizontalDivider(modifier = Modifier.weight(1f), color = colors.divider)
+        }
 
-    Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-    OutlinedButton(
-        onClick = onPasskeySignIn,
-        enabled = !isLoading,
-        shape = RoundedCornerShape(AppShapes.pillRadius),
-        border = BorderStroke(1.dp, colors.divider),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Icon(
-            imageVector = Icons.Default.Fingerprint,
-            contentDescription = null,
-            modifier = Modifier.size(20.dp)
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text = stringResource(R.string.sign_in_with_passkey),
-            style = typography.bodyLarge,
-            color = colors.textPrimary
-        )
+        OutlinedButton(
+            onClick = onPasskeySignIn,
+            enabled = !isLoading,
+            shape = RoundedCornerShape(AppShapes.pillRadius),
+            border = BorderStroke(1.dp, colors.divider),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Icon(
+                imageVector = Icons.Default.Fingerprint,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = stringResource(R.string.sign_in_with_passkey),
+                style = typography.bodyLarge,
+                color = colors.textPrimary
+            )
+        }
     }
 }
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInScreen.kt
@@ -1,7 +1,10 @@
 package pub.hackers.android.ui.screens.auth
 
+import android.app.Activity
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,12 +12,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
@@ -30,6 +39,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -86,6 +96,7 @@ fun SignInScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
+            val activity = LocalContext.current as Activity
             if (uiState.step == SignInStep.USERNAME) {
                 UsernameStep(
                     username = uiState.username,
@@ -93,6 +104,10 @@ fun SignInScreen(
                     onSubmit = {
                         keyboardController?.hide()
                         viewModel.sendVerificationCode()
+                    },
+                    onPasskeySignIn = {
+                        keyboardController?.hide()
+                        viewModel.signInWithPasskey(activity)
                     },
                     isLoading = uiState.isLoading
                 )
@@ -117,6 +132,7 @@ private fun UsernameStep(
     username: String,
     onUsernameChange: (String) -> Unit,
     onSubmit: () -> Unit,
+    onPasskeySignIn: () -> Unit = {},
     isLoading: Boolean
 ) {
     val colors = LocalAppColors.current
@@ -196,6 +212,44 @@ private fun UsernameStep(
                 style = typography.bodyLarge,
             )
         }
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        HorizontalDivider(modifier = Modifier.weight(1f), color = colors.divider)
+        Text(
+            text = stringResource(R.string.or),
+            style = typography.labelMedium,
+            color = colors.textSecondary,
+            modifier = Modifier.padding(horizontal = 16.dp)
+        )
+        HorizontalDivider(modifier = Modifier.weight(1f), color = colors.divider)
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    OutlinedButton(
+        onClick = onPasskeySignIn,
+        enabled = !isLoading,
+        shape = RoundedCornerShape(AppShapes.pillRadius),
+        border = BorderStroke(1.dp, colors.divider),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Icon(
+            imageVector = Icons.Default.Fingerprint,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = stringResource(R.string.sign_in_with_passkey),
+            style = typography.bodyLarge,
+            color = colors.textPrimary
+        )
     }
 }
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInViewModel.kt
@@ -8,8 +8,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import android.app.Activity
+import pub.hackers.android.data.auth.PasskeyManager
 import pub.hackers.android.data.local.SessionManager
 import pub.hackers.android.data.repository.HackersPubRepository
+import java.util.UUID
 import javax.inject.Inject
 
 enum class SignInStep {
@@ -30,7 +33,8 @@ data class SignInUiState(
 @HiltViewModel
 class SignInViewModel @Inject constructor(
     private val repository: HackersPubRepository,
-    private val sessionManager: SessionManager
+    private val sessionManager: SessionManager,
+    private val passkeyManager: PasskeyManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SignInUiState())
@@ -140,6 +144,49 @@ class SignInViewModel @Inject constructor(
         }
     }
 
+    fun signInWithPasskey(activity: Activity) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+
+            try {
+                val sessionId = UUID.randomUUID().toString()
+                android.util.Log.d("PasskeyAuth", "Step 1: Getting options for sessionId=$sessionId")
+
+                val optionsJson = repository.getPasskeyAuthenticationOptions(sessionId)
+                    .getOrThrow()
+                android.util.Log.d("PasskeyAuth", "Step 2: Got options: $optionsJson")
+
+                val authResponse = passkeyManager.authenticate(optionsJson, activity)
+                android.util.Log.d("PasskeyAuth", "Step 3: Got auth response: $authResponse")
+
+                val authResponseMap = jsonToMap(org.json.JSONObject(authResponse))
+                android.util.Log.d("PasskeyAuth", "Step 4: Sending loginByPasskey")
+
+                val session = repository.loginByPasskey(sessionId, authResponseMap)
+                    .getOrThrow()
+                android.util.Log.d("PasskeyAuth", "Step 5: Login success, session=${session.id}")
+
+                sessionManager.saveSession(
+                    token = session.id,
+                    userId = session.account.id,
+                    username = session.account.username,
+                    handle = session.account.handle,
+                    name = session.account.name,
+                    avatarUrl = session.account.avatarUrl
+                )
+                _uiState.update { it.copy(isLoading = false, isSignedIn = true) }
+            } catch (e: Exception) {
+                android.util.Log.e("PasskeyAuth", "Passkey auth failed", e)
+                _uiState.update {
+                    it.copy(
+                        error = e.message ?: "Passkey authentication failed",
+                        isLoading = false
+                    )
+                }
+            }
+        }
+    }
+
     fun goBackToUsername() {
         _uiState.update {
             it.copy(
@@ -152,5 +199,32 @@ class SignInViewModel @Inject constructor(
 
     fun clearError() {
         _uiState.update { it.copy(error = null) }
+    }
+
+    private fun jsonToMap(json: org.json.JSONObject): Map<String, Any?> {
+        val map = mutableMapOf<String, Any?>()
+        val keys = json.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            val value = json.get(key)
+            map[key] = when (value) {
+                is org.json.JSONObject -> jsonToMap(value)
+                is org.json.JSONArray -> jsonToList(value)
+                org.json.JSONObject.NULL -> null
+                else -> value
+            }
+        }
+        return map
+    }
+
+    private fun jsonToList(array: org.json.JSONArray): List<Any?> {
+        return (0 until array.length()).map { i ->
+            when (val value = array.get(i)) {
+                is org.json.JSONObject -> jsonToMap(value)
+                is org.json.JSONArray -> jsonToList(value)
+                org.json.JSONObject.NULL -> null
+                else -> value
+            }
+        }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
@@ -69,9 +69,10 @@ fun SettingsScreen(
     var showRevokePasskeyId by remember { mutableStateOf<String?>(null) }
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
+    val passkeyEnabled = pub.hackers.android.FeatureFlags.PASSKEY_AUTH_ENABLED
 
-    LaunchedEffect(isLoggedIn) {
-        if (isLoggedIn) viewModel.loadPasskeys()
+    LaunchedEffect(isLoggedIn, passkeyEnabled) {
+        if (isLoggedIn && passkeyEnabled) viewModel.loadPasskeys()
     }
 
     LaunchedEffect(uiState.isSignedOut) {
@@ -181,6 +182,7 @@ fun SettingsScreen(
                     )
                 }
 
+                if (passkeyEnabled) {
                 HorizontalDivider(color = colors.divider, thickness = 1.dp)
 
                 // Passkeys section
@@ -260,6 +262,7 @@ fun SettingsScreen(
                         }
                     }
                 }
+                } // passkeyEnabled
             } else {
                 Row(
                     modifier = Modifier
@@ -335,7 +338,7 @@ fun SettingsScreen(
     }
 
     // Add passkey dialog
-    if (showAddPasskeyDialog) {
+    if (passkeyEnabled && showAddPasskeyDialog) {
         var passkeyName by remember { mutableStateOf("") }
         val activity = LocalContext.current as Activity
 
@@ -375,7 +378,7 @@ fun SettingsScreen(
     }
 
     // Revoke passkey confirmation dialog
-    if (showRevokePasskeyId != null) {
+    if (passkeyEnabled && showRevokePasskeyId != null) {
         AlertDialog(
             onDismissRequest = { showRevokePasskeyId = null },
             title = { Text(stringResource(R.string.remove_passkey)) },

--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
@@ -1,24 +1,34 @@
 package pub.hackers.android.ui.screens.settings
 
+import android.app.Activity
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Login
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -38,6 +48,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -54,8 +65,14 @@ fun SettingsScreen(
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     var showSignOutDialog by remember { mutableStateOf(false) }
+    var showAddPasskeyDialog by remember { mutableStateOf(false) }
+    var showRevokePasskeyId by remember { mutableStateOf<String?>(null) }
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
+
+    LaunchedEffect(isLoggedIn) {
+        if (isLoggedIn) viewModel.loadPasskeys()
+    }
 
     LaunchedEffect(uiState.isSignedOut) {
         if (uiState.isSignedOut) {
@@ -163,6 +180,86 @@ fun SettingsScreen(
                         color = colors.textPrimary
                     )
                 }
+
+                HorizontalDivider(color = colors.divider, thickness = 1.dp)
+
+                // Passkeys section
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.Fingerprint,
+                            contentDescription = null,
+                            tint = colors.textSecondary
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Text(
+                            text = stringResource(R.string.passkeys),
+                            style = typography.bodyLarge,
+                            color = colors.textPrimary
+                        )
+                    }
+                    IconButton(onClick = { showAddPasskeyDialog = true }) {
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = stringResource(R.string.add_passkey),
+                            tint = colors.accent
+                        )
+                    }
+                }
+
+                if (uiState.isLoadingPasskeys) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    }
+                } else if (uiState.passkeys.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.no_passkeys),
+                        style = typography.bodyMedium,
+                        color = colors.textSecondary,
+                        modifier = Modifier.padding(horizontal = 56.dp, vertical = 8.dp)
+                    )
+                } else {
+                    uiState.passkeys.forEach { passkey ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(start = 56.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = passkey.name,
+                                    style = typography.bodyMedium,
+                                    color = colors.textPrimary
+                                )
+                                Text(
+                                    text = passkey.created,
+                                    style = typography.labelSmall,
+                                    color = colors.textSecondary
+                                )
+                            }
+                            IconButton(onClick = { showRevokePasskeyId = passkey.id }) {
+                                Icon(
+                                    imageVector = Icons.Default.Delete,
+                                    contentDescription = stringResource(R.string.remove),
+                                    tint = colors.reaction
+                                )
+                            }
+                        }
+                    }
+                }
             } else {
                 Row(
                     modifier = Modifier
@@ -235,5 +332,67 @@ fun SettingsScreen(
                 }
             }
         }
+    }
+
+    // Add passkey dialog
+    if (showAddPasskeyDialog) {
+        var passkeyName by remember { mutableStateOf("") }
+        val activity = LocalContext.current as Activity
+
+        AlertDialog(
+            onDismissRequest = { showAddPasskeyDialog = false },
+            title = { Text(stringResource(R.string.add_passkey)) },
+            text = {
+                OutlinedTextField(
+                    value = passkeyName,
+                    onValueChange = { passkeyName = it },
+                    placeholder = { Text(stringResource(R.string.passkey_name_hint)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = colors.accent,
+                        cursorColor = colors.accent
+                    )
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showAddPasskeyDialog = false
+                        viewModel.registerPasskey(passkeyName.ifBlank { "Android" }, activity)
+                    },
+                    enabled = !uiState.isRegisteringPasskey
+                ) {
+                    Text(stringResource(R.string.add))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showAddPasskeyDialog = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    // Revoke passkey confirmation dialog
+    if (showRevokePasskeyId != null) {
+        AlertDialog(
+            onDismissRequest = { showRevokePasskeyId = null },
+            title = { Text(stringResource(R.string.remove_passkey)) },
+            text = { Text(stringResource(R.string.remove_passkey_confirm)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.revokePasskey(showRevokePasskeyId!!)
+                    showRevokePasskeyId = null
+                }) {
+                    Text(stringResource(R.string.remove), color = colors.reaction)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRevokePasskeyId = null }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsViewModel.kt
@@ -17,9 +17,12 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import android.app.Activity
+import pub.hackers.android.data.auth.PasskeyManager
 import pub.hackers.android.data.local.PreferencesManager
 import pub.hackers.android.data.local.SessionManager
 import pub.hackers.android.data.repository.HackersPubRepository
+import pub.hackers.android.domain.model.Passkey
 import javax.inject.Inject
 
 data class SettingsUiState(
@@ -34,7 +37,11 @@ data class SettingsUiState(
     val confirmBeforeShare: Boolean = false,
     val timelineMaxLength: Int = 0,
     val useInAppBrowser: Boolean = true,
-    val fontSizePercent: Int = 100
+    val fontSizePercent: Int = 100,
+    val passkeys: List<Passkey> = emptyList(),
+    val accountId: String? = null,
+    val isLoadingPasskeys: Boolean = false,
+    val isRegisteringPasskey: Boolean = false
 )
 
 @HiltViewModel
@@ -44,6 +51,7 @@ class SettingsViewModel @Inject constructor(
     private val repository: HackersPubRepository,
     private val apolloClient: ApolloClient,
     private val notificationStateManager: NotificationStateManager,
+    private val passkeyManager: PasskeyManager,
     private val workManager: WorkManager,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
@@ -189,5 +197,124 @@ class SettingsViewModel @Inject constructor(
 
     fun clearMessage() {
         _uiState.update { it.copy(message = null) }
+    }
+
+    fun loadPasskeys() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingPasskeys = true) }
+            repository.getPasskeys()
+                .onSuccess { result ->
+                    _uiState.update {
+                        it.copy(
+                            passkeys = result.passkeys,
+                            accountId = result.accountId,
+                            isLoadingPasskeys = false
+                        )
+                    }
+                }
+                .onFailure {
+                    _uiState.update { it.copy(isLoadingPasskeys = false) }
+                }
+        }
+    }
+
+    fun registerPasskey(name: String, activity: Activity) {
+        val accountId = _uiState.value.accountId ?: run {
+            android.util.Log.e("PasskeyAuth", "registerPasskey: accountId is null")
+            return
+        }
+        viewModelScope.launch {
+            _uiState.update { it.copy(isRegisteringPasskey = true) }
+            try {
+                android.util.Log.d("PasskeyAuth", "registerPasskey: getting options for accountId=$accountId")
+                val optionsJson = repository.getPasskeyRegistrationOptions(accountId)
+                    .getOrThrow()
+                android.util.Log.d("PasskeyAuth", "registerPasskey: got options")
+
+                val registrationResponse = passkeyManager.register(optionsJson, activity)
+                android.util.Log.d("PasskeyAuth", "registerPasskey: got registration response: ${registrationResponse.take(200)}")
+
+                // Parse and re-serialize to ensure clean JSON, then convert to Map for Apollo
+                val jsonObj = org.json.JSONObject(registrationResponse)
+                android.util.Log.d("PasskeyAuth", "registerPasskey: JSON keys: ${jsonObj.keys().asSequence().toList()}")
+                android.util.Log.d("PasskeyAuth", "registerPasskey: response.keys: ${org.json.JSONObject(jsonObj.getString("response")).keys().asSequence().toList()}")
+
+                val responseMap = jsonToMap(jsonObj)
+                android.util.Log.d("PasskeyAuth", "registerPasskey: verifying with server, name=$name, map keys=${responseMap.keys}")
+
+                val result = repository.verifyPasskeyRegistration(accountId, name, responseMap)
+                    .getOrThrow()
+                android.util.Log.d("PasskeyAuth", "registerPasskey: verified=${result.verified}")
+
+                if (result.verified) {
+                    _uiState.update {
+                        it.copy(
+                            message = "Passkey registered",
+                            isRegisteringPasskey = false
+                        )
+                    }
+                    loadPasskeys()
+                } else {
+                    _uiState.update {
+                        it.copy(
+                            message = "Passkey registration failed",
+                            isRegisteringPasskey = false
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("PasskeyAuth", "registerPasskey: failed", e)
+                _uiState.update {
+                    it.copy(
+                        message = e.message ?: "Passkey registration failed",
+                        isRegisteringPasskey = false
+                    )
+                }
+            }
+        }
+    }
+
+    fun revokePasskey(passkeyId: String) {
+        viewModelScope.launch {
+            repository.revokePasskey(passkeyId)
+                .onSuccess {
+                    _uiState.update { state ->
+                        state.copy(
+                            passkeys = state.passkeys.filter { it.id != passkeyId },
+                            message = "Passkey removed"
+                        )
+                    }
+                }
+                .onFailure {
+                    _uiState.update { it.copy(message = "Failed to remove passkey") }
+                }
+        }
+    }
+
+    private fun jsonToMap(json: org.json.JSONObject): Map<String, Any?> {
+        val map = mutableMapOf<String, Any?>()
+        val keys = json.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            val value = json.get(key)
+            map[key] = when (value) {
+                is org.json.JSONObject -> jsonToMap(value)
+                is org.json.JSONArray -> jsonToList(value)
+                org.json.JSONObject.NULL -> null
+                else -> value
+            }
+        }
+        return map
+    }
+
+    private fun jsonToList(array: org.json.JSONArray): List<Any?> {
+        return (0 until array.length()).map { i ->
+            when (val value = array.get(i)) {
+                is org.json.JSONObject -> jsonToMap(value)
+                is org.json.JSONArray -> jsonToList(value)
+                org.json.JSONObject.NULL -> null
+                else -> value
+            }
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,16 @@
     <string name="send_code">Send Code</string>
     <string name="verify">Verify</string>
     <string name="account_not_found">Account not found</string>
+    <string name="or">or</string>
+    <string name="sign_in_with_passkey">Sign in with Passkey</string>
+    <string name="passkeys">Passkeys</string>
+    <string name="add_passkey">Add Passkey</string>
+    <string name="no_passkeys">No passkeys registered</string>
+    <string name="passkey_name_hint">Passkey name (e.g. My Phone)</string>
+    <string name="remove_passkey">Remove Passkey</string>
+    <string name="remove_passkey_confirm">Are you sure you want to remove this passkey?</string>
+    <string name="remove">Remove</string>
+    <string name="add">Add</string>
 
     <!-- Timeline -->
     <string name="local_timeline">Hackers\' Pub</string>


### PR DESCRIPTION
## Summary

Implement passkey authentication using Android's Credential Manager API with the existing server-side WebAuthn support. Users can sign in with biometric/PIN via passkeys and manage registered passkeys from Settings.

- **Sign-in**: "Sign in with Passkey" button on login screen with fingerprint icon, triggers biometric prompt
- **Registration**: Add passkeys from Settings with custom name, verified against server
- **Management**: List and revoke registered passkeys in Settings
- **Platform**: Passes `platform: "android"` to server for origin matching
- **Feature flag**: All passkey UI is gated behind `FeatureFlags.PASSKEY_AUTH_ENABLED` (default `false`) until server-side support is deployed