### PR TITLE
Fix duplicate post crash in LazyColumn

### DIFF
--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -59,7 +59,7 @@ class HackersPubRepository @Inject constructor(
                     TimelineResult(
                         posts = data?.edges?.mapNotNull { edge ->
                             edge.node.postFields.toPost(edge.node.sharedPost?.sharedPostFields?.toPost())
-                        } ?: emptyList(),
+                        }?.distinctBy { it.id } ?: emptyList(),
                         hasNextPage = data?.pageInfo?.hasNextPage ?: false,
                         endCursor = data?.pageInfo?.endCursor
                     )
@@ -84,7 +84,7 @@ class HackersPubRepository @Inject constructor(
                     TimelineResult(
                         posts = data?.edges?.mapNotNull { edge ->
                             edge.node.postFields.toPost(edge.node.sharedPost?.sharedPostFields?.toPost())
-                        } ?: emptyList(),
+                        }?.distinctBy { it.id } ?: emptyList(),
                         hasNextPage = data?.pageInfo?.hasNextPage ?: false,
                         endCursor = data?.pageInfo?.endCursor
                     )

--- a/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreViewModel.kt
@@ -146,7 +146,7 @@ class ExploreViewModel @Inject constructor(
                 .onSuccess { data ->
                     _uiState.update {
                         it.copy(
-                            posts = it.posts + data.posts,
+                            posts = (it.posts + data.posts).distinctBy { p -> p.id },
                             hasNextPage = data.hasNextPage,
                             endCursor = data.endCursor,
                             isLoadingMore = false

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -198,7 +198,7 @@ fun TimelineScreen(
                         ) {
                             items(
                                 items = uiState.posts,
-                                key = { "${it.id}_${it.sharedPost?.id.orEmpty()}" }
+                                key = { it.id }
                             ) { post ->
                                 PostCard(
                                     post = post,

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
@@ -114,7 +114,7 @@ class TimelineViewModel @Inject constructor(
                 .onSuccess { result ->
                     _uiState.update {
                         it.copy(
-                            posts = it.posts + result.posts,
+                            posts = (it.posts + result.posts).distinctBy { p -> p.id },
                             hasNextPage = result.hasNextPage,
                             endCursor = result.endCursor,
                             isLoadingMore = false


### PR DESCRIPTION
## Summary

Deduplicate posts by ID at both the repository and ViewModel levels to prevent `IllegalArgumentException: Key was already used` crashes when scrolling the timeline. The same post can appear multiple times in the API response (e.g., as both a direct post and a repost), causing duplicate LazyColumn keys.