### PR TITLE
Fix removeLast() crash on pre-API 35 devices

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
@@ -458,7 +458,8 @@ private fun parseHtmlToAnnotatedString(
 
                         "ul", "ol" -> {
                             if (listStack.isNotEmpty()) {
-                                listStack.removeLast()
+                                // Use removeAt instead of removeLast to avoid Java 21 SequencedCollection dependency
+                                listStack.removeAt(listStack.lastIndex)
                             }
                             insideListItem = false
                             if (listStack.isEmpty() && hasContent) {


### PR DESCRIPTION
## Summary
- Replace `List.removeLast()` with `removeAt(lastIndex)` in `HtmlContent.kt` to fix `NoSuchMethodError` crash on Android versions older than 15 (API 35)
- `removeLast()` resolves to Java 21's `SequencedCollection.removeLast()` which is unavailable on older devices

## Test plan
- [ ] Open notifications screen on a device running Android 14 or lower
- [ ] Verify HTML content with lists renders without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)