### PR TITLE
Fix HtmlContent modifier parameter order and add unit tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,5 +114,7 @@ dependencies {
 
     implementation("androidx.browser:browser:1.8.0")
 
+    testImplementation(libs.junit)
+
     debugImplementation(libs.androidx.ui.tooling)
 }

--- a/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
@@ -1,5 +1,6 @@
 package pub.hackers.android.ui.components
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -33,7 +34,7 @@ private enum class LinkType {
 
 private data class ListContext(val ordered: Boolean, var itemIndex: Int = 0)
 
-private sealed class ContentBlock {
+internal sealed class ContentBlock {
     data class Text(val html: String) : ContentBlock()
     data class Code(val codeHtml: String) : ContentBlock()
 }
@@ -48,8 +49,8 @@ private val PRE_CODE_REGEX = Regex(
 @Composable
 fun HtmlContent(
     html: String,
-    maxLines: Int = Int.MAX_VALUE,
     modifier: Modifier = Modifier,
+    maxLines: Int = Int.MAX_VALUE,
     fontScale: Float = 1f,
     onMentionClick: ((handle: String) -> Unit)? = null,
     onLinkClick: ((url: String) -> Unit)? = null,
@@ -153,7 +154,8 @@ private fun handleClick(
     onTextClick?.invoke()
 }
 
-private fun splitIntoBlocks(html: String): List<ContentBlock> {
+@VisibleForTesting
+internal fun splitIntoBlocks(html: String): List<ContentBlock> {
     val blocks = mutableListOf<ContentBlock>()
     var lastEnd = 0
     val source = html.trim()
@@ -183,7 +185,8 @@ private fun splitIntoBlocks(html: String): List<ContentBlock> {
     return blocks
 }
 
-private fun extractHandleFromUrl(url: String): String? {
+@VisibleForTesting
+internal fun extractHandleFromUrl(url: String): String? {
     return try {
         val uri = URI(url)
         val host = uri.host ?: return null
@@ -195,7 +198,8 @@ private fun extractHandleFromUrl(url: String): String? {
     }
 }
 
-private fun parseHtmlToAnnotatedString(
+@VisibleForTesting
+internal fun parseHtmlToAnnotatedString(
     html: String,
     linkColor: Color,
     mentionBg: Color,
@@ -545,7 +549,8 @@ private fun parseAttributes(attrString: String): Map<String, String> {
     return attrs
 }
 
-private fun decodeHtmlEntities(text: String): String {
+@VisibleForTesting
+internal fun decodeHtmlEntities(text: String): String {
     return text
         .replace("&nbsp;", " ")
         .replace("&amp;", "&")

--- a/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
@@ -458,7 +458,8 @@ private fun parseHtmlToAnnotatedString(
 
                         "ul", "ol" -> {
                             if (listStack.isNotEmpty()) {
-                                listStack.removeLast()
+                                // Use removeAt instead of removeLast to avoid Java 21 SequencedCollection dependency
+                                listStack.removeAt(listStack.lastIndex)
                             }
                             insideListItem = false
                             if (listStack.isEmpty() && hasContent) {

--- a/app/src/test/java/pub/hackers/android/ui/components/HtmlContentKtTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/components/HtmlContentKtTest.kt
@@ -1,0 +1,206 @@
+package pub.hackers.android.ui.components
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HtmlContentKtTest {
+
+    // region decodeHtmlEntities
+
+    @Test
+    fun `decodeHtmlEntities decodes amp`() {
+        assertEquals("A & B", decodeHtmlEntities("A &amp; B"))
+    }
+
+    @Test
+    fun `decodeHtmlEntities decodes lt and gt`() {
+        assertEquals("<div>", decodeHtmlEntities("&lt;div&gt;"))
+    }
+
+    @Test
+    fun `decodeHtmlEntities decodes quot`() {
+        assertEquals("say \"hello\"", decodeHtmlEntities("say &quot;hello&quot;"))
+    }
+
+    @Test
+    fun `decodeHtmlEntities decodes apos and numeric apos`() {
+        assertEquals("it's it's", decodeHtmlEntities("it&apos;s it&#39;s"))
+    }
+
+    @Test
+    fun `decodeHtmlEntities decodes nbsp`() {
+        assertEquals("a b", decodeHtmlEntities("a&nbsp;b"))
+    }
+
+    @Test
+    fun `decodeHtmlEntities returns plain text unchanged`() {
+        assertEquals("hello world", decodeHtmlEntities("hello world"))
+    }
+
+    // endregion
+
+    // region extractHandleFromUrl
+
+    @Test
+    fun `extractHandleFromUrl extracts handle from profile url`() {
+        assertEquals("alice@example.com", extractHandleFromUrl("https://example.com/alice"))
+    }
+
+    @Test
+    fun `extractHandleFromUrl extracts handle with at prefix`() {
+        assertEquals("alice@example.com", extractHandleFromUrl("https://example.com/@alice"))
+    }
+
+    @Test
+    fun `extractHandleFromUrl returns null for empty path`() {
+        assertNull(extractHandleFromUrl("https://example.com/"))
+    }
+
+    @Test
+    fun `extractHandleFromUrl returns null for invalid url`() {
+        assertNull(extractHandleFromUrl("not a url"))
+    }
+
+    // endregion
+
+    // region splitIntoBlocks
+
+    @Test
+    fun `splitIntoBlocks returns single text block for plain html`() {
+        val blocks = splitIntoBlocks("<p>Hello</p>")
+        assertEquals(1, blocks.size)
+        assertTrue(blocks[0] is ContentBlock.Text)
+    }
+
+    @Test
+    fun `splitIntoBlocks extracts code block`() {
+        val html = "<p>before</p><pre><code>val x = 1</code></pre><p>after</p>"
+        val blocks = splitIntoBlocks(html)
+        assertEquals(3, blocks.size)
+        assertTrue(blocks[0] is ContentBlock.Text)
+        assertTrue(blocks[1] is ContentBlock.Code)
+        assertTrue(blocks[2] is ContentBlock.Text)
+        assertEquals("val x = 1", (blocks[1] as ContentBlock.Code).codeHtml)
+    }
+
+    @Test
+    fun `splitIntoBlocks handles multiple code blocks`() {
+        val html = "<pre><code>a</code></pre><p>mid</p><pre><code>b</code></pre>"
+        val blocks = splitIntoBlocks(html)
+        assertEquals(3, blocks.size)
+        assertTrue(blocks[0] is ContentBlock.Code)
+        assertTrue(blocks[1] is ContentBlock.Text)
+        assertTrue(blocks[2] is ContentBlock.Code)
+    }
+
+    @Test
+    fun `splitIntoBlocks handles code-only content`() {
+        val html = "<pre><code>only code</code></pre>"
+        val blocks = splitIntoBlocks(html)
+        assertEquals(1, blocks.size)
+        assertTrue(blocks[0] is ContentBlock.Code)
+    }
+
+    // endregion
+
+    // region parseHtmlToAnnotatedString
+
+    private val linkColor = Color(0xFF1DA1F2)
+    private val mentionBg = Color(0x1A1DA1F2)
+    private val codeBg = Color(0xFFF5F5F5)
+
+    @Test
+    fun `parseHtmlToAnnotatedString extracts plain text`() {
+        val result = parseHtmlToAnnotatedString("<p>Hello world</p>", linkColor, mentionBg, codeBg)
+        assertEquals("Hello world", result.text)
+    }
+
+    @Test
+    fun `parseHtmlToAnnotatedString handles br tag`() {
+        val result = parseHtmlToAnnotatedString("line1<br>line2", linkColor, mentionBg, codeBg)
+        assertEquals("line1\nline2", result.text)
+    }
+
+    @Test
+    fun `parseHtmlToAnnotatedString handles multiple paragraphs`() {
+        val result = parseHtmlToAnnotatedString("<p>first</p><p>second</p>", linkColor, mentionBg, codeBg)
+        assertTrue(result.text.contains("first"))
+        assertTrue(result.text.contains("second"))
+        assertTrue(result.text.contains("\n\n"))
+    }
+
+    @Test
+    fun `parseHtmlToAnnotatedString handles link with URL annotation`() {
+        val html = """<a href="https://example.com">click</a>"""
+        val result = parseHtmlToAnnotatedString(html, linkColor, mentionBg, codeBg)
+        assertEquals("click", result.text)
+        val annotations = result.getStringAnnotations("URL", 0, result.length)
+        assertEquals(1, annotations.size)
+        assertEquals("https://example.com", annotations[0].item)
+    }
+
+    @Test
+    fun `parseHtmlToAnnotatedString handles mention link`() {
+        val html = """<a href="https://example.com/@alice" class="mention">@alice</a>"""
+        val result = parseHtmlToAnnotatedString(html, linkColor, mentionBg, codeBg)
+        assertEquals("@alice", result.text)
+        val annotations = result.getStringAnnotations("MENTION", 0, result.length)
+        assertEquals(1, annotations.size)
+        assertEquals("https://example.com/@alice", annotations[0].item)
+    }
+
+    @Test
+    fun `parseHtmlToAnnotatedString handles hashtag link`() {
+        val html = """<a href="https://example.com/tags/kotlin" class="hashtag">#kotlin</a>"""
+        val result = parseHtmlToAnnotatedString(html, linkColor, mentionBg, codeBg)
+        assertEquals("#kotlin", result.text)
+        val annotations = result.getStringAnnotations("URL", 0, result.length)
+        assertEquals(1, annotations.size)
+    }
+
+    @Test
+    fun `parseHtmlToAnnotatedString skips invisible spans`() {
+        val html = """<span class="invisible">hidden</span>visible"""
+        val result = parseHtmlToAnnotatedString(html, linkColor, mentionBg, codeBg)
+        assertEquals("visible", result.text)
+    }
+
+    @Test
+    fun `parseHtmlToAnnotatedString handles unordered list`() {
+        val html = "<ul><li>item1</li><li>item2</li></ul>"
+        val result = parseHtmlToAnnotatedString(html, linkColor, mentionBg, codeBg)
+        assertTrue(result.text.contains("\u2022 item1"))
+        assertTrue(result.text.contains("\u2022 item2"))
+    }
+
+    @Test
+    fun `parseHtmlToAnnotatedString handles ordered list`() {
+        val html = "<ol><li>first</li><li>second</li></ol>"
+        val result = parseHtmlToAnnotatedString(html, linkColor, mentionBg, codeBg)
+        assertTrue(result.text.contains("1. first"))
+        assertTrue(result.text.contains("2. second"))
+    }
+
+    @Test
+    fun `parseHtmlToAnnotatedString handles hr tag`() {
+        val result = parseHtmlToAnnotatedString("<hr>", linkColor, mentionBg, codeBg)
+        assertTrue(result.text.contains("\u2500"))
+    }
+
+    @Test
+    fun `parseHtmlToAnnotatedString decodes entities in text`() {
+        val result = parseHtmlToAnnotatedString("<p>A &amp; B</p>", linkColor, mentionBg, codeBg)
+        assertEquals("A & B", result.text)
+    }
+
+    @Test
+    fun `parseHtmlToAnnotatedString handles empty html`() {
+        val result = parseHtmlToAnnotatedString("", linkColor, mentionBg, codeBg)
+        assertEquals("", result.text)
+    }
+
+    // endregion
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ mlkitTranslate = "17.0.3"
 mlkitLanguageId = "17.0.6"
 work = "2.10.0"
 hiltWork = "1.2.0"
+junit = "4.13.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -52,6 +53,8 @@ mlkit-language-id = { group = "com.google.mlkit", name = "language-id", version.
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWork" }
 hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltWork" }
+
+junit = { group = "junit", name = "junit", version.ref = "junit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Move `modifier` to the first optional parameter position in `HtmlContent` following Compose conventions
- Add JUnit test dependency and 26 unit tests for `HtmlContent` helper functions (`decodeHtmlEntities`, `extractHandleFromUrl`, `splitIntoBlocks`, `parseHtmlToAnnotatedString`)
- Mark helper functions as `@VisibleForTesting internal` for testability

## Stacked on
- #84 (merge that first)

## Test plan
- [x] `./gradlew testDebugUnitTest` — 26 tests pass
- [x] All call sites use named arguments, no behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)