### PR TITLE
Add profile tabs and attachments display

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -295,7 +295,62 @@ query ActorByHandle($handle: String!, $after: String) {
         name
         bio
         avatarUrl
+        fields {
+            name
+            value
+        }
+        account {
+            links {
+                name
+                handle
+                icon
+                url
+                verified
+            }
+        }
         posts(first: 20, after: $after) {
+            edges {
+                cursor
+                node {
+                    ...PostFields
+                    sharedPost {
+                        ...SharedPostFields
+                    }
+                }
+            }
+            pageInfo {
+                hasNextPage
+                endCursor
+            }
+        }
+    }
+}
+
+query ActorArticles($handle: String!, $after: String) {
+    actorByHandle(handle: $handle, allowLocalHandle: true) {
+        id
+        articles(first: 20, after: $after) {
+            edges {
+                cursor
+                node {
+                    ...PostFields
+                    sharedPost {
+                        ...SharedPostFields
+                    }
+                }
+            }
+            pageInfo {
+                hasNextPage
+                endCursor
+            }
+        }
+    }
+}
+
+query ActorNotes($handle: String!, $after: String) {
+    actorByHandle(handle: $handle, allowLocalHandle: true) {
+        id
+        notes(first: 20, after: $after) {
             edges {
                 cursor
                 node {

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.cache.normalized.FetchPolicy
 import com.apollographql.apollo.cache.normalized.fetchPolicy
 import pub.hackers.android.domain.model.*
+import pub.hackers.android.graphql.ActorArticlesQuery
 import pub.hackers.android.graphql.ActorByHandleQuery
+import pub.hackers.android.graphql.ActorNotesQuery
 import pub.hackers.android.graphql.AddReactionToPostMutation
 import pub.hackers.android.graphql.BlockActorMutation
 import pub.hackers.android.graphql.CompleteLoginChallengeMutation
@@ -260,8 +262,32 @@ class HackersPubRepository @Inject constructor(
                             avatarUrl = actor.avatarUrl.toString()
                         ),
                         bio = actor.bio?.toString(),
+                        fields = actor.fields.map { field ->
+                            ActorField(
+                                name = field.name,
+                                value = field.value.toString()
+                            )
+                        },
+                        accountLinks = actor.account?.links?.map { link ->
+                            AccountLink(
+                                name = link.name,
+                                handle = link.handle,
+                                icon = link.icon.name.lowercase(),
+                                url = link.url.toString(),
+                                verified = link.verified?.toString()
+                            )
+                        } ?: emptyList(),
                         posts = actor.posts.edges.mapNotNull { edge ->
-                            edge.node.postFields.toPost(edge.node.sharedPost?.sharedPostFields?.toPost())
+                            val sharedPost = edge.node.sharedPost?.sharedPostFields?.toPost()
+                            edge.node.postFields.toPost(
+                                sharedPost = sharedPost,
+                                lastSharer = if (sharedPost != null) Actor(
+                                    id = actor.id,
+                                    name = actor.name?.toString(),
+                                    handle = actor.handle,
+                                    avatarUrl = actor.avatarUrl.toString()
+                                ) else null
+                            )
                         },
                         hasNextPage = actor.posts.pageInfo.hasNextPage,
                         endCursor = actor.posts.pageInfo.endCursor,
@@ -269,6 +295,60 @@ class HackersPubRepository @Inject constructor(
                         viewerFollows = actor.viewerFollows,
                         followsViewer = actor.followsViewer,
                         viewerBlocks = actor.viewerBlocks
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getActorArticles(handle: String, after: String? = null): Result<TimelineResult> {
+        return try {
+            val response = apolloClient.query(
+                ActorArticlesQuery(handle, Optional.presentIfNotNull(after))
+            ).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val articles = response.data?.actorByHandle?.articles
+                    ?: return Result.failure(Exception("Actor not found"))
+
+                Result.success(
+                    TimelineResult(
+                        posts = articles.edges.mapNotNull { edge ->
+                            edge.node.postFields.toPost(edge.node.sharedPost?.sharedPostFields?.toPost())
+                        },
+                        hasNextPage = articles.pageInfo.hasNextPage,
+                        endCursor = articles.pageInfo.endCursor
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getActorNotes(handle: String, after: String? = null): Result<TimelineResult> {
+        return try {
+            val response = apolloClient.query(
+                ActorNotesQuery(handle, Optional.presentIfNotNull(after))
+            ).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val notes = response.data?.actorByHandle?.notes
+                    ?: return Result.failure(Exception("Actor not found"))
+
+                Result.success(
+                    TimelineResult(
+                        posts = notes.edges.mapNotNull { edge ->
+                            edge.node.postFields.toPost(edge.node.sharedPost?.sharedPostFields?.toPost())
+                        },
+                        hasNextPage = notes.pageInfo.hasNextPage,
+                        endCursor = notes.pageInfo.endCursor
                     )
                 )
             }

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -9,6 +9,19 @@ data class Actor(
     val avatarUrl: String
 )
 
+data class ActorField(
+    val name: String,
+    val value: String
+)
+
+data class AccountLink(
+    val name: String,
+    val handle: String?,
+    val icon: String,
+    val url: String,
+    val verified: String?
+)
+
 data class Media(
     val url: String,
     val thumbnailUrl: String?,
@@ -221,6 +234,8 @@ data class QuotesResult(
 data class ProfileResult(
     val actor: Actor,
     val bio: String?,
+    val fields: List<ActorField> = emptyList(),
+    val accountLinks: List<AccountLink> = emptyList(),
     val posts: List<Post>,
     val hasNextPage: Boolean,
     val endCursor: String?,

--- a/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
@@ -3,6 +3,8 @@ package pub.hackers.android.ui.screens.profile
 import android.content.Intent
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,6 +24,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.AlertDialog
@@ -54,12 +57,16 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import pub.hackers.android.R
+import pub.hackers.android.domain.model.AccountLink
+import pub.hackers.android.domain.model.ActorField
 import pub.hackers.android.ui.components.LargeTitleHeader
 import pub.hackers.android.ui.components.ErrorMessage
 import pub.hackers.android.ui.components.FullScreenLoading
@@ -187,6 +194,8 @@ fun ProfileScreen(
                                     name = uiState.actor!!.name,
                                     handle = uiState.actor!!.handle,
                                     bio = uiState.bio,
+                                    fields = uiState.fields,
+                                    accountLinks = uiState.accountLinks,
                                     isViewer = uiState.isViewer,
                                     viewerFollows = uiState.viewerFollows,
                                     followsViewer = uiState.followsViewer,
@@ -196,10 +205,12 @@ fun ProfileScreen(
                                     onUnfollowClick = { viewModel.unfollowActor() },
                                     onMentionClick = onProfileClick
                                 )
-                                HorizontalDivider(
-                                    color = LocalAppColors.current.divider,
-                                    thickness = 1.dp,
-                                    modifier = Modifier.padding(horizontal = 16.dp)
+                            }
+
+                            item {
+                                ProfileTabBar(
+                                    selectedTab = uiState.selectedTab,
+                                    onTabSelected = { viewModel.selectTab(it) }
                                 )
                             }
 
@@ -315,11 +326,59 @@ private fun ProfileActionMenu(
 }
 
 @Composable
+private fun ProfileTabBar(
+    selectedTab: ProfileTab,
+    onTabSelected: (ProfileTab) -> Unit
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+
+    Row(modifier = Modifier.fillMaxWidth()) {
+        ProfileTab.entries.forEach { tab ->
+            val isSelected = selectedTab == tab
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable { onTabSelected(tab) },
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = when (tab) {
+                        ProfileTab.POSTS -> stringResource(R.string.profile_tab_posts)
+                        ProfileTab.NOTES -> stringResource(R.string.profile_tab_notes)
+                        ProfileTab.ARTICLES -> stringResource(R.string.profile_tab_articles)
+                    },
+                    style = if (isSelected) typography.bodyLargeSemiBold else typography.bodyLarge,
+                    color = if (isSelected) colors.accent else colors.textSecondary,
+                    modifier = Modifier.padding(vertical = 12.dp)
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(2.dp)
+                        .then(
+                            if (isSelected) Modifier.background(colors.accent) else Modifier
+                        )
+                )
+            }
+        }
+    }
+
+    HorizontalDivider(
+        color = colors.divider,
+        thickness = 1.dp,
+        modifier = Modifier.padding(horizontal = 16.dp)
+    )
+}
+
+@Composable
 private fun ProfileHeader(
     avatarUrl: String,
     name: String?,
     handle: String,
     bio: String?,
+    fields: List<ActorField>,
+    accountLinks: List<AccountLink>,
     isViewer: Boolean,
     viewerFollows: Boolean,
     followsViewer: Boolean,
@@ -436,7 +495,114 @@ private fun ProfileHeader(
                 onMentionClick = onMentionClick
             )
         }
+
+        if (accountLinks.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(12.dp))
+            ProfileAttachments(accountLinks = accountLinks)
+        } else if (fields.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(12.dp))
+            ProfileFields(fields = fields)
+        }
     }
+}
+
+@Composable
+private fun ProfileAttachments(accountLinks: List<AccountLink>) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+    val uriHandler = LocalUriHandler.current
+    val borderColor = colors.divider
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .border(1.dp, borderColor, RoundedCornerShape(8.dp))
+            .clip(RoundedCornerShape(8.dp))
+    ) {
+        accountLinks.forEachIndexed { index, link ->
+            if (index > 0) {
+                HorizontalDivider(color = borderColor, thickness = 1.dp)
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { uriHandler.openUri(link.url) }
+                    .padding(horizontal = 12.dp, vertical = 10.dp)
+            ) {
+                Text(
+                    text = link.name,
+                    style = typography.bodyMedium,
+                    color = colors.textSecondary
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = link.handle ?: compactUrl(link.url),
+                    style = typography.bodyMedium,
+                    color = colors.accent,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false)
+                )
+                if (link.verified != null) {
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Icon(
+                        imageVector = Icons.Filled.CheckCircle,
+                        contentDescription = stringResource(R.string.profile_verified),
+                        modifier = Modifier.size(16.dp),
+                        tint = Color(0xFF22C55E)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProfileFields(fields: List<ActorField>) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+    val borderColor = colors.divider
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .border(1.dp, borderColor, RoundedCornerShape(8.dp))
+            .clip(RoundedCornerShape(8.dp))
+    ) {
+        fields.forEachIndexed { index, field ->
+            if (index > 0) {
+                HorizontalDivider(color = borderColor, thickness = 1.dp)
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 10.dp)
+            ) {
+                Text(
+                    text = field.name,
+                    style = typography.bodyMedium,
+                    color = colors.textSecondary
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                HtmlContent(
+                    html = field.value,
+                    modifier = Modifier.weight(1f, fill = false)
+                )
+            }
+        }
+    }
+}
+
+private fun compactUrl(url: String): String {
+    return url
+        .removePrefix("https://")
+        .removePrefix("http://")
+        .removePrefix("www.")
+        .trimEnd('/')
 }
 
 @Composable

--- a/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileViewModel.kt
@@ -10,19 +10,33 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pub.hackers.android.data.repository.HackersPubRepository
+import pub.hackers.android.domain.model.AccountLink
 import pub.hackers.android.domain.model.Actor
+import pub.hackers.android.domain.model.ActorField
 import pub.hackers.android.domain.model.Post
 import javax.inject.Inject
+
+enum class ProfileTab {
+    POSTS, NOTES, ARTICLES
+}
+
+data class TabState(
+    val posts: List<Post> = emptyList(),
+    val hasNextPage: Boolean = false,
+    val endCursor: String? = null,
+    val isLoaded: Boolean = false
+)
 
 data class ProfileUiState(
     val actor: Actor? = null,
     val bio: String? = null,
-    val posts: List<Post> = emptyList(),
+    val fields: List<ActorField> = emptyList(),
+    val accountLinks: List<AccountLink> = emptyList(),
+    val selectedTab: ProfileTab = ProfileTab.POSTS,
+    val tabStates: Map<ProfileTab, TabState> = ProfileTab.entries.associateWith { TabState() },
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
     val isLoadingMore: Boolean = false,
-    val hasNextPage: Boolean = false,
-    val endCursor: String? = null,
     val error: String? = null,
     val isViewer: Boolean = false,
     val viewerFollows: Boolean = false,
@@ -30,7 +44,11 @@ data class ProfileUiState(
     val viewerBlocks: Boolean = false,
     val isPerformingAction: Boolean = false,
     val actionError: String? = null
-)
+) {
+    val currentTabState: TabState get() = tabStates[selectedTab] ?: TabState()
+    val posts: List<Post> get() = currentTabState.posts
+    val hasNextPage: Boolean get() = currentTabState.hasNextPage
+}
 
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
@@ -54,12 +72,19 @@ class ProfileViewModel @Inject constructor(
             repository.getProfile(handle)
                 .onSuccess { result ->
                     _uiState.update {
-                        it.copy(
-                            actor = result.actor,
-                            bio = result.bio,
+                        val newTabStates = it.tabStates.toMutableMap()
+                        newTabStates[ProfileTab.POSTS] = TabState(
                             posts = result.posts,
                             hasNextPage = result.hasNextPage,
                             endCursor = result.endCursor,
+                            isLoaded = true
+                        )
+                        it.copy(
+                            actor = result.actor,
+                            bio = result.bio,
+                            fields = result.fields,
+                            accountLinks = result.accountLinks,
+                            tabStates = newTabStates,
                             isViewer = result.isViewer,
                             viewerFollows = result.viewerFollows,
                             followsViewer = result.followsViewer,
@@ -86,18 +111,31 @@ class ProfileViewModel @Inject constructor(
             repository.getProfile(handle)
                 .onSuccess { result ->
                     _uiState.update {
-                        it.copy(
-                            actor = result.actor,
-                            bio = result.bio,
+                        // Reset all tab states on refresh
+                        val newTabStates = ProfileTab.entries.associateWith { TabState() }.toMutableMap()
+                        newTabStates[ProfileTab.POSTS] = TabState(
                             posts = result.posts,
                             hasNextPage = result.hasNextPage,
                             endCursor = result.endCursor,
+                            isLoaded = true
+                        )
+                        it.copy(
+                            actor = result.actor,
+                            bio = result.bio,
+                            fields = result.fields,
+                            accountLinks = result.accountLinks,
+                            tabStates = newTabStates,
                             isViewer = result.isViewer,
                             viewerFollows = result.viewerFollows,
                             followsViewer = result.followsViewer,
                             viewerBlocks = result.viewerBlocks,
                             isRefreshing = false
                         )
+                    }
+                    // Reload current tab if not POSTS
+                    val currentTab = _uiState.value.selectedTab
+                    if (currentTab != ProfileTab.POSTS) {
+                        loadTabData(currentTab)
                     }
                 }
                 .onFailure { error ->
@@ -111,22 +149,81 @@ class ProfileViewModel @Inject constructor(
         }
     }
 
+    fun selectTab(tab: ProfileTab) {
+        _uiState.update { it.copy(selectedTab = tab) }
+        val tabState = _uiState.value.tabStates[tab]
+        if (tabState == null || !tabState.isLoaded) {
+            loadTabData(tab)
+        }
+    }
+
+    private fun loadTabData(tab: ProfileTab) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+
+            val result = when (tab) {
+                ProfileTab.POSTS -> repository.getProfile(handle).map {
+                    Triple(it.posts, it.hasNextPage, it.endCursor)
+                }
+                ProfileTab.NOTES -> repository.getActorNotes(handle).map {
+                    Triple(it.posts, it.hasNextPage, it.endCursor)
+                }
+                ProfileTab.ARTICLES -> repository.getActorArticles(handle).map {
+                    Triple(it.posts, it.hasNextPage, it.endCursor)
+                }
+            }
+
+            result
+                .onSuccess { (posts, hasNextPage, endCursor) ->
+                    _uiState.update {
+                        val newTabStates = it.tabStates.toMutableMap()
+                        newTabStates[tab] = TabState(
+                            posts = posts,
+                            hasNextPage = hasNextPage,
+                            endCursor = endCursor,
+                            isLoaded = true
+                        )
+                        it.copy(tabStates = newTabStates, isLoading = false)
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update { it.copy(isLoading = false) }
+                }
+        }
+    }
+
     fun loadMore() {
         val currentState = _uiState.value
-        if (!currentState.hasNextPage || currentState.isLoadingMore) return
+        val tabState = currentState.currentTabState
+        if (!tabState.hasNextPage || currentState.isLoadingMore) return
 
         viewModelScope.launch {
             _uiState.update { it.copy(isLoadingMore = true) }
 
-            repository.getProfile(handle, postsAfter = currentState.endCursor)
-                .onSuccess { result ->
+            val tab = currentState.selectedTab
+            val result = when (tab) {
+                ProfileTab.POSTS -> repository.getProfile(handle, postsAfter = tabState.endCursor).map {
+                    Triple(it.posts, it.hasNextPage, it.endCursor)
+                }
+                ProfileTab.NOTES -> repository.getActorNotes(handle, after = tabState.endCursor).map {
+                    Triple(it.posts, it.hasNextPage, it.endCursor)
+                }
+                ProfileTab.ARTICLES -> repository.getActorArticles(handle, after = tabState.endCursor).map {
+                    Triple(it.posts, it.hasNextPage, it.endCursor)
+                }
+            }
+
+            result
+                .onSuccess { (posts, hasNextPage, endCursor) ->
                     _uiState.update {
-                        it.copy(
-                            posts = it.posts + result.posts,
-                            hasNextPage = result.hasNextPage,
-                            endCursor = result.endCursor,
-                            isLoadingMore = false
+                        val newTabStates = it.tabStates.toMutableMap()
+                        val existing = newTabStates[tab] ?: TabState()
+                        newTabStates[tab] = existing.copy(
+                            posts = existing.posts + posts,
+                            hasNextPage = hasNextPage,
+                            endCursor = endCursor
                         )
+                        it.copy(tabStates = newTabStates, isLoadingMore = false)
                     }
                 }
                 .onFailure {
@@ -239,22 +336,31 @@ class ProfileViewModel @Inject constructor(
         _uiState.update { it.copy(actionError = null) }
     }
 
+    private fun updatePostInAllTabs(postId: String, transform: (Post) -> Post) {
+        _uiState.update { state ->
+            val newTabStates = state.tabStates.mapValues { (_, tabState) ->
+                tabState.copy(
+                    posts = tabState.posts.map { post ->
+                        if (post.id == postId || post.sharedPost?.id == postId) {
+                            transform(post)
+                        } else post
+                    }
+                )
+            }
+            state.copy(tabStates = newTabStates)
+        }
+    }
+
     fun sharePost(postId: String) {
         viewModelScope.launch {
             repository.sharePost(postId)
                 .onSuccess {
-                    _uiState.update { state ->
-                        state.copy(
-                            posts = state.posts.map { post ->
-                                if (post.id == postId || post.sharedPost?.id == postId) {
-                                    post.copy(
-                                        viewerHasShared = true,
-                                        engagementStats = post.engagementStats.copy(
-                                            shares = post.engagementStats.shares + 1
-                                        )
-                                    )
-                                } else post
-                            }
+                    updatePostInAllTabs(postId) { post ->
+                        post.copy(
+                            viewerHasShared = true,
+                            engagementStats = post.engagementStats.copy(
+                                shares = post.engagementStats.shares + 1
+                            )
                         )
                     }
                 }
@@ -265,18 +371,12 @@ class ProfileViewModel @Inject constructor(
         viewModelScope.launch {
             repository.unsharePost(postId)
                 .onSuccess {
-                    _uiState.update { state ->
-                        state.copy(
-                            posts = state.posts.map { post ->
-                                if (post.id == postId || post.sharedPost?.id == postId) {
-                                    post.copy(
-                                        viewerHasShared = false,
-                                        engagementStats = post.engagementStats.copy(
-                                            shares = maxOf(0, post.engagementStats.shares - 1)
-                                        )
-                                    )
-                                } else post
-                            }
+                    updatePostInAllTabs(postId) { post ->
+                        post.copy(
+                            viewerHasShared = false,
+                            engagementStats = post.engagementStats.copy(
+                                shares = maxOf(0, post.engagementStats.shares - 1)
+                            )
                         )
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,10 @@
     <string name="settings_timeline_unlimited">Unlimited</string>
 
     <!-- Profile -->
+    <string name="profile_tab_posts">Posts</string>
+    <string name="profile_tab_notes">Notes</string>
+    <string name="profile_tab_articles">Articles</string>
+    <string name="profile_verified">Verified</string>
     <string name="follow">Follow</string>
     <string name="unfollow">Unfollow</string>
     <string name="block">Block</string>


### PR DESCRIPTION
## Summary
Enrich the profile page with Posts/Notes/Articles tabs that use server-side GraphQL queries for proper pagination, and display profile attachments (account links with verified badges, or ActivityPub actor fields) in a bordered grid layout below the bio. Shared posts on the profile now show the reposter indicator.