### PR TITLE
Add refresh button to empty screen states

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/components/ErrorMessage.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/ErrorMessage.kt
@@ -7,9 +7,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -26,6 +29,7 @@ import pub.hackers.android.R
 fun ErrorMessage(
     message: String,
     onRetry: (() -> Unit)? = null,
+    onRefresh: (() -> Unit)? = null,
     icon: ImageVector? = Icons.Outlined.ErrorOutline,
     modifier: Modifier = Modifier
 ) {
@@ -57,6 +61,25 @@ fun ErrorMessage(
             Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = onRetry) {
                 Text(stringResource(R.string.retry))
+            }
+        }
+
+        if (onRefresh != null) {
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(
+                onClick = onRefresh,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Refresh,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource(R.string.refresh))
             }
         }
     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreScreen.kt
@@ -174,7 +174,8 @@ fun ExploreScreen(
                     }
                     uiState.posts.isEmpty() -> {
                         ErrorMessage(
-                            message = stringResource(R.string.no_posts)
+                            message = stringResource(R.string.no_posts),
+                            onRefresh = { viewModel.refresh() }
                         )
                     }
                     else -> {

--- a/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsScreen.kt
@@ -105,17 +105,10 @@ fun NotificationsScreen(
                     )
                 }
                 uiState.notifications.isEmpty() -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = stringResource(R.string.no_notifications),
-                            style = typography.bodyLarge,
-                            color = colors.textSecondary,
-                            textAlign = TextAlign.Center
-                        )
-                    }
+                    ErrorMessage(
+                        message = stringResource(R.string.no_notifications),
+                        onRefresh = { viewModel.refresh() }
+                    )
                 }
                 else -> {
                     PullToRefreshBox(

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -185,7 +185,8 @@ fun TimelineScreen(
                 }
                 uiState.posts.isEmpty() -> {
                     ErrorMessage(
-                        message = stringResource(R.string.no_posts)
+                        message = stringResource(R.string.no_posts),
+                        onRefresh = { viewModel.refresh() }
                     )
                 }
                 else -> {


### PR DESCRIPTION
## Summary
Add a primary-colored refresh button with icon to empty screen states across Timeline, Explore, and Notifications screens. This gives users an explicit way to refresh when no content is loaded, complementing pull-to-refresh which is only available when the list is displayed.