### PR TITLE
Fix article card: zero border radius, repost indicator, and engagement bar

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -44,7 +45,7 @@ fun ArticleCard(
     modifier: Modifier = Modifier
 ) {
     val displayPost = post.sharedPost ?: post
-    val isRepost = post.sharedPost != null
+    val isRepost = post.lastSharer != null
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
 
@@ -62,24 +63,44 @@ fun ArticleCard(
             Column(
                 modifier = Modifier.padding(12.dp)
             ) {
-                if (isRepost) {
+                if (isRepost && post.lastSharer != null) {
+                    val sharer = post.lastSharer!!
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(bottom = 8.dp)
+                        modifier = Modifier
+                            .padding(start = 54.dp, bottom = 8.dp)
+                            .clickable { onProfileClick(sharer.handle) }
                     ) {
                         Icon(
                             imageVector = Icons.Filled.Repeat,
                             contentDescription = null,
-                            tint = colors.textSecondary,
-                            modifier = Modifier.size(16.dp)
+                            tint = colors.share,
+                            modifier = Modifier.size(14.dp)
                         )
                         Spacer(modifier = Modifier.width(4.dp))
-                        RichDisplayName(
-                            name = post.actor.name?.let { "$it ${stringResource(R.string.share)}d" },
-                            fallback = "${post.actor.handle} ${stringResource(R.string.share)}d",
-                            style = typography.caption,
+                        if (sharer.name != null) {
+                            RichDisplayName(
+                                name = sharer.name,
+                                fallback = sharer.handle,
+                                style = typography.caption.copy(fontStyle = FontStyle.Italic),
+                                color = colors.textSecondary,
+                                emojiHeight = 14.dp
+                            )
+                            Spacer(modifier = Modifier.width(2.dp))
+                        }
+                        Text(
+                            text = sharer.handle,
+                            style = typography.caption.copy(fontStyle = FontStyle.Italic),
                             color = colors.textSecondary,
-                            emojiHeight = 14.dp
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f, fill = false)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = stringResource(R.string.share) + "d",
+                            style = typography.caption.copy(fontStyle = FontStyle.Italic),
+                            color = colors.textSecondary
                         )
                     }
                 }

--- a/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -51,6 +52,7 @@ fun ArticleCard(
         modifier = modifier
             .fillMaxWidth()
             .clickable(onClick = onClick),
+        shape = RectangleShape,
         colors = CardDefaults.cardColors(
             containerColor = colors.surface
         ),

--- a/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
@@ -1,7 +1,11 @@
 package pub.hackers.android.ui.components
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,11 +16,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Reply
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.outlined.Favorite
+import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -42,6 +51,12 @@ fun ArticleCard(
     post: Post,
     onClick: () -> Unit,
     onProfileClick: (String) -> Unit,
+    onReplyClick: (() -> Unit)? = null,
+    onShareClick: (() -> Unit)? = null,
+    onQuoteClick: (() -> Unit)? = null,
+    onReactionClick: (() -> Unit)? = null,
+    onReactionLongPress: (() -> Unit)? = null,
+    onExternalShareClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     val displayPost = post.sharedPost ?: post
@@ -63,6 +78,7 @@ fun ArticleCard(
             Column(
                 modifier = Modifier.padding(12.dp)
             ) {
+                // Repost indicator (matching NoteCard style)
                 if (isRepost && post.lastSharer != null) {
                     val sharer = post.lastSharer!!
                     Row(
@@ -193,6 +209,79 @@ fun ArticleCard(
                     .padding(vertical = 12.dp, horizontal = 16.dp),
                 textAlign = TextAlign.Center
             )
+
+            // Engagement bar
+            HorizontalDivider(color = colors.divider)
+            ArticleEngagementBar(
+                post = displayPost,
+                onReplyClick = onReplyClick,
+                onShareClick = onShareClick,
+                onReactionClick = onReactionClick,
+                onReactionLongPress = onReactionLongPress,
+                onExternalShareClick = onExternalShareClick
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ArticleEngagementBar(
+    post: Post,
+    onReplyClick: (() -> Unit)?,
+    onShareClick: (() -> Unit)?,
+    onReactionClick: (() -> Unit)?,
+    onReactionLongPress: (() -> Unit)?,
+    onExternalShareClick: (() -> Unit)?
+) {
+    val colors = LocalAppColors.current
+    val isShared = post.viewerHasShared
+    val isReacted = post.reactionGroups.any { it.viewerHasReacted }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceAround
+    ) {
+        IconButton(onClick = { onReplyClick?.invoke() }, enabled = onReplyClick != null) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.Reply,
+                contentDescription = stringResource(R.string.replies),
+                tint = colors.textSecondary
+            )
+        }
+        IconButton(onClick = { onShareClick?.invoke() }, enabled = onShareClick != null) {
+            Icon(
+                imageVector = Icons.Filled.Repeat,
+                contentDescription = stringResource(R.string.share),
+                tint = if (isShared) colors.share else colors.textSecondary
+            )
+        }
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(48.dp)
+                .clip(CircleShape)
+                .combinedClickable(
+                    onClick = { onReactionClick?.invoke() },
+                    onLongClick = { onReactionLongPress?.invoke() }
+                )
+        ) {
+            Icon(
+                imageVector = if (isReacted) Icons.Filled.Favorite else Icons.Outlined.Favorite,
+                contentDescription = stringResource(R.string.reactions),
+                tint = if (isReacted) colors.reaction else colors.textSecondary
+            )
+        }
+        if (onExternalShareClick != null) {
+            IconButton(onClick = onExternalShareClick) {
+                Icon(
+                    imageVector = Icons.Outlined.Share,
+                    contentDescription = stringResource(R.string.share),
+                    tint = colors.textSecondary
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -120,6 +120,12 @@ fun PostCard(
             post = post,
             onClick = onClick,
             onProfileClick = onProfileClick,
+            onReplyClick = onReplyClick,
+            onShareClick = onShareClick,
+            onQuoteClick = onQuoteClick,
+            onReactionClick = onReactionClick,
+            onReactionLongPress = onReactionLongPress,
+            onExternalShareClick = onExternalShareClick,
             modifier = modifier
         )
     } else {


### PR DESCRIPTION
## Summary

Remove border radius from ArticleCard for a flat, edge-to-edge appearance. Update the repost indicator to match NoteCard style using `lastSharer` with clickable name+handle in italic. Add a SpaceAround engagement bar (reply/repost/reaction/share) below the article footer, consistent with the post detail page layout.