### PR TITLE
Add Firebase Crashlytics integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,6 @@ captures/
 .externalNativeBuild
 .cxx/
 
-# Google Services (e.g. APIs or Firebase)
-google-services.json
 
 # Version control
 vcs.xml

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     alias(libs.plugins.hilt.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.apollo)
+    alias(libs.plugins.google.services)
+    alias(libs.plugins.firebase.crashlytics)
 }
 
 android {
@@ -117,6 +119,10 @@ dependencies {
 
     implementation(libs.mlkit.translate)
     implementation(libs.mlkit.language.id)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.analytics)
 
     implementation("androidx.browser:browser:1.8.0")
     implementation("androidx.credentials:credentials:1.5.0-rc01")

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "842190151606",
+    "project_id": "hackerspub-android",
+    "storage_bucket": "hackerspub-android.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:842190151606:android:3c38592f957eafd5fdab17",
+        "android_client_info": {
+          "package_name": "pub.hackers.android"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAxp4vTvPs-gynfbDK0TDC6S4K7ImXgSx8"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,6 @@ plugins {
     alias(libs.plugins.hilt.android) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.apollo) apply false
+    alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,9 @@ work = "2.10.0"
 hiltWork = "1.2.0"
 junit = "4.13.2"
 robolectric = "4.14.1"
+googleServices = "4.4.4"
+firebaseCrashlyticsPlugin = "3.0.7"
+firebaseBom = "34.12.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -60,6 +63,10 @@ robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "
 compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
@@ -67,3 +74,5 @@ kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "ko
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 apollo = { id = "com.apollographql.apollo", version.ref = "apollo" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }


### PR DESCRIPTION
## Summary
Integrate Firebase Crashlytics and Analytics to enable crash reporting and monitoring. Adds the Google Services plugin, Firebase BOM, Crashlytics SDK, and Analytics SDK to the version catalog and Gradle build files. Also includes `google-services.json` in the repository for easier onboarding and CI setup.