### PR TITLE
Fix deep link handling and add notifications route

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,15 @@
                     android:host="hackers.pub"
                     android:pathPrefix="/tags/" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="hackers.pub"
+                    android:pathPrefix="/notifications" />
+            </intent-filter>
         </activity>
         <provider
             android:name="androidx.startup.InitializationProvider"

--- a/app/src/main/java/pub/hackers/android/MainActivity.kt
+++ b/app/src/main/java/pub/hackers/android/MainActivity.kt
@@ -54,8 +54,10 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        handleDeepLink(intent)
-        handleNavigationIntent(intent)
+        if (savedInstanceState == null) {
+            handleDeepLink(intent)
+            handleNavigationIntent(intent)
+        }
         requestNotificationPermissionIfNeeded()
         enableEdgeToEdge()
         setContent {
@@ -66,7 +68,9 @@ class MainActivity : ComponentActivity() {
                 ) {
                     HackersPubApp(
                         deepLinkData = deepLinkData,
-                        navigationIntent = navigationIntent
+                        navigationIntent = navigationIntent,
+                        onDeepLinkConsumed = { deepLinkData = null },
+                        onNavigationIntentConsumed = { navigationIntent = null }
                     )
                 }
             }
@@ -115,7 +119,8 @@ class MainActivity : ComponentActivity() {
             is HackersPubRoute.SignInVerification -> {
                 deepLinkData = DeepLinkData(token = route.token, code = route.code)
             }
-            is HackersPubRoute.Profile, is HackersPubRoute.NoteDetail, is HackersPubRoute.TagSearch -> {
+            is HackersPubRoute.Profile, is HackersPubRoute.NoteDetail,
+            is HackersPubRoute.TagSearch, is HackersPubRoute.Notifications -> {
                 navigationIntent = NavigationIntent(route = route.toNavRoute())
             }
             null -> { /* Not a recognized URL, ignore */ }

--- a/app/src/main/java/pub/hackers/android/navigation/HackersPubUrlRouter.kt
+++ b/app/src/main/java/pub/hackers/android/navigation/HackersPubUrlRouter.kt
@@ -10,6 +10,7 @@ sealed class HackersPubRoute {
     data class NoteDetail(val globalId: String) : HackersPubRoute()
     data class SignInVerification(val token: String, val code: String) : HackersPubRoute()
     data class TagSearch(val tag: String) : HackersPubRoute()
+    data object Notifications : HackersPubRoute()
 }
 
 object HackersPubUrlRouter {
@@ -34,6 +35,11 @@ object HackersPubUrlRouter {
         val segments = path.split('/').filter { it.isNotEmpty() }
 
         return when {
+            // /notifications
+            segments.size == 1 && segments[0] == "notifications" -> {
+                HackersPubRoute.Notifications
+            }
+
             // /tags/<tag>
             segments.size == 2 && segments[0] == "tags" -> {
                 HackersPubRoute.TagSearch(segments[1])
@@ -93,5 +99,6 @@ fun HackersPubRoute.toNavRoute(): String {
         is HackersPubRoute.NoteDetail -> DetailScreen.PostDetail.createRoute(globalId)
         is HackersPubRoute.SignInVerification -> DetailScreen.SignIn.createRoute(token, code)
         is HackersPubRoute.TagSearch -> Screen.Search.createRoute(tag)
+        is HackersPubRoute.Notifications -> Screen.Notifications.route
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -129,27 +130,43 @@ sealed class DetailScreen(val route: String) {
 fun HackersPubApp(
     deepLinkData: pub.hackers.android.DeepLinkData? = null,
     navigationIntent: pub.hackers.android.NavigationIntent? = null,
+    onDeepLinkConsumed: () -> Unit = {},
+    onNavigationIntentConsumed: () -> Unit = {},
     viewModel: AppViewModel = hiltViewModel()
 ) {
     val navController = rememberNavController()
-    val isLoggedIn by viewModel.isLoggedIn.collectAsState(initial = false)
+    val isLoggedInState by viewModel.isLoggedIn.collectAsState(initial = null as Boolean?)
 
     val fontSizePercent by viewModel.preferencesManager.fontSizePercent.collectAsState(initial = 100)
     val hasUnread by viewModel.hasUnread.collectAsState()
+
+    // Wait for auth state to resolve from DataStore before rendering navigation.
+    // This prevents NavHost graph recreation when isLoggedIn transitions from the
+    // initial value to the actual value, which would reset the back stack.
+    if (isLoggedInState == null) return
+    val isLoggedIn = isLoggedInState!!
+
+    // Pin startDestination so it never changes after first resolution.
+    // Login/logout transitions are handled imperatively with popUpTo(0).
+    val startDestination = remember {
+        if (isLoggedIn) Screen.Timeline.route else Screen.Explore.route
+    }
 
     // Handle deep link for verification
     LaunchedEffect(deepLinkData) {
         deepLinkData?.let {
             navController.navigate("signin?token=${it.token}&code=${it.code}")
+            onDeepLinkConsumed()
         }
     }
 
-    // Handle navigation intent from system notifications
+    // Handle navigation intent from system notifications or deep links
     LaunchedEffect(navigationIntent) {
         navigationIntent?.let {
             navController.navigate(it.route) {
                 launchSingleTop = true
             }
+            onNavigationIntentConsumed()
         }
     }
 
@@ -273,7 +290,7 @@ fun HackersPubApp(
     ) { innerPadding ->
         NavHost(
             navController = navController,
-            startDestination = if (isLoggedIn) Screen.Timeline.route else Screen.Explore.route,
+            startDestination = startDestination,
             modifier = Modifier
                 .padding(innerPadding)
                 .consumeWindowInsets(innerPadding)


### PR DESCRIPTION
## Summary
- Pin NavHost `startDestination` so it doesn't change when `isLoggedIn` resolves from DataStore, preventing unintended back-stack resets
- Consume deep link and navigation intent after handling to avoid re-navigation on configuration changes (e.g., screen rotation)
- Add `/notifications` deep link support via new `HackersPubRoute.Notifications` and corresponding intent filter