### PR TITLE
Link to profile page from settings screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,6 +87,10 @@ apollo {
     }
 }
 
+tasks.matching { it.name == "processDebugGoogleServices" }.configureEach {
+    enabled = false
+}
+
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -379,6 +379,9 @@ fun HackersPubApp(
                             popUpTo(0) { inclusive = true }
                         }
                     },
+                    onProfileClick = { handle ->
+                        navController.navigate(DetailScreen.Profile.createRoute(handle))
+                    },
                     isLoggedIn = isLoggedIn
                 )
             }

--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
@@ -58,6 +58,7 @@ import pub.hackers.android.ui.theme.LocalAppTypography
 fun SettingsScreen(
     onSignInClick: () -> Unit,
     onSignOutComplete: () -> Unit,
+    onProfileClick: (String) -> Unit,
     isLoggedIn: Boolean,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
@@ -132,6 +133,9 @@ fun SettingsScreen(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .clickable {
+                            uiState.userHandle?.let { onProfileClick(it) }
+                        }
                         .padding(16.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {


### PR DESCRIPTION
## Summary
Make the user profile card in the settings screen tappable so logged-in users can navigate to their own profile page. Also disables the `processDebugGoogleServices` task for debug builds to fix local development, since `google-services.json` only contains the release package name.