### PR TITLE
Add article creation and draft management

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -777,3 +777,67 @@ query RecommendedActors($limit: Int = 10) {
         bio
     }
 }
+
+mutation SaveArticleDraft($title: String!, $content: Markdown!, $tags: [String!]!, $id: ID) {
+    saveArticleDraft(input: { title: $title, content: $content, tags: $tags, id: $id }) {
+        ... on SaveArticleDraftPayload {
+            draft {
+                id
+                title
+                content
+                tags
+                created
+                updated
+            }
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+    }
+}
+
+mutation DeleteArticleDraft($id: ID!) {
+    deleteArticleDraft(input: { id: $id }) {
+        ... on DeleteArticleDraftPayload {
+            deletedDraftId
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+    }
+}
+
+query ArticleDrafts {
+    viewer {
+        id
+        articleDrafts(first: 50) {
+            edges {
+                node {
+                    id
+                    title
+                    content
+                    tags
+                    created
+                    updated
+                }
+            }
+        }
+    }
+}
+
+query ArticleDraft($id: ID!) {
+    articleDraft(id: $id) {
+        id
+        title
+        content
+        tags
+        created
+        updated
+    }
+}

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -5,6 +5,8 @@ import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.cache.normalized.FetchPolicy
 import com.apollographql.apollo.cache.normalized.fetchPolicy
 import pub.hackers.android.domain.model.*
+import pub.hackers.android.graphql.ArticleDraftQuery
+import pub.hackers.android.graphql.ArticleDraftsQuery
 import pub.hackers.android.graphql.ActorArticlesQuery
 import pub.hackers.android.graphql.ActorByHandleQuery
 import pub.hackers.android.graphql.ActorNotesQuery
@@ -12,6 +14,7 @@ import pub.hackers.android.graphql.AddReactionToPostMutation
 import pub.hackers.android.graphql.BlockActorMutation
 import pub.hackers.android.graphql.CompleteLoginChallengeMutation
 import pub.hackers.android.graphql.CreateNoteMutation
+import pub.hackers.android.graphql.DeleteArticleDraftMutation
 import pub.hackers.android.graphql.DeletePostMutation
 import pub.hackers.android.graphql.GetPasskeyAuthenticationOptionsMutation
 import pub.hackers.android.graphql.GetPasskeyRegistrationOptionsMutation
@@ -30,6 +33,7 @@ import pub.hackers.android.graphql.RemoveFollowerMutation
 import pub.hackers.android.graphql.RemoveReactionFromPostMutation
 import pub.hackers.android.graphql.RevokePasskeyMutation
 import pub.hackers.android.graphql.RevokeSessionMutation
+import pub.hackers.android.graphql.SaveArticleDraftMutation
 import pub.hackers.android.graphql.ViewerPasskeysQuery
 import pub.hackers.android.graphql.VerifyPasskeyRegistrationMutation
 import pub.hackers.android.graphql.SearchActorsByHandleQuery
@@ -1018,6 +1022,130 @@ class HackersPubRepository @Inject constructor(
                         Result.failure(Exception("Cannot delete a shared post"))
                     else -> Result.failure(Exception("Unknown error"))
                 }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun saveArticleDraft(
+        title: String,
+        content: String,
+        tags: List<String>,
+        id: String? = null
+    ): Result<ArticleDraft> {
+        return try {
+            val response = apolloClient.mutation(
+                SaveArticleDraftMutation(
+                    title = title,
+                    content = content,
+                    tags = tags,
+                    id = Optional.presentIfNotNull(id)
+                )
+            ).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.saveArticleDraft
+                when {
+                    result?.onSaveArticleDraftPayload != null -> {
+                        val draft = result.onSaveArticleDraftPayload.draft
+                        Result.success(
+                            ArticleDraft(
+                                id = draft.id,
+                                title = draft.title,
+                                content = draft.content.toString(),
+                                tags = draft.tags,
+                                created = Instant.parse(draft.created.toString()),
+                                updated = Instant.parse(draft.updated.toString())
+                            )
+                        )
+                    }
+                    result?.onInvalidInputError != null -> {
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    }
+                    result?.onNotAuthenticatedError != null -> {
+                        Result.failure(Exception("Not authenticated"))
+                    }
+                    else -> Result.failure(Exception("Unknown error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun deleteArticleDraft(id: String): Result<Unit> {
+        return try {
+            val response = apolloClient.mutation(DeleteArticleDraftMutation(id)).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.deleteArticleDraft
+                when {
+                    result?.onDeleteArticleDraftPayload != null -> Result.success(Unit)
+                    result?.onInvalidInputError != null ->
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    result?.onNotAuthenticatedError != null ->
+                        Result.failure(Exception("Not authenticated"))
+                    else -> Result.failure(Exception("Unknown error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getArticleDrafts(): Result<List<ArticleDraft>> {
+        return try {
+            val response = apolloClient.query(ArticleDraftsQuery())
+                .fetchPolicy(FetchPolicy.NetworkOnly)
+                .execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val drafts = response.data?.viewer?.articleDrafts?.edges?.map { edge ->
+                    val node = edge.node
+                    ArticleDraft(
+                        id = node.id,
+                        title = node.title,
+                        content = node.content.toString(),
+                        tags = node.tags,
+                        created = Instant.parse(node.created.toString()),
+                        updated = Instant.parse(node.updated.toString())
+                    )
+                } ?: emptyList()
+                Result.success(drafts)
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getArticleDraft(id: String): Result<ArticleDraft> {
+        return try {
+            val response = apolloClient.query(ArticleDraftQuery(id))
+                .fetchPolicy(FetchPolicy.NetworkOnly)
+                .execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val draft = response.data?.articleDraft
+                    ?: return Result.failure(Exception("Draft not found"))
+                Result.success(
+                    ArticleDraft(
+                        id = draft.id,
+                        title = draft.title,
+                        content = draft.content.toString(),
+                        tags = draft.tags,
+                        created = Instant.parse(draft.created.toString()),
+                        updated = Instant.parse(draft.updated.toString())
+                    )
+                )
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -232,6 +232,15 @@ data class QuotesResult(
     val endCursor: String?
 )
 
+data class ArticleDraft(
+    val id: String,
+    val title: String,
+    val content: String,
+    val tags: List<String>,
+    val created: Instant,
+    val updated: Instant
+)
+
 data class ProfileResult(
     val actor: Actor,
     val bio: String?,

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -41,7 +41,9 @@ import pub.hackers.android.ui.components.BottomNavItem
 import pub.hackers.android.ui.components.LocalFontScale
 import pub.hackers.android.ui.components.ProvideInAppBrowserUriHandler
 import pub.hackers.android.ui.screens.auth.SignInScreen
+import pub.hackers.android.ui.screens.compose.ComposeArticleScreen
 import pub.hackers.android.ui.screens.compose.ComposeScreen
+import pub.hackers.android.ui.screens.drafts.DraftsScreen
 import pub.hackers.android.ui.screens.explore.ExploreScreen
 import pub.hackers.android.ui.screens.notifications.NotificationsScreen
 import pub.hackers.android.ui.screens.postdetail.PostDetailScreen
@@ -124,6 +126,12 @@ sealed class DetailScreen(val route: String) {
         fun createRoute(handle: String) = "profile/$handle"
     }
     data object RecommendedActors : DetailScreen("recommended-actors")
+    data object ComposeArticle : DetailScreen("compose-article?draftId={draftId}") {
+        fun createRoute(draftId: String? = null): String {
+            return if (draftId != null) "compose-article?draftId=$draftId" else "compose-article"
+        }
+    }
+    data object Drafts : DetailScreen("drafts")
 }
 
 @Composable
@@ -322,6 +330,9 @@ fun HackersPubApp(
                     },
                     onRecommendedActorsClick = {
                         navController.navigate(DetailScreen.RecommendedActors.route)
+                    },
+                    onComposeArticleClick = {
+                        navController.navigate(DetailScreen.ComposeArticle.createRoute())
                     }
                 )
             }
@@ -398,6 +409,9 @@ fun HackersPubApp(
                     },
                     onProfileClick = { handle ->
                         navController.navigate(DetailScreen.Profile.createRoute(handle))
+                    },
+                    onDraftsClick = {
+                        navController.navigate(DetailScreen.Drafts.route)
                     },
                     isLoggedIn = isLoggedIn
                 )
@@ -513,6 +527,39 @@ fun HackersPubApp(
                     },
                     onQuoteClick = { postId ->
                         navController.navigate(DetailScreen.Compose.createRoute(quoteOf = postId))
+                    }
+                )
+            }
+
+            composable(
+                route = DetailScreen.ComposeArticle.route,
+                arguments = listOf(
+                    navArgument("draftId") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    }
+                )
+            ) { backStackEntry ->
+                val draftId = backStackEntry.arguments?.getString("draftId")
+                ComposeArticleScreen(
+                    draftId = draftId,
+                    onSaveSuccess = {
+                        navController.popBackStack()
+                    },
+                    onNavigateBack = {
+                        navController.popBackStack()
+                    }
+                )
+            }
+
+            composable(DetailScreen.Drafts.route) {
+                DraftsScreen(
+                    onNavigateBack = {
+                        navController.popBackStack()
+                    },
+                    onDraftClick = { draftId ->
+                        navController.navigate(DetailScreen.ComposeArticle.createRoute(draftId))
                     }
                 )
             }

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
@@ -140,7 +140,7 @@ fun ComposeArticleScreen(
                         .fillMaxWidth()
                         .focusRequester(titleFocusRequester),
                     enabled = !uiState.isSaving,
-                    textStyle = typography.headlineMedium.copy(
+                    textStyle = typography.titleLarge.copy(
                         color = colors.textPrimary
                     ),
                     cursorBrush = SolidColor(colors.composeAccent),
@@ -150,7 +150,7 @@ fun ComposeArticleScreen(
                             if (uiState.title.isEmpty()) {
                                 Text(
                                     text = stringResource(R.string.article_title_hint),
-                                    style = typography.headlineMedium,
+                                    style = typography.titleLarge,
                                     color = colors.textSecondary
                                 )
                             }

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
@@ -1,0 +1,273 @@
+package pub.hackers.android.ui.screens.compose
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import pub.hackers.android.R
+import pub.hackers.android.ui.theme.AppShapes
+import pub.hackers.android.ui.theme.LocalAppColors
+import pub.hackers.android.ui.theme.LocalAppTypography
+
+@Composable
+fun ComposeArticleScreen(
+    draftId: String? = null,
+    onSaveSuccess: () -> Unit,
+    onNavigateBack: () -> Unit,
+    viewModel: ComposeArticleViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+
+    val titleFocusRequester = remember { FocusRequester() }
+    val contentFocusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    LaunchedEffect(draftId) {
+        draftId?.let { viewModel.loadDraft(it) }
+    }
+
+    LaunchedEffect(uiState.isSaved) {
+        if (uiState.isSaved) {
+            snackbarHostState.showSnackbar("Draft saved")
+            viewModel.clearSavedFlag()
+        }
+    }
+
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        if (draftId == null) {
+            titleFocusRequester.requestFocus()
+        }
+    }
+
+    val saveEnabled = uiState.title.isNotBlank() && !uiState.isSaving
+
+    Scaffold(
+        contentWindowInsets = WindowInsets(0),
+        topBar = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 4.dp, vertical = 8.dp)
+            ) {
+                IconButton(
+                    onClick = onNavigateBack,
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(R.string.cancel),
+                        tint = colors.textPrimary
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.compose_article),
+                    style = typography.titleLarge,
+                    color = colors.textPrimary,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .imePadding()
+        ) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                // Title field
+                BasicTextField(
+                    value = uiState.title,
+                    onValueChange = { viewModel.updateTitle(it) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRequester(titleFocusRequester),
+                    enabled = !uiState.isSaving,
+                    textStyle = typography.headlineMedium.copy(
+                        color = colors.textPrimary
+                    ),
+                    cursorBrush = SolidColor(colors.composeAccent),
+                    singleLine = true,
+                    decorationBox = { innerTextField ->
+                        Box {
+                            if (uiState.title.isEmpty()) {
+                                Text(
+                                    text = stringResource(R.string.article_title_hint),
+                                    style = typography.headlineMedium,
+                                    color = colors.textSecondary
+                                )
+                            }
+                            innerTextField()
+                        }
+                    }
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Tags field
+                BasicTextField(
+                    value = uiState.tags,
+                    onValueChange = { viewModel.updateTags(it) },
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !uiState.isSaving,
+                    textStyle = typography.bodyMedium.copy(
+                        color = colors.textSecondary
+                    ),
+                    cursorBrush = SolidColor(colors.composeAccent),
+                    singleLine = true,
+                    decorationBox = { innerTextField ->
+                        Box {
+                            if (uiState.tags.isEmpty()) {
+                                Text(
+                                    text = stringResource(R.string.article_tags_hint),
+                                    style = typography.bodyMedium,
+                                    color = colors.textSecondary.copy(alpha = 0.5f)
+                                )
+                            }
+                            innerTextField()
+                        }
+                    }
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+                HorizontalDivider(color = colors.divider)
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Content field
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(4.dp),
+                    color = colors.surface,
+                    border = BorderStroke(1.dp, colors.divider)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(400.dp)
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) {
+                                contentFocusRequester.requestFocus()
+                                keyboardController?.show()
+                            }
+                            .padding(16.dp)
+                    ) {
+                        BasicTextField(
+                            value = uiState.content,
+                            onValueChange = { viewModel.updateContent(it) },
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .focusRequester(contentFocusRequester),
+                            enabled = !uiState.isSaving,
+                            textStyle = typography.bodyLarge.copy(
+                                color = colors.textBody
+                            ),
+                            cursorBrush = SolidColor(colors.composeAccent),
+                            decorationBox = { innerTextField ->
+                                Box {
+                                    if (uiState.content.isEmpty()) {
+                                        Text(
+                                            text = stringResource(R.string.article_content_hint),
+                                            style = typography.bodyLarge,
+                                            color = colors.textSecondary
+                                        )
+                                    }
+                                    innerTextField()
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+
+            // Bottom bar with Save Draft button
+            HorizontalDivider(color = colors.divider)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                contentAlignment = Alignment.CenterEnd
+            ) {
+                Button(
+                    onClick = { viewModel.saveDraft() },
+                    enabled = saveEnabled,
+                    shape = RoundedCornerShape(AppShapes.pillRadius),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = colors.composeAccent,
+                        contentColor = Color.White,
+                        disabledContainerColor = colors.composeAccent,
+                        disabledContentColor = Color.White,
+                    ),
+                    modifier = Modifier.alpha(if (saveEnabled) 1f else 0.4f)
+                ) {
+                    Text(
+                        text = if (uiState.isSaving) {
+                            stringResource(R.string.saving_draft)
+                        } else {
+                            stringResource(R.string.save_draft)
+                        },
+                        color = Color.White
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
@@ -1,0 +1,112 @@
+package pub.hackers.android.ui.screens.compose
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import pub.hackers.android.data.repository.HackersPubRepository
+import javax.inject.Inject
+
+data class ComposeArticleUiState(
+    val title: String = "",
+    val content: String = "",
+    val tags: String = "",
+    val draftId: String? = null,
+    val isSaving: Boolean = false,
+    val isSaved: Boolean = false,
+    val error: String? = null
+)
+
+@HiltViewModel
+class ComposeArticleViewModel @Inject constructor(
+    private val repository: HackersPubRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ComposeArticleUiState())
+    val uiState: StateFlow<ComposeArticleUiState> = _uiState.asStateFlow()
+
+    fun loadDraft(draftId: String) {
+        viewModelScope.launch {
+            repository.getArticleDraft(draftId)
+                .onSuccess { draft ->
+                    _uiState.update {
+                        it.copy(
+                            title = draft.title,
+                            content = draft.content,
+                            tags = draft.tags.joinToString(", "),
+                            draftId = draft.id
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update { it.copy(error = error.message) }
+                }
+        }
+    }
+
+    fun updateTitle(title: String) {
+        _uiState.update { it.copy(title = title) }
+    }
+
+    fun updateContent(content: String) {
+        _uiState.update { it.copy(content = content) }
+    }
+
+    fun updateTags(tags: String) {
+        _uiState.update { it.copy(tags = tags) }
+    }
+
+    fun saveDraft() {
+        val state = _uiState.value
+        if (state.title.isBlank()) {
+            _uiState.update { it.copy(error = "Title is required") }
+            return
+        }
+        if (state.isSaving) return
+
+        val tagsList = state.tags
+            .split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, error = null, isSaved = false) }
+
+            repository.saveArticleDraft(
+                title = state.title,
+                content = state.content,
+                tags = tagsList,
+                id = state.draftId
+            )
+                .onSuccess { draft ->
+                    _uiState.update {
+                        it.copy(
+                            isSaving = false,
+                            isSaved = true,
+                            draftId = draft.id
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            error = error.message,
+                            isSaving = false
+                        )
+                    }
+                }
+        }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+
+    fun clearSavedFlag() {
+        _uiState.update { it.copy(isSaved = false) }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/drafts/DraftsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/drafts/DraftsScreen.kt
@@ -1,0 +1,214 @@
+package pub.hackers.android.ui.screens.drafts
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import pub.hackers.android.R
+import pub.hackers.android.domain.model.ArticleDraft
+import pub.hackers.android.ui.components.ErrorMessage
+import pub.hackers.android.ui.components.FullScreenLoading
+import pub.hackers.android.ui.components.LargeTitleHeader
+import pub.hackers.android.ui.theme.LocalAppColors
+import pub.hackers.android.ui.theme.LocalAppTypography
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+@Composable
+fun DraftsScreen(
+    onNavigateBack: () -> Unit,
+    onDraftClick: (String) -> Unit,
+    viewModel: DraftsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    var draftToDelete by remember { mutableStateOf<ArticleDraft?>(null) }
+
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    // Delete confirmation dialog
+    draftToDelete?.let { draft ->
+        AlertDialog(
+            onDismissRequest = { draftToDelete = null },
+            title = { Text(stringResource(R.string.delete_draft), color = colors.textPrimary) },
+            text = { Text(stringResource(R.string.delete_draft_confirm), color = colors.textBody) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.deleteDraft(draft.id)
+                        draftToDelete = null
+                    }
+                ) {
+                    Text(stringResource(R.string.remove))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { draftToDelete = null }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    Scaffold(
+        contentWindowInsets = WindowInsets(0),
+        topBar = {
+            LargeTitleHeader(
+                title = stringResource(R.string.my_drafts),
+                leadingContent = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.cancel),
+                            tint = colors.textPrimary
+                        )
+                    }
+                }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            when {
+                uiState.isLoading && uiState.drafts.isEmpty() -> {
+                    FullScreenLoading()
+                }
+                uiState.error != null && uiState.drafts.isEmpty() -> {
+                    ErrorMessage(
+                        message = uiState.error ?: stringResource(R.string.error_generic),
+                        onRetry = { viewModel.loadDrafts() }
+                    )
+                }
+                uiState.drafts.isEmpty() -> {
+                    Text(
+                        text = stringResource(R.string.no_drafts),
+                        style = typography.bodyLarge,
+                        color = colors.textSecondary,
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+                else -> {
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(uiState.drafts, key = { it.id }) { draft ->
+                            DraftItem(
+                                draft = draft,
+                                isDeleting = uiState.deletingDraftId == draft.id,
+                                onClick = { onDraftClick(draft.id) },
+                                onDeleteClick = { draftToDelete = draft }
+                            )
+                            HorizontalDivider(color = colors.divider)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DraftItem(
+    draft: ArticleDraft,
+    isDeleting: Boolean,
+    onClick: () -> Unit,
+    onDeleteClick: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+
+    val dateFormatter = remember {
+        DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT)
+            .withZone(ZoneId.systemDefault())
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = !isDeleting, onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = draft.title.ifBlank { "(Untitled)" },
+                style = typography.titleMedium,
+                color = colors.textPrimary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = dateFormatter.format(draft.updated),
+                style = typography.bodySmall,
+                color = colors.textSecondary
+            )
+            if (draft.tags.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = draft.tags.joinToString(", "),
+                    style = typography.bodySmall,
+                    color = colors.textSecondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+
+        IconButton(
+            onClick = onDeleteClick,
+            enabled = !isDeleting,
+            modifier = Modifier.size(40.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Delete,
+                contentDescription = stringResource(R.string.delete_draft),
+                tint = if (isDeleting) colors.textSecondary.copy(alpha = 0.3f) else colors.textSecondary
+            )
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/drafts/DraftsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/drafts/DraftsScreen.kt
@@ -184,14 +184,14 @@ private fun DraftItem(
             Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = dateFormatter.format(draft.updated),
-                style = typography.bodySmall,
+                style = typography.labelMedium,
                 color = colors.textSecondary
             )
             if (draft.tags.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = draft.tags.joinToString(", "),
-                    style = typography.bodySmall,
+                    style = typography.labelMedium,
                     color = colors.textSecondary,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis

--- a/app/src/main/java/pub/hackers/android/ui/screens/drafts/DraftsViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/drafts/DraftsViewModel.kt
@@ -1,0 +1,85 @@
+package pub.hackers.android.ui.screens.drafts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import pub.hackers.android.data.repository.HackersPubRepository
+import pub.hackers.android.domain.model.ArticleDraft
+import javax.inject.Inject
+
+data class DraftsUiState(
+    val drafts: List<ArticleDraft> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val deletingDraftId: String? = null
+)
+
+@HiltViewModel
+class DraftsViewModel @Inject constructor(
+    private val repository: HackersPubRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(DraftsUiState())
+    val uiState: StateFlow<DraftsUiState> = _uiState.asStateFlow()
+
+    init {
+        loadDrafts()
+    }
+
+    fun loadDrafts() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+
+            repository.getArticleDrafts()
+                .onSuccess { drafts ->
+                    _uiState.update {
+                        it.copy(
+                            drafts = drafts,
+                            isLoading = false
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            error = error.message,
+                            isLoading = false
+                        )
+                    }
+                }
+        }
+    }
+
+    fun deleteDraft(draftId: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(deletingDraftId = draftId) }
+
+            repository.deleteArticleDraft(draftId)
+                .onSuccess {
+                    _uiState.update { state ->
+                        state.copy(
+                            drafts = state.drafts.filter { it.id != draftId },
+                            deletingDraftId = null
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            error = error.message,
+                            deletingDraftId = null
+                        )
+                    }
+                }
+        }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
@@ -59,6 +59,7 @@ fun SettingsScreen(
     onSignInClick: () -> Unit,
     onSignOutComplete: () -> Unit,
     onProfileClick: (String) -> Unit,
+    onDraftsClick: () -> Unit = {},
     isLoggedIn: Boolean,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.automirrored.outlined.Article
 import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Login
@@ -181,6 +182,29 @@ fun SettingsScreen(
                     Spacer(modifier = Modifier.width(16.dp))
                     Text(
                         text = stringResource(R.string.sign_out),
+                        style = typography.bodyLarge,
+                        color = colors.textPrimary
+                    )
+                }
+
+                HorizontalDivider(color = colors.divider, thickness = 1.dp)
+
+                // My Drafts
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onDraftsClick() }
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.Article,
+                        contentDescription = null,
+                        tint = colors.textSecondary
+                    )
+                    Spacer(modifier = Modifier.width(16.dp))
+                    Text(
+                        text = stringResource(R.string.my_drafts),
                         style = typography.bodyLarge,
                         color = colors.textPrimary
                     )

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -60,6 +60,7 @@ fun TimelineScreen(
     onQuoteClick: (String) -> Unit = {},
     onSettingsClick: () -> Unit,
     onRecommendedActorsClick: () -> Unit = {},
+    onComposeArticleClick: () -> Unit = {},
     postedAt: Long = 0L,
     tabRetapped: Long = 0L,
     userAvatarUrl: String? = null,

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -13,14 +13,18 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.automirrored.outlined.Article
 import androidx.compose.material.icons.outlined.PersonAdd
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -71,6 +75,11 @@ fun TimelineScreen(
     val context = LocalContext.current
     val colors = LocalAppColors.current
     val coroutineScope = rememberCoroutineScope()
+
+    // Refresh draft count when screen becomes visible
+    LaunchedEffect(Unit) {
+        viewModel.loadDraftCount()
+    }
 
     LaunchedEffect(postedAt) {
         if (postedAt > 0L) {
@@ -130,6 +139,30 @@ fun TimelineScreen(
         contentWindowInsets = WindowInsets(0),
         topBar = {
             LargeTitleHeader(title = stringResource(R.string.personal_timeline)) {
+                // New article button with draft badge
+                Box(
+                    modifier = Modifier
+                        .size(28.dp)
+                        .background(color = colors.surface, shape = CircleShape)
+                        .clickable { onComposeArticleClick() },
+                    contentAlignment = Alignment.Center
+                ) {
+                    BadgedBox(
+                        badge = {
+                            if (uiState.draftCount > 0) {
+                                Badge { Text(uiState.draftCount.toString()) }
+                            }
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Outlined.Article,
+                            contentDescription = stringResource(R.string.new_article),
+                            tint = colors.accent,
+                            modifier = Modifier.size(22.dp)
+                        )
+                    }
+                }
+
                 // Recommended actors button
                 Box(
                     modifier = Modifier

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
@@ -23,7 +23,8 @@ data class TimelineUiState(
     val hasNextPage: Boolean = false,
     val endCursor: String? = null,
     val error: String? = null,
-    val reactionPickerPostId: String? = null
+    val reactionPickerPostId: String? = null,
+    val draftCount: Int = 0
 )
 
 @HiltViewModel
@@ -40,6 +41,16 @@ class TimelineViewModel @Inject constructor(
 
     init {
         loadTimeline()
+        loadDraftCount()
+    }
+
+    fun loadDraftCount() {
+        viewModelScope.launch {
+            repository.getArticleDrafts()
+                .onSuccess { drafts ->
+                    _uiState.update { it.copy(draftCount = drafts.size) }
+                }
+        }
     }
 
     fun refreshIfStale() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,24 @@
     <string name="visibility_unlisted">Unlisted</string>
     <string name="visibility_followers">Followers only</string>
 
+    <!-- Article Compose -->
+    <string name="new_article">New Article</string>
+    <string name="compose_article">Write Article</string>
+    <string name="article_title_hint">Article title</string>
+    <string name="article_content_hint">Write your article in Markdown…</string>
+    <string name="article_tags_hint">Tags (comma separated)</string>
+    <string name="save_draft">Save Draft</string>
+    <string name="saving_draft">Saving draft…</string>
+    <string name="draft_saved">Draft saved</string>
+    <string name="article_title_required">Title is required</string>
+    <string name="article_content_required">Content is required</string>
+
+    <!-- Drafts -->
+    <string name="my_drafts">My Drafts</string>
+    <string name="no_drafts">No drafts yet</string>
+    <string name="delete_draft">Delete Draft</string>
+    <string name="delete_draft_confirm">Are you sure you want to delete this draft?</string>
+
     <!-- Notifications -->
     <string name="notification_follow">followed you</string>
     <string name="notification_mention">mentioned you</string>


### PR DESCRIPTION
## Summary
Add the ability to create and save article drafts from the home screen. A new article icon (with draft count badge) in the timeline top bar opens a full article editor with title, tags, and markdown content fields. Saved drafts are accessible from Settings > My Drafts, where users can resume editing or delete drafts.