### PR TITLE
Fix Timeline tab being unresponsive after arriving from a system notification

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -168,11 +168,19 @@ fun HackersPubApp(
         }
     }
 
-    // Handle navigation intent from system notifications or deep links
+    // Handle navigation intent from system notifications or deep links.
+    // Uses the same options as bottom-nav onItemSelected so that back-stack
+    // save/restore markers line up; otherwise Timeline (=startDestination)
+    // gets stuck in a no-op state on the first bottom-nav tap after arriving
+    // here from a system notification.
     LaunchedEffect(navigationIntent) {
         navigationIntent?.let {
             navController.navigate(it.route) {
+                popUpTo(navController.graph.findStartDestination().id) {
+                    saveState = true
+                }
                 launchSingleTop = true
+                restoreState = true
             }
             onNavigationIntentConsumed()
         }


### PR DESCRIPTION
## Summary

시스템 알림(Android status bar) 탭으로 앱에 들어왔을 때 bottom nav 의 **Timeline** 탭만 무반응이 되는 기존 버그를 수정.

## 증상

- Status-bar 알림 탭 → 앱이 실행되며 Notifications 화면 도착 (정상)
- 그 상태에서 bottom nav 의 **Timeline** 탭 눌러도 ripple 도 없고 전환도 없음
- Explore / Search / Settings 등 **다른 탭은 정상 전환**
- BACK 버튼 한 번 누르면 Timeline 화면이 나타남
- **In-app 경로**(bottom nav 로 Notifications → Timeline) 는 처음부터 정상 동작

## 원인

`LaunchedEffect(navigationIntent)` (`HackersPubApp.kt:172-179`) 의 navigate options 가 bottom-nav `onItemSelected` (`HackersPubApp.kt:286-292`) 와 다른 형태:

```kotlin
// Before — LaunchedEffect
navController.navigate(it.route) {
    launchSingleTop = true   // popUpTo / saveState / restoreState 없음
}

// onItemSelected (bottom-nav) — works correctly
navController.navigate(item.route) {
    popUpTo(navController.graph.findStartDestination().id) {
        saveState = true
    }
    launchSingleTop = true
    restoreState = true
}
```

알림 진입 시:

1. NavHost 초기화 → back stack `[Timeline]` (startDestination)
2. `LaunchedEffect(navigationIntent)` 이 `navigate("notifications") { launchSingleTop = true }` 만 호출 → `[Timeline, Notifications]`. Timeline 엔트리에 `saveState` 마커가 붙지 않음
3. 사용자가 Timeline 탭 클릭 → bottom-nav 의 `popUpTo(start) saveState=true; launchSingleTop=true; restoreState=true` 실행
4. Timeline 엔트리에 매칭되는 saved state 가 없는데 `restoreState=true` 로 복원 시도 + `launchSingleTop=true` 로 재사용 요청 → Compose Navigation 의 startDestination 관련 edge case 로 **시각적으로 no-op** (Google IssueTracker [#179469431](https://issuetracker.google.com/issues/179469431) 및 관련 리포트)
5. BACK 은 표준 popBackStack 이라 정상 동작. 다른 탭은 startDestination 이 아니어서 이 edge case 를 건드리지 않음

## Fix

`LaunchedEffect(navigationIntent)` 의 navigate options 를 bottom-nav 와 정확히 같은 형태로 통일:

```kotlin
navController.navigate(it.route) {
    popUpTo(navController.graph.findStartDestination().id) {
        saveState = true
    }
    launchSingleTop = true
    restoreState = true
}
```

이렇게 하면 알림 진입 시 Timeline 엔트리에 `saveState` 마커가 붙고, 이후 bottom-nav Timeline 탭의 `restoreState` 가 기대한 pair 로 매칭되어 pop + restore 가 정상 수행된다.

## 스코프 외

- 동일 패턴 불일치가 `deepLinkData` `LaunchedEffect` 와 `ProvideInAppBrowserUriHandler` 의 `onInternalNavigate` 에도 있지만 증상과 직접 연결된 곳만 정확히 집어 수정. 나머지는 관찰 대상.
- `NotificationWorker.kt` 의 `putExtra("navigate_to", "notifications")` 하드코딩으로 모든 알림이 Notifications 목록으로만 direct 하는 문제는 별개. 별도 PR 에서 route-per-notification 처리 예정.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
- [ ] 실기 검증:
  - [ ] 앱 완전 종료 상태 → status-bar 알림 탭 → Notifications 도착 후 bottom-nav Timeline 탭 → Timeline 으로 즉시 전환
  - [ ] 같은 상태에서 Explore / Search / Settings 탭도 회귀 없이 정상 동작
  - [ ] 앱 foreground 상태에서 status-bar 알림 탭(`onNewIntent` 경로) 도 동일 확인
  - [ ] BACK 버튼 동작 정상
  - [ ] In-app bottom-nav 로 Notifications → Timeline 여전히 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)