### PR TITLE
Use HTTPS applink URL for sign-in verification email

### DIFF
--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -480,7 +480,7 @@ class HackersPubRepository @Inject constructor(
                 LoginByUsernameMutation(
                     username = username,
                     locale = locale,
-                    verifyUrl = "hackerspub://verify?token={token}&code={code}"
+                    verifyUrl = "https://hackers.pub/applink/sign/in/{token}?code={code}"
                 )
             ).execute()
 


### PR DESCRIPTION
## Summary
Switch the `verifyUrl` sent in login mutations from the custom `hackerspub://verify` scheme to the HTTPS applink route (`https://hackers.pub/applink/sign/in/{token}?code={code}`). This lets the web server's applink handler manage app-open detection with an intent fallback, instead of relying on the custom scheme which some email clients may not support.

---
Assisted-By: Claude Code(claude-opus-4-6)