### PR TITLE
feat: Add article publish flow for drafts

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -869,3 +869,22 @@ query ArticleDraft($id: ID!) {
         updated
     }
 }
+
+mutation PublishArticleDraft($id: ID!, $slug: String!, $language: Locale!, $allowLlmTranslation: Boolean) {
+    publishArticleDraft(input: { id: $id, slug: $slug, language: $language, allowLlmTranslation: $allowLlmTranslation }) {
+        ... on PublishArticleDraftPayload {
+            article {
+                id
+                name
+                url
+            }
+            deletedDraftId
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -31,6 +31,7 @@ import pub.hackers.android.graphql.PostQuotesQuery
 import pub.hackers.android.graphql.PostRepliesQuery
 import pub.hackers.android.graphql.PostSharesQuery
 import pub.hackers.android.graphql.PostDetailQuery
+import pub.hackers.android.graphql.PublishArticleDraftMutation
 import pub.hackers.android.graphql.PublicTimelineQuery
 import pub.hackers.android.graphql.RecommendedActorsQuery
 import pub.hackers.android.graphql.RemoveFollowerMutation
@@ -1174,6 +1175,51 @@ class HackersPubRepository @Inject constructor(
                         Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
                     result?.onNotAuthenticatedError != null ->
                         Result.failure(Exception("Not authenticated"))
+                    else -> Result.failure(Exception("Unknown error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun publishArticleDraft(
+        id: String,
+        slug: String,
+        language: String,
+        allowLlmTranslation: Boolean = true
+    ): Result<PublishedArticle> {
+        return try {
+            val response = apolloClient.mutation(
+                PublishArticleDraftMutation(
+                    id = id,
+                    slug = slug,
+                    language = language,
+                    allowLlmTranslation = Optional.present(allowLlmTranslation)
+                )
+            ).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.publishArticleDraft
+                when {
+                    result?.onPublishArticleDraftPayload != null -> {
+                        val article = result.onPublishArticleDraftPayload.article
+                        Result.success(
+                            PublishedArticle(
+                                id = article.id,
+                                name = article.name,
+                                url = article.url?.toString()
+                            )
+                        )
+                    }
+                    result?.onInvalidInputError != null -> {
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    }
+                    result?.onNotAuthenticatedError != null -> {
+                        Result.failure(Exception("Not authenticated"))
+                    }
                     else -> Result.failure(Exception("Unknown error"))
                 }
             }

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -272,6 +272,13 @@ data class ArticleDraft(
 )
 
 @Immutable
+data class PublishedArticle(
+    val id: String,
+    val name: String?,
+    val url: String?
+)
+
+@Immutable
 data class ProfileResult(
     val actor: Actor,
     val bio: String?,

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -341,6 +341,9 @@ fun HackersPubApp(
                     },
                     onComposeArticleClick = {
                         navController.navigate(DetailScreen.ComposeArticle.createRoute())
+                    },
+                    onComposeArticleLongClick = {
+                        navController.navigate(DetailScreen.Drafts.route)
                     }
                 )
             }

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -558,6 +558,10 @@ fun HackersPubApp(
                     onSaveSuccess = {
                         navController.popBackStack()
                     },
+                    onPublishSuccess = { articleId ->
+                        navController.popBackStack()
+                        navController.navigate(DetailScreen.PostDetail.createRoute(articleId))
+                    },
                     onNavigateBack = {
                         navController.popBackStack()
                     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
@@ -1,10 +1,15 @@
 package pub.hackers.android.ui.screens.compose
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -23,6 +29,9 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -77,6 +86,13 @@ fun ComposeArticleScreen(
         }
     }
 
+    LaunchedEffect(uiState.isPublished) {
+        if (uiState.isPublished) {
+            snackbarHostState.showSnackbar("Article published")
+            onSaveSuccess()
+        }
+    }
+
     LaunchedEffect(uiState.error) {
         uiState.error?.let {
             snackbarHostState.showSnackbar(it)
@@ -90,7 +106,8 @@ fun ComposeArticleScreen(
         }
     }
 
-    val saveEnabled = uiState.title.isNotBlank() && !uiState.isSaving
+    val saveEnabled = uiState.title.isNotBlank() && !uiState.isSaving && !uiState.isPublishing
+    val publishEnabled = uiState.title.isNotBlank() && !uiState.isSaving && !uiState.isPublishing
 
     Scaffold(
         contentWindowInsets = WindowInsets(0),
@@ -139,7 +156,7 @@ fun ComposeArticleScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .focusRequester(titleFocusRequester),
-                    enabled = !uiState.isSaving,
+                    enabled = !uiState.isSaving && !uiState.isPublishing,
                     textStyle = typography.titleLarge.copy(
                         color = colors.textPrimary
                     ),
@@ -166,7 +183,7 @@ fun ComposeArticleScreen(
                     value = uiState.tags,
                     onValueChange = { viewModel.updateTags(it) },
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !uiState.isSaving,
+                    enabled = !uiState.isSaving && !uiState.isPublishing,
                     textStyle = typography.bodyMedium.copy(
                         color = colors.textSecondary
                     ),
@@ -216,7 +233,7 @@ fun ComposeArticleScreen(
                             modifier = Modifier
                                 .fillMaxSize()
                                 .focusRequester(contentFocusRequester),
-                            enabled = !uiState.isSaving,
+                            enabled = !uiState.isSaving && !uiState.isPublishing,
                             textStyle = typography.bodyLarge.copy(
                                 color = colors.textBody
                             ),
@@ -238,34 +255,154 @@ fun ComposeArticleScreen(
                 }
             }
 
-            // Bottom bar with Save Draft button
-            HorizontalDivider(color = colors.divider)
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                contentAlignment = Alignment.CenterEnd
+            // Publish fields (slug + language)
+            AnimatedVisibility(
+                visible = uiState.showPublishFields,
+                enter = expandVertically(),
+                exit = shrinkVertically()
             ) {
-                Button(
-                    onClick = { viewModel.saveDraft() },
-                    enabled = saveEnabled,
-                    shape = RoundedCornerShape(AppShapes.pillRadius),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = colors.composeAccent,
-                        contentColor = Color.White,
-                        disabledContainerColor = colors.composeAccent,
-                        disabledContentColor = Color.White,
-                    ),
-                    modifier = Modifier.alpha(if (saveEnabled) 1f else 0.4f)
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
                 ) {
+                    HorizontalDivider(color = colors.divider)
+                    Spacer(modifier = Modifier.height(12.dp))
+
                     Text(
-                        text = if (uiState.isSaving) {
-                            stringResource(R.string.saving_draft)
-                        } else {
-                            stringResource(R.string.save_draft)
-                        },
-                        color = Color.White
+                        text = stringResource(R.string.publish_confirm_title),
+                        style = typography.titleMedium,
+                        color = colors.textPrimary
                     )
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    OutlinedTextField(
+                        value = uiState.slug,
+                        onValueChange = { viewModel.updateSlug(it) },
+                        label = { Text(stringResource(R.string.article_slug_hint)) },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        enabled = !uiState.isPublishing,
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = colors.composeAccent,
+                            focusedLabelColor = colors.composeAccent,
+                            cursorColor = colors.composeAccent,
+                            focusedTextColor = colors.textPrimary,
+                            unfocusedTextColor = colors.textPrimary,
+                            unfocusedBorderColor = colors.divider,
+                            unfocusedLabelColor = colors.textSecondary
+                        )
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    OutlinedTextField(
+                        value = uiState.language,
+                        onValueChange = { viewModel.updateLanguage(it) },
+                        label = { Text(stringResource(R.string.article_language_label)) },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        enabled = !uiState.isPublishing,
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = colors.composeAccent,
+                            focusedLabelColor = colors.composeAccent,
+                            cursorColor = colors.composeAccent,
+                            focusedTextColor = colors.textPrimary,
+                            unfocusedTextColor = colors.textPrimary,
+                            unfocusedBorderColor = colors.divider,
+                            unfocusedLabelColor = colors.textSecondary
+                        )
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        OutlinedButton(
+                            onClick = { viewModel.hidePublishFields() },
+                            enabled = !uiState.isPublishing,
+                            shape = RoundedCornerShape(AppShapes.pillRadius)
+                        ) {
+                            Text(
+                                text = stringResource(R.string.cancel),
+                                color = colors.textSecondary
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Button(
+                            onClick = { viewModel.publishDraft() },
+                            enabled = uiState.slug.isNotBlank() && !uiState.isPublishing,
+                            shape = RoundedCornerShape(AppShapes.pillRadius),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = colors.composeAccent,
+                                contentColor = Color.White,
+                                disabledContainerColor = colors.composeAccent,
+                                disabledContentColor = Color.White,
+                            ),
+                            modifier = Modifier.alpha(
+                                if (uiState.slug.isNotBlank() && !uiState.isPublishing) 1f else 0.4f
+                            )
+                        ) {
+                            Text(
+                                text = if (uiState.isPublishing) {
+                                    stringResource(R.string.publishing_article)
+                                } else {
+                                    stringResource(R.string.publish_article)
+                                },
+                                color = Color.White
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+            }
+
+            // Bottom bar with Save Draft + Publish buttons
+            if (!uiState.showPublishFields) {
+                HorizontalDivider(color = colors.divider)
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    OutlinedButton(
+                        onClick = { viewModel.saveDraft() },
+                        enabled = saveEnabled,
+                        shape = RoundedCornerShape(AppShapes.pillRadius),
+                        border = BorderStroke(
+                            1.dp,
+                            if (saveEnabled) colors.composeAccent else colors.composeAccent.copy(alpha = 0.4f)
+                        ),
+                        modifier = Modifier.alpha(if (saveEnabled) 1f else 0.4f)
+                    ) {
+                        Text(
+                            text = if (uiState.isSaving) {
+                                stringResource(R.string.saving_draft)
+                            } else {
+                                stringResource(R.string.save_draft)
+                            },
+                            color = colors.composeAccent
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Button(
+                        onClick = { viewModel.showPublishFields() },
+                        enabled = publishEnabled,
+                        shape = RoundedCornerShape(AppShapes.pillRadius),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = colors.composeAccent,
+                            contentColor = Color.White,
+                            disabledContainerColor = colors.composeAccent,
+                            disabledContentColor = Color.White,
+                        ),
+                        modifier = Modifier.alpha(if (publishEnabled) 1f else 0.4f)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.publish_article),
+                            color = Color.White
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -255,7 +257,7 @@ fun ComposeArticleScreen(
                 }
             }
 
-            // Publish fields (slug + language)
+            // Publish fields (slug, language, allow LLM translation)
             AnimatedVisibility(
                 visible = uiState.showPublishFields,
                 enter = expandVertically(),
@@ -312,7 +314,35 @@ fun ComposeArticleScreen(
                             unfocusedLabelColor = colors.textSecondary
                         )
                     )
-                    Spacer(modifier = Modifier.height(12.dp))
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) {
+                                viewModel.updateAllowLlmTranslation(!uiState.allowLlmTranslation)
+                            },
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Checkbox(
+                            checked = uiState.allowLlmTranslation,
+                            onCheckedChange = { viewModel.updateAllowLlmTranslation(it) },
+                            enabled = !uiState.isPublishing,
+                            colors = CheckboxDefaults.colors(
+                                checkedColor = colors.composeAccent,
+                                uncheckedColor = colors.textSecondary
+                            )
+                        )
+                        Text(
+                            text = stringResource(R.string.allow_llm_translation),
+                            style = typography.bodyMedium,
+                            color = colors.textPrimary
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
 
                     Row(
                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
@@ -64,6 +64,7 @@ import pub.hackers.android.ui.theme.LocalAppTypography
 fun ComposeArticleScreen(
     draftId: String? = null,
     onSaveSuccess: () -> Unit,
+    onPublishSuccess: (articleId: String) -> Unit,
     onNavigateBack: () -> Unit,
     viewModel: ComposeArticleViewModel = hiltViewModel()
 ) {
@@ -90,8 +91,12 @@ fun ComposeArticleScreen(
 
     LaunchedEffect(uiState.isPublished) {
         if (uiState.isPublished) {
-            snackbarHostState.showSnackbar("Article published")
-            onSaveSuccess()
+            val articleId = uiState.publishedArticleId
+            if (articleId != null) {
+                onPublishSuccess(articleId)
+            } else {
+                onSaveSuccess()
+            }
         }
     }
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
@@ -1,8 +1,13 @@
 package pub.hackers.android.ui.screens.compose
 
+import android.content.Context
+import android.os.Build
+import android.view.textclassifier.TextClassificationManager
+import android.view.textclassifier.TextLanguage
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,12 +23,19 @@ data class ComposeArticleUiState(
     val draftId: String? = null,
     val isSaving: Boolean = false,
     val isSaved: Boolean = false,
+    val slug: String = "",
+    val language: String = java.util.Locale.getDefault().language,
+    val showPublishFields: Boolean = false,
+    val isPublishing: Boolean = false,
+    val isPublished: Boolean = false,
+    val publishedArticleUrl: String? = null,
     val error: String? = null
 )
 
 @HiltViewModel
 class ComposeArticleViewModel @Inject constructor(
-    private val repository: HackersPubRepository
+    private val repository: HackersPubRepository,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ComposeArticleUiState())
@@ -38,9 +50,11 @@ class ComposeArticleViewModel @Inject constructor(
                             title = draft.title,
                             content = draft.content,
                             tags = draft.tags.joinToString(", "),
-                            draftId = draft.id
+                            draftId = draft.id,
+                            slug = generateSlug(draft.title)
                         )
                     }
+                    detectLanguage(draft.content)
                 }
                 .onFailure { error ->
                     _uiState.update { it.copy(error = error.message) }
@@ -49,15 +63,29 @@ class ComposeArticleViewModel @Inject constructor(
     }
 
     fun updateTitle(title: String) {
-        _uiState.update { it.copy(title = title) }
+        _uiState.update {
+            it.copy(
+                title = title,
+                slug = if (!it.showPublishFields) generateSlug(title) else it.slug
+            )
+        }
     }
 
     fun updateContent(content: String) {
         _uiState.update { it.copy(content = content) }
+        detectLanguage(content)
     }
 
     fun updateTags(tags: String) {
         _uiState.update { it.copy(tags = tags) }
+    }
+
+    fun updateSlug(slug: String) {
+        _uiState.update { it.copy(slug = slug) }
+    }
+
+    fun updateLanguage(language: String) {
+        _uiState.update { it.copy(language = language) }
     }
 
     fun saveDraft() {
@@ -102,11 +130,121 @@ class ComposeArticleViewModel @Inject constructor(
         }
     }
 
+    fun showPublishFields() {
+        val state = _uiState.value
+        if (state.title.isBlank()) {
+            _uiState.update { it.copy(error = "Title is required") }
+            return
+        }
+        _uiState.update { it.copy(showPublishFields = true) }
+    }
+
+    fun hidePublishFields() {
+        _uiState.update { it.copy(showPublishFields = false) }
+    }
+
+    fun publishDraft() {
+        val state = _uiState.value
+        if (state.slug.isBlank()) {
+            _uiState.update { it.copy(error = "Slug is required") }
+            return
+        }
+        if (state.isPublishing) return
+
+        viewModelScope.launch {
+            // Save draft first if not yet saved
+            if (state.draftId == null) {
+                _uiState.update { it.copy(isSaving = true, error = null) }
+
+                val tagsList = state.tags
+                    .split(",")
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() }
+
+                val saveResult = repository.saveArticleDraft(
+                    title = state.title,
+                    content = state.content,
+                    tags = tagsList
+                )
+
+                saveResult.onFailure { error ->
+                    _uiState.update { it.copy(error = error.message, isSaving = false) }
+                    return@launch
+                }
+
+                saveResult.onSuccess { draft ->
+                    _uiState.update { it.copy(draftId = draft.id, isSaving = false) }
+                }
+            }
+
+            val draftId = _uiState.value.draftId ?: return@launch
+
+            _uiState.update { it.copy(isPublishing = true, error = null) }
+
+            repository.publishArticleDraft(
+                id = draftId,
+                slug = state.slug,
+                language = state.language
+            )
+                .onSuccess { article ->
+                    _uiState.update {
+                        it.copy(
+                            isPublishing = false,
+                            isPublished = true,
+                            publishedArticleUrl = article.url
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            error = error.message,
+                            isPublishing = false
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun detectLanguage(text: String) {
+        if (text.isBlank() || text.length < 20) return
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                val tcm = context.getSystemService(Context.TEXT_CLASSIFICATION_SERVICE) as? TextClassificationManager
+                val classifier = tcm?.textClassifier ?: return
+                val request = TextLanguage.Request.Builder(text).build()
+                val result = classifier.detectLanguage(request)
+                if (result.localeHypothesisCount > 0) {
+                    val topLocale = result.getLocale(0)
+                    val lang = topLocale.language
+                    if (lang.isNotEmpty()) {
+                        _uiState.update { it.copy(language = lang) }
+                    }
+                }
+            }
+        } catch (_: Exception) {
+            // Fallback: keep current language
+        }
+    }
+
     fun clearError() {
         _uiState.update { it.copy(error = null) }
     }
 
     fun clearSavedFlag() {
         _uiState.update { it.copy(isSaved = false) }
+    }
+
+    companion object {
+        fun generateSlug(title: String): String {
+            return title
+                .lowercase()
+                .replace(Regex("[^a-z0-9\\s-]"), "")
+                .replace(Regex("\\s+"), "-")
+                .replace(Regex("-+"), "-")
+                .trim('-')
+                .take(128)
+        }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
@@ -25,6 +25,7 @@ data class ComposeArticleUiState(
     val isSaved: Boolean = false,
     val slug: String = "",
     val language: String = java.util.Locale.getDefault().language,
+    val allowLlmTranslation: Boolean = true,
     val showPublishFields: Boolean = false,
     val isPublishing: Boolean = false,
     val isPublished: Boolean = false,
@@ -66,7 +67,7 @@ class ComposeArticleViewModel @Inject constructor(
         _uiState.update {
             it.copy(
                 title = title,
-                slug = if (!it.showPublishFields) generateSlug(title) else it.slug
+                slug = generateSlug(title)
             )
         }
     }
@@ -86,6 +87,10 @@ class ComposeArticleViewModel @Inject constructor(
 
     fun updateLanguage(language: String) {
         _uiState.update { it.copy(language = language) }
+    }
+
+    fun updateAllowLlmTranslation(allow: Boolean) {
+        _uiState.update { it.copy(allowLlmTranslation = allow) }
     }
 
     fun saveDraft() {
@@ -145,6 +150,10 @@ class ComposeArticleViewModel @Inject constructor(
 
     fun publishDraft() {
         val state = _uiState.value
+        if (state.title.isBlank()) {
+            _uiState.update { it.copy(error = "Title is required") }
+            return
+        }
         if (state.slug.isBlank()) {
             _uiState.update { it.copy(error = "Slug is required") }
             return
@@ -184,7 +193,8 @@ class ComposeArticleViewModel @Inject constructor(
             repository.publishArticleDraft(
                 id = draftId,
                 slug = state.slug,
-                language = state.language
+                language = state.language,
+                allowLlmTranslation = state.allowLlmTranslation
             )
                 .onSuccess { article ->
                     _uiState.update {

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
@@ -250,7 +250,7 @@ class ComposeArticleViewModel @Inject constructor(
         fun generateSlug(title: String): String {
             return title
                 .lowercase()
-                .replace(Regex("[^a-z0-9\\s-]"), "")
+                .replace(Regex("[^\\p{L}\\p{N}\\s-]"), "")
                 .replace(Regex("\\s+"), "-")
                 .replace(Regex("-+"), "-")
                 .trim('-')

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
@@ -29,6 +29,7 @@ data class ComposeArticleUiState(
     val showPublishFields: Boolean = false,
     val isPublishing: Boolean = false,
     val isPublished: Boolean = false,
+    val publishedArticleId: String? = null,
     val publishedArticleUrl: String? = null,
     val error: String? = null
 )
@@ -201,6 +202,7 @@ class ComposeArticleViewModel @Inject constructor(
                         it.copy(
                             isPublishing = false,
                             isPublished = true,
+                            publishedArticleId = article.id,
                             publishedArticleUrl = article.url
                         )
                     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -2,7 +2,9 @@ package pub.hackers.android.ui.screens.timeline
 
 import android.content.Intent
 import androidx.compose.foundation.background
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -54,7 +56,7 @@ import pub.hackers.android.ui.components.PostCard
 import pub.hackers.android.ui.components.ReactionPicker
 import pub.hackers.android.ui.theme.LocalAppColors
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun TimelineScreen(
     onPostClick: (String) -> Unit,
@@ -64,6 +66,7 @@ fun TimelineScreen(
     onSettingsClick: () -> Unit,
     onRecommendedActorsClick: () -> Unit = {},
     onComposeArticleClick: () -> Unit = {},
+    onComposeArticleLongClick: () -> Unit = {},
     postedAt: Long = 0L,
     tabRetapped: Long = 0L,
     userAvatarUrl: String? = null,
@@ -133,7 +136,10 @@ fun TimelineScreen(
                     modifier = Modifier
                         .size(28.dp)
                         .background(color = colors.surface, shape = CircleShape)
-                        .clickable { onComposeArticleClick() },
+                        .combinedClickable(
+                            onClick = { onComposeArticleClick() },
+                            onLongClick = { onComposeArticleLongClick() }
+                        ),
                     contentAlignment = Alignment.Center
                 ) {
                     BadgedBox(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="article_language_label">Language</string>
     <string name="publish_confirm_title">Publish Article</string>
     <string name="article_slug_required">Slug is required</string>
+    <string name="allow_llm_translation">Allow LLM translation</string>
 
     <!-- Drafts -->
     <string name="my_drafts">My Drafts</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,13 @@
     <string name="draft_saved">Draft saved</string>
     <string name="article_title_required">Title is required</string>
     <string name="article_content_required">Content is required</string>
+    <string name="publish_article">Publish</string>
+    <string name="publishing_article">Publishing…</string>
+    <string name="article_published">Article published</string>
+    <string name="article_slug_hint">URL slug</string>
+    <string name="article_language_label">Language</string>
+    <string name="publish_confirm_title">Publish Article</string>
+    <string name="article_slug_required">Slug is required</string>
 
     <!-- Drafts -->
     <string name="my_drafts">My Drafts</string>


### PR DESCRIPTION
## Summary
Add a complete article publish flow to the compose article screen, matching the web-next implementation. The publish step exposes an auto-generated (but editable) slug, auto-detected language field, and an "Allow LLM Translation" checkbox. After publishing, the app navigates to the article detail page. Long-pressing the article icon in the timeline header now opens the drafts list for quick access.

---
Assisted-By: Claude Code(claude-opus-4-6)