### PR TITLE
Fix timeline refresh after composing a post

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/AppViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/AppViewModel.kt
@@ -22,6 +22,7 @@ import pub.hackers.android.data.local.PreferencesManager
 import pub.hackers.android.data.local.SessionManager
 import pub.hackers.android.data.repository.HackersPubRepository
 import pub.hackers.android.data.worker.NotificationWorker
+import pub.hackers.android.ui.screens.timeline.TimelineRefreshTrigger
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -31,7 +32,8 @@ class AppViewModel @Inject constructor(
     val preferencesManager: PreferencesManager,
     private val notificationStateManager: NotificationStateManager,
     private val workManager: WorkManager,
-    private val repository: HackersPubRepository
+    private val repository: HackersPubRepository,
+    val timelineRefreshTrigger: TimelineRefreshTrigger,
 ) : ViewModel() {
 
     companion object {

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -312,14 +312,10 @@ fun HackersPubApp(
                 .consumeWindowInsets(innerPadding)
         ) {
             composable(Screen.Timeline.route) { backStackEntry ->
-                val postedTimestamp by backStackEntry.savedStateHandle
-                    .getStateFlow<Long>("postedAt", 0L)
-                    .collectAsState()
                 val tabRetapped by backStackEntry.savedStateHandle
                     .getStateFlow<Long>("tabRetapped", 0L)
                     .collectAsState()
                 TimelineScreen(
-                    postedAt = postedTimestamp,
                     tabRetapped = tabRetapped,
                     onPostClick = { postId ->
                         navController.navigate(DetailScreen.PostDetail.createRoute(postId))
@@ -477,9 +473,7 @@ fun HackersPubApp(
                     replyToId = replyTo,
                     quotedPostId = quoteOf,
                     onPostSuccess = {
-                        navController.previousBackStackEntry
-                            ?.savedStateHandle
-                            ?.set("postedAt", System.currentTimeMillis())
+                        viewModel.timelineRefreshTrigger.requestRefresh()
                         navController.popBackStack()
                     },
                     onNavigateBack = {

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineRefreshTrigger.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineRefreshTrigger.kt
@@ -1,16 +1,17 @@
 package pub.hackers.android.ui.screens.timeline
 
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class TimelineRefreshTrigger @Inject constructor() {
-    private val _requests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    val requests = _requests.asSharedFlow()
+    private val _refreshAt = MutableStateFlow(0L)
+    val refreshAt: StateFlow<Long> = _refreshAt.asStateFlow()
 
     fun requestRefresh() {
-        _requests.tryEmit(Unit)
+        _refreshAt.value = System.currentTimeMillis()
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineRefreshTrigger.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineRefreshTrigger.kt
@@ -1,0 +1,16 @@
+package pub.hackers.android.ui.screens.timeline
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TimelineRefreshTrigger @Inject constructor() {
+    private val _requests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val requests = _requests.asSharedFlow()
+
+    fun requestRefresh() {
+        _requests.tryEmit(Unit)
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -43,8 +42,6 @@ import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import coil.compose.AsyncImage
-import kotlinx.coroutines.flow.dropWhile
-import kotlinx.coroutines.flow.first
 import pub.hackers.android.R
 import pub.hackers.android.ui.components.ErrorMessage
 import pub.hackers.android.ui.components.FullScreenLoading
@@ -64,7 +61,6 @@ fun TimelineScreen(
     onSettingsClick: () -> Unit,
     onRecommendedActorsClick: () -> Unit = {},
     onComposeArticleClick: () -> Unit = {},
-    postedAt: Long = 0L,
     tabRetapped: Long = 0L,
     userAvatarUrl: String? = null,
     viewModel: TimelineViewModel = hiltViewModel()
@@ -80,13 +76,10 @@ fun TimelineScreen(
         viewModel.loadDraftCount()
     }
 
-    // After composing a new post, refresh and scroll to top once refresh completes.
-    LaunchedEffect(postedAt) {
-        if (postedAt > 0L) {
+    // After composing a new post, refresh and scroll to top.
+    LaunchedEffect(Unit) {
+        viewModel.refreshTrigger.requests.collect {
             items.refresh()
-            snapshotFlow { items.loadState.refresh }
-                .dropWhile { it !is LoadState.Loading }
-                .first { it !is LoadState.Loading }
             listState.scrollToItem(0)
         }
     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -76,10 +76,10 @@ fun TimelineScreen(
         viewModel.loadDraftCount()
     }
 
-    // After composing a new post, refresh and scroll to top.
-    LaunchedEffect(Unit) {
-        viewModel.refreshTrigger.requests.collect {
-            items.refresh()
+    // After composing a new post, scroll to top (ViewModel handles cache invalidation).
+    val refreshAt by viewModel.refreshTrigger.refreshAt.collectAsState()
+    LaunchedEffect(refreshAt) {
+        if (refreshAt > 0L) {
             listState.scrollToItem(0)
         }
     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
@@ -2,7 +2,10 @@ package pub.hackers.android.ui.screens.timeline
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingConfig
 import androidx.paging.PagingData
+import androidx.paging.PagingSource
+import androidx.paging.Pager
 import androidx.paging.cachedIn
 import androidx.paging.map
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -11,12 +14,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pub.hackers.android.data.local.PreferencesManager
+import pub.hackers.android.data.paging.CursorPagingSource
 import pub.hackers.android.data.paging.PostOverlayStore
 import pub.hackers.android.data.paging.applyOverlays
-import pub.hackers.android.data.paging.cursorPager
 import pub.hackers.android.data.paging.distinctByEffectiveId
 import pub.hackers.android.data.paging.personalTimelinePage
 import pub.hackers.android.data.repository.HackersPubRepository
@@ -42,9 +46,21 @@ class TimelineViewModel @Inject constructor(
 
     private val overlayStore = PostOverlayStore()
 
+    private var currentPagingSource: PagingSource<String, Post>? = null
+
     val posts: Flow<PagingData<Post>> = combine(
-        cursorPager { after -> repository.personalTimelinePage(after) }
-            .flow
+        Pager(
+            config = PagingConfig(
+                pageSize = 20,
+                prefetchDistance = 5,
+                enablePlaceholders = false,
+                initialLoadSize = 20,
+            ),
+            pagingSourceFactory = {
+                CursorPagingSource<Post> { after -> repository.personalTimelinePage(after) }
+                    .also { currentPagingSource = it }
+            },
+        ).flow
             .distinctByEffectiveId()
             .cachedIn(viewModelScope),
         overlayStore.overlays,
@@ -54,6 +70,11 @@ class TimelineViewModel @Inject constructor(
 
     init {
         loadDraftCount()
+        viewModelScope.launch {
+            refreshTrigger.refreshAt.drop(1).collect {
+                currentPagingSource?.invalidate()
+            }
+        }
     }
 
     fun loadDraftCount() {

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
@@ -34,6 +34,7 @@ data class TimelineUiState(
 class TimelineViewModel @Inject constructor(
     private val repository: HackersPubRepository,
     val preferencesManager: PreferencesManager,
+    val refreshTrigger: TimelineRefreshTrigger,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TimelineUiState())


### PR DESCRIPTION
## Summary
Replace the savedStateHandle-based `postedAt` signal with a singleton `TimelineRefreshTrigger` that invalidates the PagingSource from the ViewModel scope. This ensures the timeline reliably refreshes and scrolls to top after composing a post, regardless of which screen the compose was opened from or the composable's lifecycle state.

---
Assisted-By: Claude Code(claude-opus-4-6)