### PR TITLE
Show emoji and actor count in react notifications

### DIFF
--- a/app/src/main/java/pub/hackers/android/data/worker/NotificationWorker.kt
+++ b/app/src/main/java/pub/hackers/android/data/worker/NotificationWorker.kt
@@ -136,7 +136,14 @@ class NotificationWorker @AssistedInject constructor(
             is Notification.Reply -> "$actorName replied to your post"
             is Notification.Quote -> "$actorName quoted your post"
             is Notification.Share -> "$actorName shared your post"
-            is Notification.React -> "$actorName reacted to your post"
+            is Notification.React -> {
+                val othersCount = notification.actors.size - 1
+                val othersText = if (othersCount > 0) {
+                    " and $othersCount " + if (othersCount == 1) "other" else "others"
+                } else ""
+                val emojiText = notification.emoji?.let { " with $it" } ?: ""
+                "$actorName$othersText reacted to your post$emojiText"
+            }
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -172,10 +173,18 @@ private fun NotificationItem(
             stringResource(R.string.notification_share)
         )
 
-        is Notification.React -> Pair(
-            Icons.Default.Favorite,
-            notification.emoji?.let { "$it" } ?: stringResource(R.string.notification_react)
-        )
+        is Notification.React -> {
+            val othersCount = notification.actors.size - 1
+            val prefix = if (othersCount > 0) {
+                pluralStringResource(R.plurals.notification_and_others, othersCount, othersCount) + " "
+            } else ""
+            val actionStr = if (notification.emoji != null) {
+                prefix + stringResource(R.string.notification_react_with_emoji, notification.emoji)
+            } else {
+                prefix + stringResource(R.string.notification_react)
+            }
+            Pair(Icons.Default.Favorite, actionStr)
+        }
     }
 
     val post = when (notification) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,11 @@
     <string name="notification_quote">quoted your post</string>
     <string name="notification_share">shared your post</string>
     <string name="notification_react">reacted to your post</string>
+    <string name="notification_react_with_emoji">reacted to your post with %1$s</string>
+    <plurals name="notification_and_others">
+        <item quantity="one">and %1$d other</item>
+        <item quantity="other">and %1$d others</item>
+    </plurals>
     <string name="no_notifications">No Notifications\nWhen you receive notifications, they\'ll appear here</string>
     <string name="notification_post_unavailable">(Post unavailable)</string>
 


### PR DESCRIPTION
## Summary
Display the specific emoji used when showing reaction notifications (e.g., "reacted to your post with 👍") instead of a generic message. When multiple actors reacted, include an "and N others" suffix to indicate the total count without listing every actor.

---
Assisted-By: Claude Code(claude-opus-4-6)