### PR TITLE
Highlight hashtags with cyan color

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
@@ -66,6 +66,7 @@ private const val HTML_SYNC_PARSE_THRESHOLD = 500
 private data class HtmlCacheKey(
     val html: String,
     val linkColor: ULong,
+    val hashtagColor: ULong,
     val mentionBg: ULong,
     val codeBg: ULong,
 )
@@ -76,10 +77,11 @@ private fun parseAndCacheHtml(
     key: HtmlCacheKey,
     html: String,
     linkColor: Color,
+    hashtagColor: Color,
     mentionBg: Color,
     codeBg: Color,
 ): AnnotatedString {
-    val parsed = parseHtmlToAnnotatedString(html, linkColor, mentionBg, codeBg)
+    val parsed = parseHtmlToAnnotatedString(html, linkColor, hashtagColor, mentionBg, codeBg)
     htmlCache.put(key, parsed)
     return parsed
 }
@@ -100,17 +102,18 @@ private fun parseAndCacheHtml(
 private fun rememberParsedHtml(
     html: String,
     linkColor: Color,
+    hashtagColor: Color,
     mentionBg: Color,
     codeBg: Color,
 ): AnnotatedString {
-    val cacheKey = remember(html, linkColor, mentionBg, codeBg) {
-        HtmlCacheKey(html, linkColor.value, mentionBg.value, codeBg.value)
+    val cacheKey = remember(html, linkColor, hashtagColor, mentionBg, codeBg) {
+        HtmlCacheKey(html, linkColor.value, hashtagColor.value, mentionBg.value, codeBg.value)
     }
 
     // Fast path: cache hit or short enough to parse inline.
     val syncValue: AnnotatedString? = remember(cacheKey) {
         htmlCache.get(cacheKey) ?: if (html.length < HTML_SYNC_PARSE_THRESHOLD) {
-            parseAndCacheHtml(cacheKey, html, linkColor, mentionBg, codeBg)
+            parseAndCacheHtml(cacheKey, html, linkColor, hashtagColor, mentionBg, codeBg)
         } else {
             null
         }
@@ -121,7 +124,7 @@ private fun rememberParsedHtml(
     // Slow path: long HTML, cache miss. Parse off-Main.
     val asyncValue by produceState(initialValue = AnnotatedString(""), cacheKey) {
         value = withContext(Dispatchers.Default) {
-            htmlCache.get(cacheKey) ?: parseAndCacheHtml(cacheKey, html, linkColor, mentionBg, codeBg)
+            htmlCache.get(cacheKey) ?: parseAndCacheHtml(cacheKey, html, linkColor, hashtagColor, mentionBg, codeBg)
         }
     }
     return asyncValue
@@ -140,6 +143,7 @@ fun HtmlContent(
     val uriHandler = LocalUriHandler.current
     val colors = LocalAppColors.current
     val linkColor = colors.accent
+    val hashtagColor = colors.hashtag
     val mentionBg = colors.accent.copy(alpha = 0.10f)
     val codeBg = colors.surface
     val textColor = colors.textBody
@@ -152,7 +156,7 @@ fun HtmlContent(
 
     if (maxLines < Int.MAX_VALUE) {
         // Preview mode: flat AnnotatedString (no block code highlighting)
-        val annotatedString = rememberParsedHtml(html, linkColor, mentionBg, codeBg)
+        val annotatedString = rememberParsedHtml(html, linkColor, hashtagColor, mentionBg, codeBg)
 
         ClickableText(
             text = annotatedString,
@@ -173,7 +177,7 @@ fun HtmlContent(
                 when (block) {
                     is ContentBlock.Text -> {
                         if (block.html.isNotBlank()) {
-                            val annotatedString = rememberParsedHtml(block.html, linkColor, mentionBg, codeBg)
+                            val annotatedString = rememberParsedHtml(block.html, linkColor, hashtagColor, mentionBg, codeBg)
                             if (annotatedString.isNotEmpty()) {
                                 ClickableText(
                                     text = annotatedString,
@@ -279,6 +283,7 @@ internal fun extractHandleFromUrl(url: String): String? {
 internal fun parseHtmlToAnnotatedString(
     html: String,
     linkColor: Color,
+    hashtagColor: Color,
     mentionBg: Color,
     codeBg: Color
 ): AnnotatedString {
@@ -326,12 +331,12 @@ internal fun parseHtmlToAnnotatedString(
                 if (!insideInvisibleSpan && !insideRp && decoded.isNotEmpty()) {
                     if (preDepth > 0) {
                         // Preserve all whitespace in preformatted blocks
-                        appendStyledText(this, decoded, currentLinkType, linkColor, mentionBg)
+                        appendStyledText(this, decoded, currentLinkType, linkColor, hashtagColor, mentionBg)
                         hasContent = true
                     } else {
                         val isInterBlockWhitespace = decoded.isBlank() && decoded.contains('\n')
                         if (!isInterBlockWhitespace) {
-                            appendStyledText(this, decoded, currentLinkType, linkColor, mentionBg)
+                            appendStyledText(this, decoded, currentLinkType, linkColor, hashtagColor, mentionBg)
                             hasContent = true
                         }
                     }
@@ -615,6 +620,7 @@ private fun appendStyledText(
     text: String,
     linkType: LinkType?,
     linkColor: Color,
+    hashtagColor: Color,
     mentionBg: Color
 ) {
     when (linkType) {
@@ -630,7 +636,7 @@ private fun appendStyledText(
             }
         }
         LinkType.HASHTAG -> {
-            builder.withStyle(SpanStyle(color = linkColor)) {
+            builder.withStyle(SpanStyle(color = hashtagColor)) {
                 append(text)
             }
         }

--- a/app/src/main/java/pub/hackers/android/ui/theme/Colors.kt
+++ b/app/src/main/java/pub/hackers/android/ui/theme/Colors.kt
@@ -18,6 +18,7 @@ data class AppColorScheme(
     val composeAccent: Color,
     val reaction: Color,
     val share: Color,
+    val hashtag: Color,
 )
 
 val LightAppColors = AppColorScheme(
@@ -33,6 +34,7 @@ val LightAppColors = AppColorScheme(
     composeAccent = Color(0xFFEF4444),
     reaction = Color(0xFFE8453C),
     share = Color(0xFF34D399),
+    hashtag = Color(0xFF0891B2),
 )
 
 val DarkAppColors = AppColorScheme(
@@ -48,6 +50,7 @@ val DarkAppColors = AppColorScheme(
     composeAccent = Color(0xFFF87171),
     reaction = Color(0xFFE8453C),
     share = Color(0xFF34D399),
+    hashtag = Color(0xFF22D3EE),
 )
 
 val LocalAppColors = staticCompositionLocalOf { LightAppColors }

--- a/app/src/test/java/pub/hackers/android/ui/components/HtmlContentKtTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/components/HtmlContentKtTest.kt
@@ -109,24 +109,25 @@ class HtmlContentKtTest {
     // region parseHtmlToAnnotatedString
 
     private val linkColor = Color(0xFF1DA1F2)
+    private val hashtagColor = Color(0xFF0891B2)
     private val mentionBg = Color(0x1A1DA1F2)
     private val codeBg = Color(0xFFF5F5F5)
 
     @Test
     fun `parseHtmlToAnnotatedString extracts plain text`() {
-        val result = parseHtmlToAnnotatedString("<p>Hello world</p>", linkColor, mentionBg, codeBg)
+        val result = parseHtmlToAnnotatedString("<p>Hello world</p>", linkColor, hashtagColor, mentionBg, codeBg)
         assertEquals("Hello world", result.text)
     }
 
     @Test
     fun `parseHtmlToAnnotatedString handles br tag`() {
-        val result = parseHtmlToAnnotatedString("line1<br>line2", linkColor, mentionBg, codeBg)
+        val result = parseHtmlToAnnotatedString("line1<br>line2", linkColor, hashtagColor, mentionBg, codeBg)
         assertEquals("line1\nline2", result.text)
     }
 
     @Test
     fun `parseHtmlToAnnotatedString handles multiple paragraphs`() {
-        val result = parseHtmlToAnnotatedString("<p>first</p><p>second</p>", linkColor, mentionBg, codeBg)
+        val result = parseHtmlToAnnotatedString("<p>first</p><p>second</p>", linkColor, hashtagColor, mentionBg, codeBg)
         assertTrue(result.text.contains("first"))
         assertTrue(result.text.contains("second"))
         assertTrue(result.text.contains("\n\n"))
@@ -135,7 +136,7 @@ class HtmlContentKtTest {
     @Test
     fun `parseHtmlToAnnotatedString handles link with URL annotation`() {
         val html = """<a href="https://example.com">click</a>"""
-        val result = parseHtmlToAnnotatedString(html, linkColor, mentionBg, codeBg)
+        val result = parseHtmlToAnnotatedString(html, linkColor, hashtagColor, mentionBg, codeBg)
         assertEquals("click", result.text)
         val annotations = result.getStringAnnotations("URL", 0, result.length)
         assertEquals(1, annotations.size)
@@ -145,7 +146,7 @@ class HtmlContentKtTest {
     @Test
     fun `parseHtmlToAnnotatedString handles mention link`() {
         val html = """<a href="https://example.com/@alice" class="mention">@alice</a>"""
-        val result = parseHtmlToAnnotatedString(html, linkColor, mentionBg, codeBg)
+        val result = parseHtmlToAnnotatedString(html, linkColor, hashtagColor, mentionBg, codeBg)
         assertEquals("@alice", result.text)
         val annotations = result.getStringAnnotations("MENTION", 0, result.length)
         assertEquals(1, annotations.size)
@@ -155,7 +156,7 @@ class HtmlContentKtTest {
     @Test
     fun `parseHtmlToAnnotatedString handles hashtag link`() {
         val html = """<a href="https://example.com/tags/kotlin" class="hashtag">#kotlin</a>"""
-        val result = parseHtmlToAnnotatedString(html, linkColor, mentionBg, codeBg)
+        val result = parseHtmlToAnnotatedString(html, linkColor, hashtagColor, mentionBg, codeBg)
         assertEquals("#kotlin", result.text)
         val annotations = result.getStringAnnotations("URL", 0, result.length)
         assertEquals(1, annotations.size)
@@ -164,14 +165,14 @@ class HtmlContentKtTest {
     @Test
     fun `parseHtmlToAnnotatedString skips invisible spans`() {
         val html = """<span class="invisible">hidden</span>visible"""
-        val result = parseHtmlToAnnotatedString(html, linkColor, mentionBg, codeBg)
+        val result = parseHtmlToAnnotatedString(html, linkColor, hashtagColor, mentionBg, codeBg)
         assertEquals("visible", result.text)
     }
 
     @Test
     fun `parseHtmlToAnnotatedString handles unordered list`() {
         val html = "<ul><li>item1</li><li>item2</li></ul>"
-        val result = parseHtmlToAnnotatedString(html, linkColor, mentionBg, codeBg)
+        val result = parseHtmlToAnnotatedString(html, linkColor, hashtagColor, mentionBg, codeBg)
         assertTrue(result.text.contains("\u2022 item1"))
         assertTrue(result.text.contains("\u2022 item2"))
     }
@@ -179,26 +180,26 @@ class HtmlContentKtTest {
     @Test
     fun `parseHtmlToAnnotatedString handles ordered list`() {
         val html = "<ol><li>first</li><li>second</li></ol>"
-        val result = parseHtmlToAnnotatedString(html, linkColor, mentionBg, codeBg)
+        val result = parseHtmlToAnnotatedString(html, linkColor, hashtagColor, mentionBg, codeBg)
         assertTrue(result.text.contains("1. first"))
         assertTrue(result.text.contains("2. second"))
     }
 
     @Test
     fun `parseHtmlToAnnotatedString handles hr tag`() {
-        val result = parseHtmlToAnnotatedString("<hr>", linkColor, mentionBg, codeBg)
+        val result = parseHtmlToAnnotatedString("<hr>", linkColor, hashtagColor, mentionBg, codeBg)
         assertTrue(result.text.contains("\u2500"))
     }
 
     @Test
     fun `parseHtmlToAnnotatedString decodes entities in text`() {
-        val result = parseHtmlToAnnotatedString("<p>A &amp; B</p>", linkColor, mentionBg, codeBg)
+        val result = parseHtmlToAnnotatedString("<p>A &amp; B</p>", linkColor, hashtagColor, mentionBg, codeBg)
         assertEquals("A & B", result.text)
     }
 
     @Test
     fun `parseHtmlToAnnotatedString handles empty html`() {
-        val result = parseHtmlToAnnotatedString("", linkColor, mentionBg, codeBg)
+        val result = parseHtmlToAnnotatedString("", linkColor, hashtagColor, mentionBg, codeBg)
         assertEquals("", result.text)
     }
 


### PR DESCRIPTION
## Summary
Add a dedicated hashtag color to the theme so hashtags are visually distinct from regular links and mentions. Hashtags now render in cyan (cyan-600 in light theme, cyan-400 in dark theme) instead of using the generic accent color.

---
Assisted-By: Claude Code(claude-opus-4-6)