### PR TITLE
Fix follow/unfollow with optimistic updates and cache invalidation

### DIFF
--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -261,11 +261,11 @@ class HackersPubRepository @Inject constructor(
         }
     }
 
-    suspend fun getProfile(handle: String): Result<ProfileResult> {
+    suspend fun getProfile(handle: String, refresh: Boolean = false): Result<ProfileResult> {
         return try {
             val response = apolloClient.query(
                 ActorByHandleQuery(handle)
-            ).execute()
+            ).apply { if (refresh) fetchPolicy(FetchPolicy.NetworkOnly) }.execute()
 
             if (response.hasErrors()) {
                 Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))

--- a/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileViewModel.kt
@@ -130,7 +130,7 @@ class ProfileViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(isRefreshing = true, error = null) }
 
-            repository.getProfile(handle)
+            repository.getProfile(handle, refresh = true)
                 .onSuccess { profile ->
                     _uiState.update {
                         it.copy(
@@ -156,26 +156,89 @@ class ProfileViewModel @Inject constructor(
         _selectedTab.value = tab
     }
 
-    private fun performAction(op: suspend (String) -> Result<Unit>) {
+    fun followActor() {
         val actorId = _uiState.value.actor?.id ?: return
         if (_uiState.value.isPerformingAction) return
-
+        _uiState.update { it.copy(viewerFollows = true, isPerformingAction = true, actionError = null) }
         viewModelScope.launch {
-            _uiState.update { it.copy(isPerformingAction = true, actionError = null) }
-            op(actorId).onSuccess {
-                refresh()
-                _uiState.update { it.copy(isPerformingAction = false) }
-            }.onFailure { error ->
-                _uiState.update { it.copy(isPerformingAction = false, actionError = error.message) }
-            }
+            repository.followActor(actorId)
+                .onSuccess {
+                    _uiState.update { it.copy(isPerformingAction = false) }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(viewerFollows = false, isPerformingAction = false, actionError = error.message)
+                    }
+                }
         }
     }
 
-    fun followActor() = performAction { repository.followActor(it) }
-    fun unfollowActor() = performAction { repository.unfollowActor(it) }
-    fun blockActor() = performAction { repository.blockActor(it) }
-    fun unblockActor() = performAction { repository.unblockActor(it) }
-    fun removeFollower() = performAction { repository.removeFollower(it) }
+    fun unfollowActor() {
+        val actorId = _uiState.value.actor?.id ?: return
+        if (_uiState.value.isPerformingAction) return
+        _uiState.update { it.copy(viewerFollows = false, isPerformingAction = true, actionError = null) }
+        viewModelScope.launch {
+            repository.unfollowActor(actorId)
+                .onSuccess {
+                    _uiState.update { it.copy(isPerformingAction = false) }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(viewerFollows = true, isPerformingAction = false, actionError = error.message)
+                    }
+                }
+        }
+    }
+    fun blockActor() {
+        val actorId = _uiState.value.actor?.id ?: return
+        if (_uiState.value.isPerformingAction) return
+        _uiState.update { it.copy(viewerBlocks = true, isPerformingAction = true, actionError = null) }
+        viewModelScope.launch {
+            repository.blockActor(actorId)
+                .onSuccess {
+                    _uiState.update { it.copy(isPerformingAction = false) }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(viewerBlocks = false, isPerformingAction = false, actionError = error.message)
+                    }
+                }
+        }
+    }
+
+    fun unblockActor() {
+        val actorId = _uiState.value.actor?.id ?: return
+        if (_uiState.value.isPerformingAction) return
+        _uiState.update { it.copy(viewerBlocks = false, isPerformingAction = true, actionError = null) }
+        viewModelScope.launch {
+            repository.unblockActor(actorId)
+                .onSuccess {
+                    _uiState.update { it.copy(isPerformingAction = false) }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(viewerBlocks = true, isPerformingAction = false, actionError = error.message)
+                    }
+                }
+        }
+    }
+
+    fun removeFollower() {
+        val actorId = _uiState.value.actor?.id ?: return
+        if (_uiState.value.isPerformingAction) return
+        _uiState.update { it.copy(followsViewer = false, isPerformingAction = true, actionError = null) }
+        viewModelScope.launch {
+            repository.removeFollower(actorId)
+                .onSuccess {
+                    _uiState.update { it.copy(isPerformingAction = false) }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(followsViewer = true, isPerformingAction = false, actionError = error.message)
+                    }
+                }
+        }
+    }
 
     fun dismissActionError() {
         _uiState.update { it.copy(actionError = null) }

--- a/app/src/test/java/pub/hackers/android/ui/screens/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/profile/ProfileViewModelTest.kt
@@ -119,49 +119,26 @@ class ProfileViewModelTest {
     // region actions (follow/unfollow/block/unblock/removeFollower)
 
     @Test
-    fun `followActor calls repository and triggers refresh`() = runTest {
-        stubLoadProfile()
+    fun `followActor optimistically sets viewerFollows to true`() = runTest {
+        stubLoadProfile(sampleProfile(viewerFollows = false))
         coEvery { repository.followActor(any()) } returns Result.success(Unit)
         val vm = newViewModel()
         advanceUntilIdle()
 
         vm.followActor()
+        // Before coroutine runs, viewerFollows should already be true
+        assertEquals(true, vm.uiState.value.viewerFollows)
+
         advanceUntilIdle()
 
         coVerify(exactly = 1) { repository.followActor("actor-1") }
-        // After action, isPerformingAction goes back to false
+        assertEquals(true, vm.uiState.value.viewerFollows)
         assertEquals(false, vm.uiState.value.isPerformingAction)
     }
 
     @Test
-    fun `unfollowActor calls repository unfollowActor`() = runTest {
-        stubLoadProfile()
-        coEvery { repository.unfollowActor(any()) } returns Result.success(Unit)
-        val vm = newViewModel()
-        advanceUntilIdle()
-
-        vm.unfollowActor()
-        advanceUntilIdle()
-
-        coVerify(exactly = 1) { repository.unfollowActor("actor-1") }
-    }
-
-    @Test
-    fun `blockActor calls repository blockActor`() = runTest {
-        stubLoadProfile()
-        coEvery { repository.blockActor(any()) } returns Result.success(Unit)
-        val vm = newViewModel()
-        advanceUntilIdle()
-
-        vm.blockActor()
-        advanceUntilIdle()
-
-        coVerify(exactly = 1) { repository.blockActor("actor-1") }
-    }
-
-    @Test
-    fun `action failure stores actionError`() = runTest {
-        stubLoadProfile()
+    fun `followActor rolls back viewerFollows on failure`() = runTest {
+        stubLoadProfile(sampleProfile(viewerFollows = false))
         coEvery { repository.followActor(any()) } returns Result.failure(RuntimeException("network"))
         val vm = newViewModel()
         advanceUntilIdle()
@@ -169,8 +146,70 @@ class ProfileViewModelTest {
         vm.followActor()
         advanceUntilIdle()
 
+        assertEquals(false, vm.uiState.value.viewerFollows)
         assertEquals("network", vm.uiState.value.actionError)
         assertEquals(false, vm.uiState.value.isPerformingAction)
+    }
+
+    @Test
+    fun `unfollowActor optimistically sets viewerFollows to false`() = runTest {
+        stubLoadProfile(sampleProfile(viewerFollows = true))
+        coEvery { repository.unfollowActor(any()) } returns Result.success(Unit)
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.unfollowActor()
+        assertEquals(false, vm.uiState.value.viewerFollows)
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.unfollowActor("actor-1") }
+        assertEquals(false, vm.uiState.value.viewerFollows)
+    }
+
+    @Test
+    fun `unfollowActor rolls back viewerFollows on failure`() = runTest {
+        stubLoadProfile(sampleProfile(viewerFollows = true))
+        coEvery { repository.unfollowActor(any()) } returns Result.failure(RuntimeException("err"))
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.unfollowActor()
+        advanceUntilIdle()
+
+        assertEquals(true, vm.uiState.value.viewerFollows)
+        assertEquals("err", vm.uiState.value.actionError)
+    }
+
+    @Test
+    fun `blockActor optimistically sets viewerBlocks to true`() = runTest {
+        stubLoadProfile(sampleProfile(viewerBlocks = false))
+        coEvery { repository.blockActor(any()) } returns Result.success(Unit)
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.blockActor()
+        assertEquals(true, vm.uiState.value.viewerBlocks)
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.blockActor("actor-1") }
+        assertEquals(true, vm.uiState.value.viewerBlocks)
+        assertEquals(false, vm.uiState.value.isPerformingAction)
+    }
+
+    @Test
+    fun `blockActor rolls back viewerBlocks on failure`() = runTest {
+        stubLoadProfile(sampleProfile(viewerBlocks = false))
+        coEvery { repository.blockActor(any()) } returns Result.failure(RuntimeException("err"))
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.blockActor()
+        advanceUntilIdle()
+
+        assertEquals(false, vm.uiState.value.viewerBlocks)
+        assertEquals("err", vm.uiState.value.actionError)
     }
 
     @Test
@@ -186,11 +225,6 @@ class ProfileViewModelTest {
 
         assertNull(vm.uiState.value.actionError)
     }
-
-    // Note: The VM's `isPerformingAction` guard is set inside `viewModelScope.launch`,
-    // so two back-to-back synchronous calls BOTH pass the guard before either
-    // launch body runs. That's acceptable for a debouncing UI button but can't
-    // be asserted cleanly with StandardTestDispatcher; we skip that test.
 
     // endregion
 


### PR DESCRIPTION
## Summary
Replace the old `performAction` approach with optimistic state mutations for follow, unfollow, block, unblock, and removeFollower. The UI now updates immediately on tap with automatic rollback on API failure, matching the existing pattern used by share/unshare. Also adds `FetchPolicy.NetworkOnly` to pull-to-refresh so profile data bypasses the Apollo cache and always fetches fresh state from the server.

---
Assisted-By: Claude Code(claude-opus-4-6)