### PR TITLE
Fix quoted post click not propagating to content area

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -839,7 +839,8 @@ fun QuotedPostPreview(
             html = post.content,
             maxLines = 3,
             modifier = Modifier.fillMaxWidth(),
-            onMentionClick = onProfileClick
+            onMentionClick = onProfileClick,
+            onTextClick = onClick
         )
 
         if (post.media.isNotEmpty()) {


### PR DESCRIPTION
## Summary
Tapping on the text content area of a quoted post/article was not navigating to the quoted post. This was because `ClickableText` inside `HtmlContent` consumed all tap events, and `onTextClick` was not wired up to propagate non-link taps to the parent click handler. Now tapping anywhere on the quoted post content correctly navigates to it.

---
Assisted-By: Claude Code(claude-opus-4-6)