### PR TITLE
Add CONVENTION.md documenting recent architectural rules

### DIFF
--- a/CONVENTION.md
+++ b/CONVENTION.md
@@ -1,0 +1,301 @@
+# Conventions
+
+Rules that reviewers enforce during PR review. Violations block merge unless explicitly justified in the PR description.
+
+## §1 Scope
+
+- These rules apply to code under `app/src/main/`.
+- Test code (`app/src/test/`, `app/src/androidTest/`) has relaxed rules noted in §9.
+- Generated code (Apollo, Hilt, KSP output) is out of scope.
+
+---
+
+## §2 Null-safety
+
+### §2.1 No new `!!`
+
+The `!!` non-null assertion operator is forbidden in new code. Existing call sites (3 as of this writing) are all defensive invariants immediately after a null check:
+
+| Site | Invariant guaranteeing non-null |
+|------|----------------------------------|
+| `ui/HackersPubApp.kt:155` | early `return` when `isLoggedInState == null` on the preceding line |
+| `ui/components/ArticleCard.kt:83` | inside `if (isRepost && post.lastSharer != null)` |
+| `ui/components/ReactionPicker.kt:53` | inside `.filter { it.emoji != null }` |
+
+New `!!` requires a `// safe because <reason>` comment and reviewer approval. Before adding one, try:
+
+- Elvis `?:` with a default or `return`
+- Smart cast after an `if (x != null)` / early return on a local `val`
+- `?.let { ... }` to scope the non-null binding
+- Restructure to eliminate the nullable in the first place
+
+### §2.2 No `lateinit` in domain/UI code
+
+Prefer `val ... by lazy { ... }` or a nullable `var`. `lateinit` is acceptable only for framework requirements (test rules, some Hilt test fixtures).
+
+---
+
+## §3 Paging 3
+
+### §3.1 Fixed `PagingConfig` values
+
+All cursor-based feeds must use the factory in `app/src/main/java/pub/hackers/android/data/paging/CursorPagingSource.kt`:
+
+```kotlin
+pageSize = 20
+prefetchDistance = 5
+initialLoadSize = 20
+enablePlaceholders = false
+```
+
+Do not override these without a written rationale. The specific values are not arbitrary — see `CursorPagingSource.kt` KDoc for each value's history:
+
+- `pageSize = 20` matches the server's GraphQL `first: 20` (hard ceiling).
+- `prefetchDistance = 5` — `20` caused cascading prefetches of pages 2/3/4 right after first render.
+- `initialLoadSize = 20` — `30` made Paging think the first window was under-filled and immediately schedule an append.
+
+### §3.2 Build pagers with `cursorPager { ... }`
+
+ViewModels must not construct `Pager` or `PagingConfig` directly. Use the `cursorPager { repository.xxxPage(it) }` factory. Each new endpoint gets a one-line adapter in the `Repository adapters` region of `CursorPagingSource.kt`.
+
+### §3.3 All post feeds must pass through `.distinctByEffectiveId()`
+
+Every `Flow<PagingData<Post>>` must be composed with `.distinctByEffectiveId()` (defined in `data/paging/PostOverlay.kt`). This is the paging-layer half of the deduplication strategy described in §3.4.
+
+### §3.4 Two-layer deduplication is mandatory
+
+Keep both layers in place; neither alone is sufficient.
+
+| Layer | What it catches | Key |
+|-------|-----------------|-----|
+| Repository `.distinctBy { it.id }` | Server returns the same outer post id across pages | `post.id` |
+| Paging `.distinctByEffectiveId()` | Original + repost wrapper both land in the feed (different outer ids, same displayed content) | `post.sharedPost?.id ?: post.id` |
+
+### §3.5 No `PagingSource.invalidate()` for optimistic updates
+
+Do not call `invalidate()`, `refresh()`, or rebuild the `Pager` to reflect a share/reaction/repost toggle. Use the overlay system in `data/paging/PostOverlay.kt`:
+
+1. `overlayStore.mutate(postId) { it.copy(...) }`
+2. Compose the flow with `combine(pagingFlow, overlayStore.overlays) { paging, overlays -> paging.map { it.applyOverlays(overlays) } }`.
+
+Invalidating the source drops the user's scroll position, refetches already-loaded pages, and defeats `cachedIn(viewModelScope)`.
+
+### §3.6 ViewModel assembly template
+
+```kotlin
+val posts: Flow<PagingData<Post>> = combine(
+    cursorPager { repository.xxxPage(it) }
+        .flow
+        .distinctByEffectiveId()
+        .cachedIn(viewModelScope),
+    overlayStore.overlays,
+) { paging, overlays ->
+    paging.map { post -> post.applyOverlays(overlays) }
+}.cachedIn(viewModelScope)
+```
+
+Note the **two** `cachedIn` calls: the first caches raw paging data, the second caches after overlay application so downstream collectors don't re-apply on every recomposition.
+
+### §3.7 Optimistic update error handling
+
+Mutate the overlay first, launch the network call, and on failure either revert the mutation or `overlayStore.clear(postId)`. See `TimelineViewModel.sharePost` / `toggleReaction` for the reference shape.
+
+---
+
+## §4 Coroutine dispatchers
+
+### §4.1 HTML rendering
+
+Parsing longer than `HTML_SYNC_PARSE_THRESHOLD = 500` characters must run on `Dispatchers.Default` via `produceState`, with results cached in `LruCache<HtmlCacheKey, AnnotatedString>(256)`. See `ui/components/HtmlContent.kt`. Short HTML and cache hits stay on the main thread.
+
+### §4.2 Code block syntax highlighting
+
+Same pattern at `CODE_SYNC_PARSE_THRESHOLD = 300` characters, `LruCache(128)`. See `ui/components/CodeBlockView.kt`.
+
+### §4.3 Repository response mapping
+
+GraphQL response → domain model conversion must run inside `withContext(Dispatchers.Default)`. `HackersPubRepository` does this at every paginated / detail endpoint. Mapping post graphs (with nested shared/quoted posts, media, reactions) is CPU-heavy enough to show up as main-thread jank on timeline refresh.
+
+### §4.4 File and disk I/O
+
+Use `Dispatchers.IO`. Examples: cache-size computation and cache clearing in `SettingsViewModel`, translation model downloads in `PostCard`.
+
+### §4.5 Network
+
+Do not wrap Apollo calls in `withContext(Dispatchers.IO)` — Apollo/OkHttp manage their own dispatchers.
+
+---
+
+## §5 Compose stability
+
+### §5.1 Domain models must be `@Immutable`
+
+Every class in `domain/model/Models.kt` (and any new domain model) is annotated `@Immutable`. Adding a domain model without the annotation is a blocking review comment.
+
+### §5.2 Memoize hot-path computations
+
+Inside Composables in the post list / detail feed, wrap non-trivial transformations in `remember(key) { ... }`. Established examples:
+
+- `ReactionPicker`: reaction grouping, emoji map, sorted reaction list
+- `PostCard`: `DateTimeFormatter`, relative-time formatter
+- Any list filter/sort over `reactionGroups`
+
+Simple formatting of primitive values (numbers, short strings) is cheap enough that `remember` adds noise without benefit — use judgment.
+
+### §5.3 Prefer `ImmutableList<T>` for Composable parameters
+
+For new Composable parameters that accept collections, prefer `kotlinx.collections.immutable.ImmutableList<T>` over `List<T>` to preserve Compose's stable-skipping. Existing `List<T>` signatures are not retroactively migrated by this rule; it applies to new code.
+
+---
+
+## §6 ViewModel and state
+
+### §6.1 Hilt
+
+ViewModels must be `@HiltViewModel` and injected via `hiltViewModel()` in the Composable that owns them.
+
+### §6.2 UI state as `StateFlow<UiState>`
+
+`UiState` is a `data class` (or sealed class if the states are disjoint). Expose it as `StateFlow<UiState>`, not `LiveData` and not a raw `Flow`.
+
+### §6.3 One-shot events are separate from state
+
+Snackbar messages, navigation triggers, and other one-shot effects go through a `Channel` or `SharedFlow(replay = 0)`, never mixed into `StateFlow<UiState>`. Mixing them creates re-play bugs on configuration change.
+
+### §6.4 Optimistic update pattern
+
+```kotlin
+overlayStore.mutate(postId) { it.copy(viewerHasShared = true, shareDelta = +1) }
+viewModelScope.launch {
+    repository.sharePost(postId).onFailure {
+        overlayStore.mutate(postId) { it.copy(viewerHasShared = false, shareDelta = 0) }
+    }
+}
+```
+
+---
+
+## §7 Repository
+
+### §7.1 Return `Result<T>`
+
+Repository methods return `Result<T>`. Don't throw for expected error paths (network failure, auth expiration, not-found). Reserve exceptions for programmer errors.
+
+### §7.2 `FetchPolicy` pattern
+
+Paginated feeds use `FetchPolicy.NetworkOnly` on refresh (first page) and fall through to Apollo's default (CacheFirst) for subsequent pages. The canonical shape is:
+
+```kotlin
+.apply { if (refresh) fetchPolicy(FetchPolicy.NetworkOnly) }
+```
+
+Detail queries apply `NetworkOnly` explicitly when freshness is load-bearing (post detail after a reaction, profile after a follow action). Normalized-cache writes still happen under `NetworkOnly` — the policy controls reads, not writes, so fragment-shared data remains consistent across screens.
+
+New queries should follow this pattern. If a new query needs a different policy (e.g., `CacheAndNetwork` for "show cached then update"), justify it in the PR description or a code comment.
+
+---
+
+## §8 Navigation
+
+### §8.1 Sealed `Route` types
+
+Route destinations are a sealed class hierarchy. Do not pass raw route strings through the NavController.
+
+### §8.2 Deep links through `HackersPubUrlRouter`
+
+All URL-based entry points (external links, email verification, push notifications) are parsed by `HackersPubUrlRouter` into the sealed `Route` type. Don't add ad-hoc deep-link handling elsewhere.
+
+---
+
+## §9 Testing
+
+### §9.1 `MainDispatcherRule`
+
+ViewModel tests must install `MainDispatcherRule` (`app/src/test/java/pub/hackers/android/testutil/MainDispatcherRule.kt`), which uses `StandardTestDispatcher`.
+
+### §9.2 `!!` allowed under test invariants
+
+In test code, `!!` is permitted when a setUp method or the test's own preceding assertion establishes the non-null invariant. Example:
+
+```kotlin
+val inner = post(id = "inner")
+val outer = post(sharedPost = inner).applyOverlays(...)
+assertEquals(expected, outer.sharedPost!!.field)  // setUp guarantees sharedPost != null
+```
+
+### §9.3 New ViewModels require tests
+
+New or substantially refactored ViewModels ship with tests in the same PR. Reference tests live in `app/src/test/java/pub/hackers/android/ui/screens/**/*ViewModelTest.kt`.
+
+---
+
+## §10 Build and variants
+
+### §10.1 Dependencies via Version Catalog
+
+All dependency declarations go in `gradle/libs.versions.toml`. Module `build.gradle.kts` files reference them as `libs.xxx`. No hardcoded versions in build scripts.
+
+### §10.2 Debug variant separation
+
+The `debug` build type sets `applicationIdSuffix = ".dev"` and ships a distinct DEV launcher icon from `app/src/debug/res/mipmap-*`. Do not remove this separation — the DEV icon is what prevents debug-vs-release confusion on developer devices.
+
+### §10.3 ProGuard keep rules
+
+`app/proguard-rules.pro` keeps generated Apollo classes, Coil classes, and WorkManager `HiltWorker` / `WorkerAssistedFactory`. Removing or narrowing these rules requires a minified-release smoke test in the PR.
+
+### §10.4 Release is minified
+
+`release` build type has `isMinifyEnabled = true`. Don't disable minification to "make debugging easier" — add the missing keep rule instead.
+
+---
+
+## §11 Localization and accessibility
+
+### §11.1 No hardcoded user-facing strings
+
+All user-visible text goes through `stringResource(R.string.xxx)`. No string literals in Composables that will render to the screen. Exceptions: debug-only labels, log messages, format templates that are themselves composed from resources.
+
+String keys are descriptive: `error_no_network`, not `msg3`.
+
+### §11.2 `contentDescription` on interactive icons
+
+Every `Icon`, `IconButton`, `AsyncImage` that carries meaning requires a `contentDescription`, usually sourced from `stringResource`. Decorative-only icons pass `contentDescription = null` explicitly — the argument is never omitted.
+
+### §11.3 Don't rely on color alone
+
+State conveyed through color (success/error/active) must also have an icon, text label, or shape cue so color-blind users and grayscale displays don't lose information.
+
+---
+
+## §12 GraphQL hygiene
+
+### §12.1 Fragments are reused
+
+When editing `app/src/main/graphql/pub/hackers/android/operations.graphql`, prefer extending or composing existing fragments (`ActorFields`, `PostFields`, `EngagementStatsFields`, etc.) over introducing parallel ad-hoc selections. Divergent selections across operations break normalized-cache sharing.
+
+### §12.2 Generated code stays in `build/`
+
+Do not commit KSP-generated Apollo code. Regenerate locally with `./gradlew generateApolloSources`. If a generated file appears in `git status`, the Gradle setup is misconfigured — fix the config, don't commit the artifact.
+
+---
+
+## Rule index (for review comments)
+
+| § | One-line summary |
+|---|-------------------|
+| §2.1 | No new `!!` |
+| §3.1 | `PagingConfig` values are fixed |
+| §3.3 | Post flows pass `.distinctByEffectiveId()` |
+| §3.5 | Use overlay, not `invalidate()` |
+| §4.1 | HTML ≥ 500 chars → `Dispatchers.Default` |
+| §4.2 | Code ≥ 300 chars → `Dispatchers.Default` |
+| §4.3 | Repository response mapping → `Dispatchers.Default` |
+| §4.4 | File I/O → `Dispatchers.IO` |
+| §5.1 | Domain models → `@Immutable` |
+| §6.2 | UI state → `StateFlow<UiState>` |
+| §6.3 | One-shot events → `Channel` / `SharedFlow` |
+| §7.1 | Repository returns `Result<T>` |
+| §10.1 | Dependencies → Version Catalog |
+| §11.1 | No hardcoded user-facing strings |
+| §11.2 | `contentDescription` on interactive icons |
+| §12.2 | Don't commit generated Apollo code |

--- a/README.md
+++ b/README.md
@@ -31,15 +31,17 @@ An Android client for [Hackers' Pub](https://hackers.pub), a fediverse-compatibl
 ```
 app/src/main/java/pub/hackers/android/
 ├── data/
-│   ├── local/          # SessionManager (DataStore)
+│   ├── local/          # SessionManager, PreferencesManager (DataStore)
+│   ├── paging/         # CursorPagingSource, PostOverlay
 │   └── repository/     # HackersPubRepository
 ├── di/                 # Hilt modules
 ├── domain/
-│   └── model/          # Domain models
+│   └── model/          # Domain models (@Immutable)
+├── navigation/         # Sealed routes, HackersPubUrlRouter
 ├── ui/
 │   ├── components/     # Reusable UI components
 │   ├── screens/        # Screen composables & ViewModels
-│   └── theme/          # Material theme
+│   └── theme/          # Theme, LocalAppColors
 ├── HackersPubApplication.kt
 └── MainActivity.kt
 ```
@@ -99,6 +101,8 @@ UI (Compose) → ViewModel → Repository → Apollo Client → GraphQL API
                               ↓
                         Apollo Cache (SQLite)
 ```
+
+For the rules reviewers enforce during PRs — null-safety, Paging config, threading, Compose stability — see [CONVENTION.md](./CONVENTION.md).
 
 ## Screens
 


### PR DESCRIPTION
## Summary

Adds `CONVENTION.md` at the repo root to document the rules established during the recent Paging 3 / `@Immutable` / null-safety / threading work. Adds a short link to it from `README.md`.

The goal is to give PR reviewers a file they can cite by section number (e.g., "§3.5 violation: this calls `invalidate()` on the PagingSource") instead of re-explaining the same patterns in every review.

## Scope

The document captures **observable patterns** — rules that are already in the codebase — rather than proposing new ones. Each section references specific files and commits:

- **§2 Null-safety** — no new `!!` (3 existing sites listed with their defensive invariants), no `lateinit` in domain/UI code.
- **§3 Paging 3** — fixed `PagingConfig` values, `cursorPager` factory, mandatory `.distinctByEffectiveId()`, two-layer dedup, overlay-based optimistic updates (no `PagingSource.invalidate()`).
- **§4 Coroutine dispatchers** — HTML/code parsing thresholds (500/300 chars), repository response mapping on `Dispatchers.Default`, file I/O on `Dispatchers.IO`.
- **§5 Compose stability** — `@Immutable` on domain models, hot-path memoization, `ImmutableList<T>` preference for new Composable params.
- **§6 ViewModel and state** — Hilt usage, `StateFlow<UiState>`, one-shot events via `Channel` / `SharedFlow`, optimistic update pattern.
- **§7 Repository** — `Result<T>` return type, observed `FetchPolicy` pattern (`NetworkOnly` on refresh, default on subsequent pages).
- **§8 Navigation** — sealed `Route` types, deep links through `HackersPubUrlRouter`.
- **§9 Testing** — `MainDispatcherRule`, `!!` rules for test code.
- **§10 Build and variants** — version catalog, debug `.dev` suffix with distinct DEV launcher icon, ProGuard keep rules, release minification.
- **§11 Localization and accessibility** — no hardcoded user-facing strings, `contentDescription` on interactive icons, no color-only state cues.
- **§12 GraphQL hygiene** — fragment reuse, don't commit generated Apollo code.

The `Rule index` table at the bottom lists the sections most commonly cited during review.

## Out of scope

- No `CONTRIBUTING.md`, `ARCHITECTURE.md`, or `ROADMAP.md` added. The project's KDoc (especially in `CursorPagingSource.kt`, `PostOverlay.kt`, `HtmlContent.kt`, `CodeBlockView.kt`) already explains the _why_ behind each pattern. `CONVENTION.md` is the _what_; the _why_ stays in code comments where it's harder to go stale.
- Tooling adoption (ktlint, detekt) is deliberately deferred — see #105 and #106 for the tradeoff analysis and revisit triggers.

## README.md changes

- Expanded the `Project Structure` section to reflect current packages (`data/paging/`, `navigation/`, `@Immutable` note on `domain/model/`).
- Added a one-line link to `CONVENTION.md` in the `Architecture` section.

## Test plan

- [x] Documentation-only change; no runtime behavior affected.
- [x] Verified the claims in CONVENTION.md against the code: `PagingConfig` values (`pageSize=20`, `prefetchDistance=5`, `initialLoadSize=20`), parse thresholds (`HTML=500`, `CODE=300`), LRU cache sizes (`HTML=256`, `CODE=128`), and existing `!!` sites (3, all defensive).

## Related

- #105 — ktlint/Spotless adoption consideration
- #106 — detekt adoption consideration

🤖 Generated with [Claude Code](https://claude.com/claude-code)