### PR TITLE
Add CONVENTION §5.4 on Modifier parameter position

### DIFF
--- a/CONVENTION.md
+++ b/CONVENTION.md
@@ -146,6 +146,17 @@ Simple formatting of primitive values (numbers, short strings) is cheap enough t
 
 For new Composable parameters that accept collections, prefer `kotlinx.collections.immutable.ImmutableList<T>` over `List<T>` to preserve Compose's stable-skipping. Existing `List<T>` signatures are not retroactively migrated by this rule; it applies to new code.
 
+### §5.4 `Modifier` parameter position
+
+Composable parameters follow the Compose API Guidelines for `Modifier`:
+
+- `modifier: Modifier = Modifier` is the **first optional parameter**, immediately after all required parameters.
+- The default value is bare `Modifier` — do not pre-apply modifiers inside the default (`Modifier.fillMaxWidth()` etc.). The caller composes modifiers.
+- When a Composable has other optional parameters, `modifier` comes **before** them. Trailing-lambda content (`content: @Composable () -> Unit`) is the usual exception and goes last.
+- Internal `@Composable` helpers that always require a modifier from the caller may omit the default, but must still place the `modifier` parameter as the first `Modifier`-typed parameter.
+
+This is an established convention in the project — see commit `0e92f03` (PR #86) which refactored `HtmlContent` specifically to fix a violation, and every `ui/components/*.kt` Composable follows the pattern.
+
 ---
 
 ## §6 ViewModel and state
@@ -292,6 +303,7 @@ Do not commit KSP-generated Apollo code. Regenerate locally with `./gradlew gene
 | §4.3 | Repository response mapping → `Dispatchers.Default` |
 | §4.4 | File I/O → `Dispatchers.IO` |
 | §5.1 | Domain models → `@Immutable` |
+| §5.4 | `modifier: Modifier = Modifier` is the first optional param |
 | §6.2 | UI state → `StateFlow<UiState>` |
 | §6.3 | One-shot events → `Channel` / `SharedFlow` |
 | §7.1 | Repository returns `Result<T>` |


### PR DESCRIPTION
## Summary

Adds **§5.4 `Modifier` parameter position** to `CONVENTION.md`, documenting the Compose API Guideline for `modifier` placement that is already the established pattern across `ui/components/*.kt`.

## Rule added

- `modifier: Modifier = Modifier` is the **first optional parameter**, immediately after required parameters.
- Default value is bare `Modifier` — no `Modifier.fillMaxWidth()` in the default. The caller composes modifiers.
- `modifier` precedes other optional parameters; trailing `content: @Composable () -> Unit` is the usual exception and goes last.
- Internal helpers that require a modifier from the caller may omit the default but still place `modifier` first among `Modifier`-typed params.

Rule Index gets one extra row for §5.4.

## Motivation

This was the rule that was violated in `HtmlContent.kt` and fixed in PR #86 (commit `0e92f03`). Writing it down explicitly prevents the same drift in future Composables — and gives reviewers a section number to cite.

## Verification

- Every `ui/components/*.kt` Composable with a `modifier` parameter already follows the pattern (checked via `grep 'modifier: Modifier' ui/components/`).
- No code changes in this PR; documentation only.

## Follow-up from #110

This is a follow-up to the recently merged #110. Would have been part of that PR, but we caught it after the merge.