### PR TITLE
Move modifier to first optional parameter position

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
@@ -51,13 +51,13 @@ fun ArticleCard(
     post: Post,
     onClick: () -> Unit,
     onProfileClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
     onReplyClick: (() -> Unit)? = null,
     onShareClick: (() -> Unit)? = null,
     onQuoteClick: (() -> Unit)? = null,
     onReactionClick: (() -> Unit)? = null,
     onReactionLongPress: (() -> Unit)? = null,
-    onExternalShareClick: (() -> Unit)? = null,
-    modifier: Modifier = Modifier
+    onExternalShareClick: (() -> Unit)? = null
 ) {
     val displayPost = post.sharedPost ?: post
     val isRepost = post.lastSharer != null

--- a/app/src/main/java/pub/hackers/android/ui/components/ErrorMessage.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/ErrorMessage.kt
@@ -28,10 +28,10 @@ import pub.hackers.android.R
 @Composable
 fun ErrorMessage(
     message: String,
+    modifier: Modifier = Modifier,
     onRetry: (() -> Unit)? = null,
     onRefresh: (() -> Unit)? = null,
-    icon: ImageVector? = Icons.Outlined.ErrorOutline,
-    modifier: Modifier = Modifier
+    icon: ImageVector? = Icons.Outlined.ErrorOutline
 ) {
     Column(
         modifier = modifier

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -100,6 +100,7 @@ fun PostCard(
     post: Post,
     onClick: () -> Unit,
     onProfileClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
     onReplyClick: (() -> Unit)? = null,
     onShareClick: (() -> Unit)? = null,
     onQuoteClick: (() -> Unit)? = null,
@@ -107,8 +108,7 @@ fun PostCard(
     onReactionLongPress: (() -> Unit)? = null,
     onExternalShareClick: (() -> Unit)? = null,
     onQuotedPostClick: ((String) -> Unit)? = null,
-    contentMaxLength: Int = 0,
-    modifier: Modifier = Modifier
+    contentMaxLength: Int = 0
 ) {
     val displayPost = post.sharedPost ?: post
 
@@ -148,6 +148,7 @@ private fun NoteCard(
     post: Post,
     onClick: () -> Unit,
     onProfileClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
     onReplyClick: (() -> Unit)? = null,
     onShareClick: (() -> Unit)? = null,
     onQuoteClick: (() -> Unit)? = null,
@@ -155,8 +156,7 @@ private fun NoteCard(
     onReactionLongPress: (() -> Unit)? = null,
     onExternalShareClick: (() -> Unit)? = null,
     onQuotedPostClick: ((String) -> Unit)? = null,
-    contentMaxLength: Int = 0,
-    modifier: Modifier = Modifier
+    contentMaxLength: Int = 0
 ) {
     val displayPost = post.sharedPost ?: post
     val isRepost = post.lastSharer != null


### PR DESCRIPTION
## Summary

Fixes Compose API convention violations in 4 Composables where `modifier: Modifier = Modifier` was declared as the **last** optional parameter instead of the first. Moves `modifier` to the first optional position in each signature.

## Files

- `ui/components/ArticleCard.kt` — `ArticleCard`
- `ui/components/ErrorMessage.kt` — `ErrorMessage`
- `ui/components/PostCard.kt` — `PostCard` (public) and `NoteCard` (private)

## Rationale

The Compose API Guidelines require `modifier` to be the first optional parameter so callers composing modifiers don't need to name all intervening arguments. This also matches every other Composable in `ui/components/*.kt` — these four were the remaining outliers. Previously fixed for `HtmlContent` in #86 (commit `0e92f03`).

See also PR #111 which proposes documenting this as CONVENTION §5.4.

## Safety

All existing call sites use **named arguments**, so parameter reordering is not a breaking change. Verified by grep across `app/src/main/java` — every `ArticleCard(...)`, `PostCard(...)`, `NoteCard(...)`, `ErrorMessage(...)` invocation uses `post = ...`, `message = ...`, etc. rather than positional arguments.

## Verification

- `./gradlew :app:compileDebugKotlin` passes; no new warnings.
- Unit tests: `./gradlew :app:testDebugUnitTest` currently fails with an **unrelated** pre-existing compilation error in `TimelineViewModelTest` (missing `refreshTrigger` argument introduced in commit `976addd` that predates this PR). This fails on `main` too and is not caused by this change.