### PR TITLE
Fix API-level violations and document API compatibility rule

### DIFF
--- a/CONVENTION.md
+++ b/CONVENTION.md
@@ -279,6 +279,31 @@ Do not commit KSP-generated Apollo code. Regenerate locally with `./gradlew gene
 
 ---
 
+## §13 API level compatibility
+
+The app ships with `minSdk = 26` (Android 8.0, Oreo). Any platform API referenced unconditionally must be available at API 26, or the call site must be gated with a `Build.VERSION.SDK_INT` check and a fallback.
+
+### §13.1 Check the API level for every platform call
+
+Before accepting code that touches `android.*`, `java.util.*`, or Kotlin stdlib extensions that alias newer JDK methods, verify the minimum API level on the official doc. Android Studio's `NewApi` lint catches most cases, but **Kotlin extension functions that delegate to newer Java methods can escape the detector**. Review such calls manually.
+
+### §13.2 Known traps
+
+Concrete cases that have bitten this codebase:
+
+- **`List.removeFirst()` / `List.removeLast()`** — Kotlin's `MutableList.removeFirst()` / `removeLast()` now resolve to `java.util.SequencedCollection` methods added in **API 35** (Android 15). They crash with `NoSuchMethodError` on older devices. Use `removeAt(0)` / `removeAt(lastIndex)` instead. See PR #84 for the `removeLast` incident on HTML parsing.
+- **`PackageInfo.longVersionCode`** — API 28+. Use `androidx.core.content.pm.PackageInfoCompat.getLongVersionCode(packageInfo)` which falls back on older devices.
+- **`Icons.Filled.Reply` / `Icons.Filled.Login`** — have `AutoMirrored` replacements for RTL correctness. Not strictly API-level but same class of "newer API exists, older still works, lint warns". Prefer the `AutoMirrored` variants in new code.
+
+### §13.3 AI-assisted code is a specific risk vector
+
+AI code-completion tools frequently suggest API calls that match the intent but violate `minSdk`. They tend to pick the most idiomatic modern API regardless of the project's min-SDK constraint. Treat every AI-suggested platform call as requiring API-level verification, especially:
+
+- Collection operations (Kotlin stdlib increasingly delegates to newer Java methods)
+- Anything that looks like it might have a `*Compat` variant in `androidx.core` — if a Compat helper exists, it exists *because* the platform API has a version requirement.
+
+---
+
 ## Rule index (for review comments)
 
 | § | One-line summary |
@@ -299,3 +324,5 @@ Do not commit KSP-generated Apollo code. Regenerate locally with `./gradlew gene
 | §11.1 | No hardcoded user-facing strings |
 | §11.2 | `contentDescription` on interactive icons |
 | §12.2 | Don't commit generated Apollo code |
+| §13.1 | Verify API level for every platform call (minSdk = 26) |
+| §13.2 | Avoid `removeFirst/Last` (API 35), use `PackageInfoCompat` (API 28) |

--- a/app/src/main/java/pub/hackers/android/ui/screens/recommendedactors/RecommendedActorsViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/recommendedactors/RecommendedActorsViewModel.kt
@@ -74,7 +74,10 @@ class RecommendedActorsViewModel @Inject constructor(
 
     private fun replaceActorAt(index: Int) {
         if (hiddenActors.isNotEmpty()) {
-            shownActors[index] = hiddenActors.removeFirst()
+            // removeAt(0) is API-level safe; MutableList.removeFirst() resolves to
+            // SequencedCollection.removeFirst() which is API 35+ and crashes on
+            // older devices. See PR #84 for the same fix on removeLast().
+            shownActors[index] = hiddenActors.removeAt(0)
         } else {
             shownActors.removeAt(index)
         }

--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsViewModel.kt
@@ -2,6 +2,7 @@ package pub.hackers.android.ui.screens.settings
 
 import android.app.NotificationManager
 import android.content.Context
+import androidx.core.content.pm.PackageInfoCompat
 import androidx.lifecycle.ViewModel
 import androidx.work.WorkManager
 import pub.hackers.android.data.local.NotificationStateManager
@@ -88,7 +89,10 @@ class SettingsViewModel @Inject constructor(
         try {
             val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
             val version = packageInfo.versionName ?: "Unknown"
-            val versionCode = packageInfo.longVersionCode
+            // PackageInfo.longVersionCode is API 28+. PackageInfoCompat covers
+            // minSdk 26 by falling back to the deprecated versionCode on older
+            // devices.
+            val versionCode = PackageInfoCompat.getLongVersionCode(packageInfo)
             _uiState.update { it.copy(appVersion = "$version ($versionCode)") }
         } catch (_: Exception) {
             _uiState.update { it.copy(appVersion = "Unknown") }


### PR DESCRIPTION
## Summary

Fixes two unconditional calls to platform APIs that exceed the project's `minSdk = 26` floor and would crash on older Android devices. Adds CONVENTION §13 documenting the rule so this class of regression is caught at review time.

## Bugs fixed

### 1. `RecommendedActorsViewModel.kt:77` — `hiddenActors.removeFirst()`

Kotlin's `MutableList.removeFirst()` now resolves to `java.util.SequencedCollection.removeFirst()`, which was added in **API 35** (Android 15). On devices running API 26–34, this crashes with `NoSuchMethodError`. Same class of bug as #84 (which was about `removeLast()` in `HtmlContent.kt`).

Fix: replace with `removeAt(0)`, which has been available since API 1.

### 2. `SettingsViewModel.kt:91` — `packageInfo.longVersionCode`

`PackageInfo.longVersionCode` is API 28+. On API 26–27 it's absent. The app's "About" screen would fail to load app version text on Android 8.0/8.1 devices.

Fix: use `PackageInfoCompat.getLongVersionCode(packageInfo)` from `androidx.core.content.pm` (already in the dependency graph via `androidx-core-ktx`). `PackageInfoCompat` handles the version fork internally — on API 28+ it calls `longVersionCode`, on earlier devices it falls back to the deprecated `versionCode`.

## Convention added

**§13 API level compatibility** — documents that minSdk = 26, lists these two known traps, and flags AI-assisted code as a specific risk vector. AI completion tools tend to pick the newest idiomatic API regardless of min-SDK, and Kotlin stdlib extensions that delegate to newer JDK methods (like `removeFirst`) can escape Android Lint's `NewApi` detection. Reviewers should treat every AI-suggested platform call as requiring manual API-level verification.

Rule Index updated with §13.1 and §13.2.

## Verification

- `./gradlew :app:compileDebugKotlin` passes.
- `PackageInfoCompat` import is already available — no dependency changes.
- No behavior change for API 28+ devices; correct behavior added for API 26–27.

## Related

- #84 — the first incident of the `SequencedCollection` issue (`removeLast` fix for `HtmlContent`). This PR catches two more call sites and documents the rule so future ones get caught at review.