### PR TITLE
Gate passkey auth behind API 28+ at the UI layer

### DIFF
--- a/app/src/main/java/pub/hackers/android/data/auth/PasskeyManager.kt
+++ b/app/src/main/java/pub/hackers/android/data/auth/PasskeyManager.kt
@@ -2,6 +2,8 @@ package pub.hackers.android.data.auth
 
 import android.app.Activity
 import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.credentials.CreatePublicKeyCredentialRequest
 import androidx.credentials.CreatePublicKeyCredentialResponse
 import androidx.credentials.CredentialManager
@@ -12,12 +14,23 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Passkey (WebAuthn) sign-in and registration via the Jetpack Credential Manager.
+ *
+ * The passkey-specific classes (`PublicKeyCredential`,
+ * `CreatePublicKeyCredentialRequest`, etc.) require **API 28+**. This class's
+ * constructor and `credentialManager` field are API 26-safe, so the Hilt graph
+ * can instantiate it on all supported devices. The two public entry points
+ * ([authenticate] and [register]) are annotated `@RequiresApi(Build.VERSION_CODES.P)`
+ * — callers must gate invocation with a runtime SDK check.
+ */
 @Singleton
 class PasskeyManager @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
     private val credentialManager = CredentialManager.create(context)
 
+    @RequiresApi(Build.VERSION_CODES.P)
     suspend fun authenticate(optionsJson: String, activity: Activity): String {
         android.util.Log.d("PasskeyAuth", "authenticate: creating request with options: ${optionsJson.take(200)}")
         val request = GetCredentialRequest(
@@ -36,6 +49,7 @@ class PasskeyManager @Inject constructor(
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.P)
     suspend fun register(optionsJson: String, activity: Activity): String {
         android.util.Log.d("PasskeyAuth", "register: creating request")
         val request = CreatePublicKeyCredentialRequest(optionsJson)

--- a/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInScreen.kt
@@ -1,6 +1,7 @@
 package pub.hackers.android.ui.screens.auth
 
 import android.app.Activity
+import android.os.Build
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -104,7 +105,12 @@ fun SignInScreen(
                         keyboardController?.hide()
                         viewModel.sendVerificationCode()
                     },
-                    onPasskeySignIn = if (pub.hackers.android.FeatureFlags.PASSKEY_AUTH_ENABLED) {
+                    // Passkey requires the feature flag AND Android 9+
+                    // (androidx.credentials.PublicKeyCredential is API 28+).
+                    onPasskeySignIn = if (
+                        pub.hackers.android.FeatureFlags.PASSKEY_AUTH_ENABLED &&
+                        Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+                    ) {
                         val activity = LocalContext.current as Activity
                         {
                             keyboardController?.hide()

--- a/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInViewModel.kt
@@ -1,5 +1,8 @@
 package pub.hackers.android.ui.screens.auth
 
+import android.app.Activity
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -8,7 +11,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import android.app.Activity
 import pub.hackers.android.data.auth.PasskeyManager
 import pub.hackers.android.data.local.SessionManager
 import pub.hackers.android.data.repository.HackersPubRepository
@@ -144,6 +146,7 @@ class SignInViewModel @Inject constructor(
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.P)
     fun signInWithPasskey(activity: Activity) {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }

--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package pub.hackers.android.ui.screens.settings
 
 import android.app.Activity
+import android.os.Build
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -71,7 +72,10 @@ fun SettingsScreen(
     var showRevokePasskeyId by remember { mutableStateOf<String?>(null) }
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
-    val passkeyEnabled = pub.hackers.android.FeatureFlags.PASSKEY_AUTH_ENABLED
+    // Passkey requires the feature flag AND Android 9+
+    // (androidx.credentials.PublicKeyCredential is API 28+).
+    val passkeyEnabled = pub.hackers.android.FeatureFlags.PASSKEY_AUTH_ENABLED &&
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
 
     LaunchedEffect(isLoggedIn, passkeyEnabled) {
         if (isLoggedIn && passkeyEnabled) viewModel.loadPasskeys()

--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsViewModel.kt
@@ -1,7 +1,10 @@
 package pub.hackers.android.ui.screens.settings
 
+import android.app.Activity
 import android.app.NotificationManager
 import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.core.content.pm.PackageInfoCompat
 import androidx.lifecycle.ViewModel
 import androidx.work.WorkManager
@@ -20,7 +23,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import android.app.Activity
 import pub.hackers.android.data.auth.PasskeyManager
 import pub.hackers.android.data.local.PreferencesManager
 import pub.hackers.android.data.local.SessionManager
@@ -228,6 +230,7 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.P)
     fun registerPasskey(name: String, activity: Activity) {
         val accountId = _uiState.value.accountId ?: run {
             android.util.Log.e("PasskeyAuth", "registerPasskey: accountId is null")


### PR DESCRIPTION
## Summary

`androidx.credentials.PublicKeyCredential` and its companions (`CreatePublicKeyCredentialRequest`, `GetPublicKeyCredentialOption`, etc.) require **API 28+**. With `minSdk = 26`, `PasskeyManager` was lint-flagged and would `NoSuchMethodError` on Android 8.0/8.1 devices if ever called. This PR adds proper gating at the UI layer so the feature only activates on API 28+.

Follow-up to #113 which covered the same class of issue for `removeFirst()` and `longVersionCode` and added CONVENTION §13.

## Approach

- **`PasskeyManager.authenticate` / `register`**: `@RequiresApi(Build.VERSION_CODES.P)`. The class itself (constructor, `credentialManager` field) stays API-safe so Hilt can still instantiate the singleton on all supported devices.
- **`SignInViewModel.signInWithPasskey` / `SettingsViewModel.registerPasskey`**: `@RequiresApi(Build.VERSION_CODES.P)`. **No runtime SDK check in the ViewModel** — the UI is the sole gate, so a defensive runtime check would emit user-facing errors on a path that can't be reached.
- **`SignInScreen`**: the `onPasskeySignIn` lambda is set to `null` unless both `FeatureFlags.PASSKEY_AUTH_ENABLED` and `Build.VERSION.SDK_INT >= P` hold. `UsernameStep` already hides its passkey button when this lambda is null.
- **`SettingsScreen`**: `passkeyEnabled` now requires both conditions. The entire Passkeys section, the Add dialog, and the Revoke dialog are all already wrapped in `if (passkeyEnabled)`.

## No defensive ViewModel errors

An earlier draft put a runtime `if (Build.VERSION.SDK_INT < P) { set error; return }` in the ViewModel. That was dead code — the UI gate makes the path unreachable on API < 28, so the error state could never be displayed. Removed in favor of the `@RequiresApi` annotation alone.

## Lint impact

| | errors | warnings |
|---|---|---|
| main (before) | 3 | 140 |
| this PR | 2 | 139 |

Eliminated: `PublicKeyCredential`, `CreatePublicKeyCredentialResponse`, `GetPublicKeyCredentialOption`, `CreatePublicKeyCredentialRequest` NewApi warnings.

Remaining 2 errors are pre-existing `produceState` false positives in `CodeBlockView.kt` (unrelated, not touched by this PR).

## Verification

- `./gradlew :app:compileDebugKotlin` passes.
- `./gradlew :app:lintDebug` shows the expected improvement (details above).
- `FeatureFlags.PASSKEY_AUTH_ENABLED` is currently `false`, so UI behavior is unchanged until that flag flips. When it does flip, passkey features will be correctly hidden on API 26-27 devices.

## Related

- #113 — first API-level compatibility PR (`removeFirst`, `longVersionCode`) + CONVENTION §13 that this PR follows
- #84 — the original `SequencedCollection`-on-older-API incident (`removeLast` in HtmlContent)