### PR TITLE
Resolve article and post URLs via postByUrl

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -870,6 +870,12 @@ query ArticleDraft($id: ID!) {
     }
 }
 
+query PostByUrl($url: String!) {
+    postByUrl(url: $url) {
+        id
+    }
+}
+
 mutation PublishArticleDraft($id: ID!, $slug: String!, $language: Locale!, $allowLlmTranslation: Boolean) {
     publishArticleDraft(input: { id: $id, slug: $slug, language: $language, allowLlmTranslation: $allowLlmTranslation }) {
         ... on PublishArticleDraftPayload {

--- a/app/src/main/java/pub/hackers/android/MainActivity.kt
+++ b/app/src/main/java/pub/hackers/android/MainActivity.kt
@@ -123,6 +123,7 @@ class MainActivity : ComponentActivity() {
                 deepLinkData = DeepLinkData(token = route.token, code = route.code)
             }
             is HackersPubRoute.Profile, is HackersPubRoute.NoteDetail,
+            is HackersPubRoute.PostByUrl,
             is HackersPubRoute.TagSearch, is HackersPubRoute.Notifications -> {
                 navigationIntent = NavigationIntent(route = route.toNavRoute())
             }

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -30,6 +30,7 @@ import pub.hackers.android.graphql.PersonalTimelineQuery
 import pub.hackers.android.graphql.PostQuotesQuery
 import pub.hackers.android.graphql.PostRepliesQuery
 import pub.hackers.android.graphql.PostSharesQuery
+import pub.hackers.android.graphql.PostByUrlQuery
 import pub.hackers.android.graphql.PostDetailQuery
 import pub.hackers.android.graphql.PublishArticleDraftMutation
 import pub.hackers.android.graphql.PublicTimelineQuery
@@ -255,6 +256,24 @@ class HackersPubRepository @Inject constructor(
                         )
                     )
                 }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun resolvePostIdByUrl(url: String): Result<String> {
+        return try {
+            val response = apolloClient.query(
+                PostByUrlQuery(url)
+            ).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val postId = response.data?.postByUrl?.id
+                    ?: return Result.failure(Exception("Post not found"))
+                Result.success(postId)
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/pub/hackers/android/navigation/HackersPubUrlRouter.kt
+++ b/app/src/main/java/pub/hackers/android/navigation/HackersPubUrlRouter.kt
@@ -8,6 +8,7 @@ import java.net.URI
 sealed class HackersPubRoute {
     data class Profile(val handle: String) : HackersPubRoute()
     data class NoteDetail(val globalId: String) : HackersPubRoute()
+    data class PostByUrl(val url: String) : HackersPubRoute()
     data class SignInVerification(val token: String, val code: String) : HackersPubRoute()
     data class TagSearch(val tag: String) : HackersPubRoute()
     data object Notifications : HackersPubRoute()
@@ -20,6 +21,7 @@ object HackersPubUrlRouter {
         "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
         RegexOption.IGNORE_CASE
     )
+    private val YEAR_REGEX = Regex("^\\d{4}$")
 
     fun resolve(url: String): HackersPubRoute? {
         val uri = try {
@@ -53,12 +55,10 @@ object HackersPubUrlRouter {
                 HackersPubRoute.SignInVerification(token, code)
             }
 
-            // /@<handle>/<noteId> where noteId is a UUID
-            segments.size == 2 && segments[0].startsWith("@") && UUID_REGEX.matches(segments[1]) -> {
-                val handle = segments[0].removePrefix("@")
-                val noteId = segments[1]
-                val globalId = encodeRelayId("Note", noteId)
-                HackersPubRoute.NoteDetail(globalId)
+            // /@<handle>/<year>/<slug> (article) or /@<handle>/<uuid> (post)
+            segments.size >= 2 && segments[0].startsWith("@") &&
+                (YEAR_REGEX.matches(segments[1]) || UUID_REGEX.matches(segments[1])) -> {
+                HackersPubRoute.PostByUrl(url)
             }
 
             // /@<handle>
@@ -97,6 +97,7 @@ fun HackersPubRoute.toNavRoute(): String {
     return when (this) {
         is HackersPubRoute.Profile -> DetailScreen.Profile.createRoute(handle)
         is HackersPubRoute.NoteDetail -> DetailScreen.PostDetail.createRoute(globalId)
+        is HackersPubRoute.PostByUrl -> DetailScreen.PostByUrl.createRoute(url)
         is HackersPubRoute.SignInVerification -> DetailScreen.SignIn.createRoute(token, code)
         is HackersPubRoute.TagSearch -> Screen.Search.createRoute(tag)
         is HackersPubRoute.Notifications -> Screen.Notifications.route

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -46,6 +46,7 @@ import pub.hackers.android.ui.screens.compose.ComposeScreen
 import pub.hackers.android.ui.screens.drafts.DraftsScreen
 import pub.hackers.android.ui.screens.explore.ExploreScreen
 import pub.hackers.android.ui.screens.notifications.NotificationsScreen
+import pub.hackers.android.ui.screens.postdetail.PostByUrlResolverScreen
 import pub.hackers.android.ui.screens.postdetail.PostDetailScreen
 import pub.hackers.android.ui.screens.profile.ProfileScreen
 import pub.hackers.android.ui.screens.recommendedactors.RecommendedActorsScreen
@@ -125,6 +126,12 @@ sealed class DetailScreen(val route: String) {
     }
     data object Profile : DetailScreen("profile/{handle}") {
         fun createRoute(handle: String) = "profile/$handle"
+    }
+    data object PostByUrl : DetailScreen("post-by-url?url={url}") {
+        fun createRoute(url: String): String {
+            val encoded = android.net.Uri.encode(url)
+            return "post-by-url?url=$encoded"
+        }
     }
     data object RecommendedActors : DetailScreen("recommended-actors")
     data object ComposeArticle : DetailScreen("compose-article?draftId={draftId}") {
@@ -515,6 +522,26 @@ fun HackersPubApp(
                         navController.navigate(DetailScreen.PostDetail.createRoute(id))
                     },
                     isLoggedIn = isLoggedIn
+                )
+            }
+
+            composable(
+                route = DetailScreen.PostByUrl.route,
+                arguments = listOf(
+                    navArgument("url") { type = NavType.StringType }
+                )
+            ) { backStackEntry ->
+                val url = backStackEntry.arguments?.getString("url") ?: return@composable
+                PostByUrlResolverScreen(
+                    url = url,
+                    onResolved = { postId ->
+                        navController.navigate(DetailScreen.PostDetail.createRoute(postId)) {
+                            popUpTo(DetailScreen.PostByUrl.route) { inclusive = true }
+                        }
+                    },
+                    onNavigateBack = {
+                        navController.popBackStack()
+                    }
                 )
             }
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostByUrlResolverScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostByUrlResolverScreen.kt
@@ -1,0 +1,65 @@
+package pub.hackers.android.ui.screens.postdetail
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PostByUrlResolverScreen(
+    url: String,
+    onResolved: (String) -> Unit,
+    onNavigateBack: () -> Unit,
+    viewModel: PostByUrlResolverViewModel = hiltViewModel()
+) {
+    var resolved by remember { mutableStateOf(false) }
+
+    LaunchedEffect(url) {
+        val postId = viewModel.resolve(url)
+        if (postId != null) {
+            resolved = true
+            onResolved(postId)
+        } else {
+            onNavigateBack()
+        }
+    }
+
+    if (!resolved) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("") },
+                    navigationIcon = {
+                        IconButton(onClick = onNavigateBack) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        }
+                    }
+                )
+            }
+        ) { innerPadding ->
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostByUrlResolverScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostByUrlResolverScreen.kt
@@ -2,6 +2,7 @@ package pub.hackers.android.ui.screens.postdetail
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -53,9 +54,11 @@ fun PostByUrlResolverScreen(
                     }
                 )
             }
-        ) { innerPadding ->
+        ) { contentPadding ->
             Box(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(contentPadding),
                 contentAlignment = Alignment.Center
             ) {
                 CircularProgressIndicator()

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostByUrlResolverViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostByUrlResolverViewModel.kt
@@ -1,0 +1,16 @@
+package pub.hackers.android.ui.screens.postdetail
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import pub.hackers.android.data.repository.HackersPubRepository
+import javax.inject.Inject
+
+@HiltViewModel
+class PostByUrlResolverViewModel @Inject constructor(
+    private val repository: HackersPubRepository,
+) : ViewModel() {
+
+    suspend fun resolve(url: String): String? {
+        return repository.resolvePostIdByUrl(url).getOrNull()
+    }
+}


### PR DESCRIPTION
## Summary
Add deep link support for article URLs (`/@handle/year/slug`) and fix post URL (`/@handle/uuid`) resolution by using the server-side `postByUrl` GraphQL query. Previously, post URLs relied on manually constructing relay IDs which didn't match the server's expected format. Now both article and post URLs go through a lightweight resolver screen that calls the `postByUrl` API to get the correct relay ID, then navigates to the existing PostDetailScreen.

---
Assisted-By: Claude Code(claude-opus-4-6)