### PR TITLE
Remove WorkManager startup initializer override

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,12 +69,7 @@
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"
-            android:exported="false"
-            tools:node="merge">
-            <meta-data
-                android:name="androidx.work.WorkManagerInitializer"
-                tools:node="remove" />
-        </provider>
+            tools:node="remove" />
     </application>
 
 </manifest>


### PR DESCRIPTION
## Summary
- remove the merged androidx.startup InitializationProvider from the app manifest
- rely on Application Configuration.Provider for WorkManager initialization
- resolve the RemoveWorkManagerInitializer lint warning for on-demand initialization

## Testing
- not run