### PR TITLE
Fix implicit default locale in String.format calls

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -1246,8 +1246,8 @@ internal fun formatRelativeTime(instant: Instant): String {
 private fun formatCount(count: Int): String {
     return when {
         count < 1000 -> count.toString()
-        count < 1_000_000 -> String.format("%.1fK", count / 1000.0)
-        else -> String.format("%.1fM", count / 1_000_000.0)
+        count < 1_000_000 -> String.format(Locale.ROOT, "%.1fK", count / 1000.0)
+        else -> String.format(Locale.ROOT, "%.1fM", count / 1_000_000.0)
     }
 }
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsViewModel.kt
@@ -28,6 +28,7 @@ import pub.hackers.android.data.local.PreferencesManager
 import pub.hackers.android.data.local.SessionManager
 import pub.hackers.android.data.repository.HackersPubRepository
 import pub.hackers.android.domain.model.Passkey
+import java.util.Locale
 import javax.inject.Inject
 
 data class SettingsUiState(
@@ -185,9 +186,9 @@ class SettingsViewModel @Inject constructor(
     private fun formatBytes(bytes: Long): String {
         return when {
             bytes < 1024 -> "$bytes B"
-            bytes < 1024 * 1024 -> String.format("%.1f KB", bytes / 1024.0)
-            bytes < 1024 * 1024 * 1024 -> String.format("%.1f MB", bytes / (1024.0 * 1024))
-            else -> String.format("%.1f GB", bytes / (1024.0 * 1024 * 1024))
+            bytes < 1024 * 1024 -> String.format(Locale.ROOT, "%.1f KB", bytes / 1024.0)
+            bytes < 1024 * 1024 * 1024 -> String.format(Locale.ROOT, "%.1f MB", bytes / (1024.0 * 1024))
+            else -> String.format(Locale.ROOT, "%.1f GB", bytes / (1024.0 * 1024 * 1024))
         }
     }
 


### PR DESCRIPTION
## Summary
- `PostCard.kt`와 `SettingsViewModel.kt`의 `String.format` 호출에 `Locale.ROOT`를 명시하여 로케일 의존 포맷팅 경고 해결
- 숫자 포맷(K/M 축약, 바이트 단위)이 기기 로케일과 무관하게 일관되게 표시됨

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)