### PR TITLE
Handle NoCredentialException in passkey sign-in

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInViewModel.kt
@@ -1,16 +1,20 @@
 package pub.hackers.android.ui.screens.auth
 
 import android.app.Activity
+import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.credentials.exceptions.NoCredentialException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import pub.hackers.android.R
 import pub.hackers.android.data.auth.PasskeyManager
 import pub.hackers.android.data.local.SessionManager
 import pub.hackers.android.data.repository.HackersPubRepository
@@ -36,7 +40,8 @@ data class SignInUiState(
 class SignInViewModel @Inject constructor(
     private val repository: HackersPubRepository,
     private val sessionManager: SessionManager,
-    private val passkeyManager: PasskeyManager
+    private val passkeyManager: PasskeyManager,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SignInUiState())
@@ -178,6 +183,14 @@ class SignInViewModel @Inject constructor(
                     avatarUrl = session.account.avatarUrl
                 )
                 _uiState.update { it.copy(isLoading = false, isSignedIn = true) }
+            } catch (e: NoCredentialException) {
+                android.util.Log.w("PasskeyAuth", "No passkey registered", e)
+                _uiState.update {
+                    it.copy(
+                        error = context.getString(R.string.no_passkey_registered),
+                        isLoading = false
+                    )
+                }
             } catch (e: Exception) {
                 android.util.Log.e("PasskeyAuth", "Passkey auth failed", e)
                 _uiState.update {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="remove_passkey_confirm">Are you sure you want to remove this passkey?</string>
     <string name="remove">Remove</string>
     <string name="add">Add</string>
+    <string name="no_passkey_registered">No passkey found. Sign in with your username first, then register a passkey in Settings.</string>
 
     <!-- Timeline -->
     <string name="local_timeline">Hackers\' Pub</string>

--- a/app/src/test/java/pub/hackers/android/ui/screens/auth/SignInViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/auth/SignInViewModelTest.kt
@@ -1,0 +1,73 @@
+package pub.hackers.android.ui.screens.auth
+
+import android.app.Activity
+import android.content.Context
+import androidx.credentials.exceptions.NoCredentialException
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import pub.hackers.android.R
+import pub.hackers.android.data.auth.PasskeyManager
+import pub.hackers.android.data.local.SessionManager
+import pub.hackers.android.data.repository.HackersPubRepository
+import pub.hackers.android.testutil.MainDispatcherRule
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class SignInViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val repository = mockk<HackersPubRepository>(relaxed = true)
+    private val sessionManager = mockk<SessionManager>(relaxed = true)
+    private val passkeyManager = mockk<PasskeyManager>(relaxed = true)
+    private val context = mockk<Context>(relaxed = true)
+    private val activity = mockk<Activity>(relaxed = true)
+
+    private fun newViewModel() = SignInViewModel(
+        repository = repository,
+        sessionManager = sessionManager,
+        passkeyManager = passkeyManager,
+        context = context,
+    )
+
+    @Test
+    fun `signInWithPasskey shows no-passkey message on NoCredentialException`() = runTest {
+        val expectedMessage = "No passkey found."
+        every { context.getString(R.string.no_passkey_registered) } returns expectedMessage
+        coEvery { repository.getPasskeyAuthenticationOptions(any()) } returns Result.success("{}")
+        coEvery { passkeyManager.authenticate(any(), any()) } throws NoCredentialException()
+
+        val vm = newViewModel()
+        vm.signInWithPasskey(activity)
+        advanceUntilIdle()
+
+        assertEquals(expectedMessage, vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isLoading)
+        assertFalse(vm.uiState.value.isSignedIn)
+    }
+
+    @Test
+    fun `signInWithPasskey shows exception message on generic failure`() = runTest {
+        coEvery { repository.getPasskeyAuthenticationOptions(any()) } returns Result.success("{}")
+        coEvery { passkeyManager.authenticate(any(), any()) } throws RuntimeException("timeout")
+
+        val vm = newViewModel()
+        vm.signInWithPasskey(activity)
+        advanceUntilIdle()
+
+        assertEquals("timeout", vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isLoading)
+        assertFalse(vm.uiState.value.isSignedIn)
+    }
+}

--- a/app/src/test/java/pub/hackers/android/ui/screens/timeline/TimelineViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/timeline/TimelineViewModelTest.kt
@@ -34,7 +34,9 @@ class TimelineViewModelTest {
         coEvery { confirmBeforeShare } returns MutableStateFlow(false)
     }
 
-    private fun newViewModel() = TimelineViewModel(repository, preferencesManager)
+    private val refreshTrigger = TimelineRefreshTrigger()
+
+    private fun newViewModel() = TimelineViewModel(repository, preferencesManager, refreshTrigger)
 
     private val sampleActor = Actor(
         id = "actor-1",


### PR DESCRIPTION
## Summary
- `SignInViewModel`에서 `NoCredentialException`을 별도 catch하여 "패스키가 없으니 먼저 username으로 로그인 후 설정에서 등록하라"는 안내 스낵바 표시
- `SignInViewModelTest` 추가 (NoCredentialException / generic Exception 분기 검증)
- 기존 `TimelineViewModelTest` 컴파일 에러 수정 (누락된 `refreshTrigger` 파라미터)

## :warning: Testing caveat
패스키 기능이 `FeatureFlags.PASSKEY_AUTH_ENABLED = false`로 비활성화되어 있어 dev 빌드에서 실제 UI 동선을 수동 테스트할 수 없습니다. 유닛테스트로 예외 분기는 검증했으나, 피처플래그 활성화 후 실기기에서 스낵바 노출 및 UX 흐름을 반드시 확인해야 합니다.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` 빌드 성공
- [x] `SignInViewModelTest` 2개 테스트 통과
- [x] `TimelineViewModelTest` 기존 테스트 전부 통과
- [ ] 피처플래그 활성화 후 실기기에서 패스키 없는 상태로 로그인 시도 → 스낵바 확인 (미완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)