### PR TITLE
Fix IME composition loss and reply prefix overwrite

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -134,7 +134,7 @@ fun ComposeScreen(
     // Sync TextFieldValue with ViewModel state changes (e.g., when mention is selected)
     LaunchedEffect(uiState.content, uiState.cursorPosition) {
         if (textFieldValue.text != uiState.content) {
-            textFieldValue = TextFieldValue(
+            textFieldValue = textFieldValue.copy(
                 text = uiState.content,
                 selection = TextRange(uiState.cursorPosition)
             )

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
@@ -217,8 +217,8 @@ class ComposeViewModel @Inject constructor(
                         it.copy(
                             replyTargetPost = post,
                             isLoadingReplyTarget = false,
-                            content = mentionPrefix,
-                            cursorPosition = mentionPrefix.length
+                            content = if (it.content.isBlank()) mentionPrefix else it.content,
+                            cursorPosition = if (it.content.isBlank()) mentionPrefix.length else it.cursorPosition
                         )
                     }
                 }

--- a/app/src/test/java/pub/hackers/android/ui/screens/compose/ComposeViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/compose/ComposeViewModelTest.kt
@@ -1,0 +1,108 @@
+package pub.hackers.android.ui.screens.compose
+
+import android.content.Context
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import pub.hackers.android.data.repository.HackersPubRepository
+import pub.hackers.android.domain.model.Actor
+import pub.hackers.android.domain.model.EngagementStats
+import pub.hackers.android.domain.model.Post
+import pub.hackers.android.domain.model.PostDetailResult
+import pub.hackers.android.testutil.MainDispatcherRule
+import java.time.Instant
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class ComposeViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val repository = mockk<HackersPubRepository>(relaxed = true)
+    private val context = mockk<Context>(relaxed = true)
+
+    private fun newViewModel() = ComposeViewModel(repository, context)
+
+    private val sampleActor = Actor(
+        id = "actor-1",
+        name = "Alice",
+        handle = "alice@hackers.pub",
+        avatarUrl = "https://example.com/avatar.png",
+    )
+
+    private fun samplePost(
+        id: String = "post-1",
+        actor: Actor = sampleActor,
+        mentions: List<String> = emptyList(),
+    ) = Post(
+        id = id,
+        typename = "Note",
+        name = null,
+        published = Instant.parse("2025-01-01T00:00:00Z"),
+        summary = null,
+        content = "<p>hello</p>",
+        excerpt = "hello",
+        url = null,
+        viewerHasShared = false,
+        actor = actor,
+        media = emptyList(),
+        engagementStats = EngagementStats(replies = 0, reactions = 0, shares = 0, quotes = 0),
+        mentions = mentions,
+        reactionGroups = emptyList(),
+    )
+
+    @Test
+    fun `setReplyTarget injects mention prefix when content is blank`() = runTest {
+        val post = samplePost()
+        coEvery { repository.getPostDetail("post-1") } returns Result.success(
+            PostDetailResult(
+                post = post,
+                reactionGroups = emptyList(),
+                replies = emptyList(),
+                hasMoreReplies = false,
+                repliesEndCursor = null,
+            )
+        )
+
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.setReplyTarget("post-1")
+        advanceUntilIdle()
+
+        assertEquals("@alice@hackers.pub ", vm.uiState.value.content)
+    }
+
+    @Test
+    fun `setReplyTarget does not overwrite when user already typed content`() = runTest {
+        val post = samplePost()
+        coEvery { repository.getPostDetail("post-1") } returns Result.success(
+            PostDetailResult(
+                post = post,
+                reactionGroups = emptyList(),
+                replies = emptyList(),
+                hasMoreReplies = false,
+                repliesEndCursor = null,
+            )
+        )
+
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.updateContent("user typed this")
+        vm.setReplyTarget("post-1")
+        advanceUntilIdle()
+
+        assertEquals("user typed this", vm.uiState.value.content)
+    }
+}


### PR DESCRIPTION
## Summary
- `ComposeScreen.kt`: `TextFieldValue()` 생성자 대신 `copy()` 사용하여 IME composition 상태 보존
- `ComposeViewModel.kt`: `setReplyTarget()`이 비동기 응답 후 사용자가 이미 입력한 content를 덮어쓰지 않도록 방어
- `ComposeViewModelTest.kt`: setReplyTarget() 동작 검증 테스트 추가

## Context
사용자 제보: "입력하다가 IME 바꿔서 입력하면 마지막 단어가 날라감"

디버그 로그로 확인한 결과, 삼성 키보드가 전체 텍스트를 하나의 composition으로 유지하여(`comp=TextRange(0, N)`), IME 전환 시 commit 없이 composition이 통째로 버려지는 삼성 키보드 고유 동작이 원인. 이 부분은 앱 수준에서 완벽히 우회 불가.

본 PR은 앱 코드에서 제어 가능한 두 가지 문제를 수정:
1. `LaunchedEffect`에서 `TextFieldValue` 재생성 시 composition 유실 방지
2. Reply 진입 시 비동기 네트워크 응답이 사용자 입력을 덮어쓰는 경합 방지

## Test plan
- [x] `./gradlew assembleDebug` 빌드 성공
- [x] ComposeViewModelTest 추가 (setReplyTarget prefix 주입/비주입 검증)
- [ ] Reply 진입 후 mention prefix 정상 주입 확인
- [ ] Reply 진입 후 빠르게 입력 시 네트워크 응답이 입력을 덮어쓰지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)