### PR TITLE
Redirect unrecognized deep links to browser

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -58,15 +58,6 @@
                     android:host="hackers.pub"
                     android:pathPrefix="/tags/" />
             </intent-filter>
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data
-                    android:scheme="https"
-                    android:host="hackers.pub"
-                    android:pathPrefix="/notifications" />
-            </intent-filter>
         </activity>
         <provider
             android:name="androidx.startup.InitializationProvider"

--- a/app/src/main/java/pub/hackers/android/MainActivity.kt
+++ b/app/src/main/java/pub/hackers/android/MainActivity.kt
@@ -180,10 +180,25 @@ class MainActivity : ComponentActivity() {
             }
             is HackersPubRoute.Profile, is HackersPubRoute.NoteDetail,
             is HackersPubRoute.PostByUrl,
-            is HackersPubRoute.TagSearch, is HackersPubRoute.Notifications -> {
+            is HackersPubRoute.TagSearch -> {
                 navigationIntent = NavigationIntent(route = route.toNavRoute())
             }
-            null -> { /* Not a recognized URL, ignore */ }
+            null -> {
+                // Unrecognized hackers.pub URL — open in browser
+                val browserIntent = Intent.makeMainSelectorActivity(
+                    Intent.ACTION_MAIN,
+                    Intent.CATEGORY_APP_BROWSER
+                ).apply {
+                    setData(data)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                try {
+                    startActivity(browserIntent)
+                } catch (_: Exception) {
+                    startActivity(Intent(Intent.ACTION_VIEW, data))
+                }
+                if (isTaskRoot) finish()
+            }
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/navigation/HackersPubUrlRouter.kt
+++ b/app/src/main/java/pub/hackers/android/navigation/HackersPubUrlRouter.kt
@@ -11,7 +11,6 @@ sealed class HackersPubRoute {
     data class PostByUrl(val url: String) : HackersPubRoute()
     data class SignInVerification(val token: String, val code: String) : HackersPubRoute()
     data class TagSearch(val tag: String) : HackersPubRoute()
-    data object Notifications : HackersPubRoute()
 }
 
 object HackersPubUrlRouter {
@@ -37,11 +36,6 @@ object HackersPubUrlRouter {
         val segments = path.split('/').filter { it.isNotEmpty() }
 
         return when {
-            // /notifications
-            segments.size == 1 && segments[0] == "notifications" -> {
-                HackersPubRoute.Notifications
-            }
-
             // /tags/<tag>
             segments.size == 2 && segments[0] == "tags" -> {
                 HackersPubRoute.TagSearch(segments[1])
@@ -100,6 +94,5 @@ fun HackersPubRoute.toNavRoute(): String {
         is HackersPubRoute.PostByUrl -> DetailScreen.PostByUrl.createRoute(url)
         is HackersPubRoute.SignInVerification -> DetailScreen.SignIn.createRoute(token, code)
         is HackersPubRoute.TagSearch -> Screen.Search.createRoute(tag)
-        is HackersPubRoute.Notifications -> Screen.Notifications.route
     }
 }


### PR DESCRIPTION
## Summary
Remove the `/notifications` intent filter and URL route since it should not be handled as a deep link. For unrecognized hackers.pub URLs caught by the broad `/@.*` manifest pattern (e.g. `/@handle/settings`, `/@handle/invites`), redirect to the system browser instead of silently showing the home screen.

---
Assisted-By: Claude Code(claude-opus-4-6)