### PR TITLE
Display reactors in post detail bottom sheet

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -6,6 +6,7 @@ import android.text.Html
 import android.webkit.WebView
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -184,6 +185,26 @@ fun PostDetailScreen(
         }
     }
 
+    // Reactors bottom sheet
+    if (uiState.showReactorsSheet && uiState.reactionGroups.isNotEmpty()) {
+        val initialIndex = uiState.selectedReactionGroup
+            ?.let { selected -> uiState.reactionGroups.indexOf(selected).coerceAtLeast(0) }
+            ?: 0
+        ModalBottomSheet(
+            onDismissRequest = { viewModel.dismissReactorsSheet() },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        ) {
+            ReactorsSheet(
+                groups = uiState.reactionGroups,
+                initialIndex = initialIndex,
+                onProfileClick = { handle ->
+                    viewModel.dismissReactorsSheet()
+                    onProfileClick(handle)
+                }
+            )
+        }
+    }
+
     // Quotes bottom sheet
     if (uiState.showQuotesSheet) {
         ModalBottomSheet(
@@ -349,11 +370,12 @@ fun PostDetailScreen(
                                 }
                             }
                         },
-                        onReactionClick = { emoji -> viewModel.toggleReaction(emoji) },
+                        onReactionClick = { group -> viewModel.showReactorsSheet(group) },
                         onReactionPickerClick = { viewModel.toggleReactionPicker() },
                         onQuoteClick = { onQuoteClick(postId) },
                         onSharesClick = { viewModel.showSharesSheet() },
                         onQuotesClick = { viewModel.showQuotesSheet() },
+                        onReactionsClick = { viewModel.showAllReactors() },
                         onExternalShareClick = {
                             val shareUrl = uiState.post?.url
                                 ?: uiState.post?.iri
@@ -428,11 +450,12 @@ internal fun PostDetailContent(
     onPostClick: (String) -> Unit,
     onShareClick: () -> Unit,
     onReplyClick: () -> Unit,
-    onReactionClick: (String) -> Unit,
+    onReactionClick: (ReactionGroup) -> Unit,
     onReactionPickerClick: () -> Unit,
     onQuoteClick: () -> Unit,
     onSharesClick: () -> Unit,
     onQuotesClick: () -> Unit,
+    onReactionsClick: () -> Unit,
     onExternalShareClick: () -> Unit,
     onWebViewClick: (String) -> Unit = {},
 ) {
@@ -706,7 +729,8 @@ internal fun PostDetailContent(
                     Text(
                         text = "${post.engagementStats.reactions} ${stringResource(R.string.reactions)}",
                         style = typography.labelMedium,
-                        color = colors.textSecondary
+                        color = colors.accent,
+                        modifier = Modifier.clickable { onReactionsClick() }
                     )
                     Text(
                         text = "${post.engagementStats.quotes} ${stringResource(R.string.quotes)}",
@@ -721,9 +745,7 @@ internal fun PostDetailContent(
                     Row {
                         reactionGroups.forEach { group ->
                             Card(
-                                onClick = {
-                                    group.emoji?.let { onReactionClick(it) }
-                                },
+                                onClick = { onReactionClick(group) },
                                 shape = RoundedCornerShape(AppShapes.reactionPillRadius),
                                 colors = CardDefaults.cardColors(
                                     containerColor = if (group.viewerHasReacted)
@@ -848,6 +870,128 @@ internal fun PostDetailContent(
             if (replies.loadState.append is LoadState.Loading) {
                 item {
                     LoadingItem()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReactorsSheet(
+    groups: List<ReactionGroup>,
+    initialIndex: Int,
+    onProfileClick: (String) -> Unit
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+    val safeInitial = initialIndex.coerceIn(0, (groups.size - 1).coerceAtLeast(0))
+    var selectedIndex by remember(groups) { mutableIntStateOf(safeInitial) }
+    val selectedGroup = groups.getOrNull(selectedIndex)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.reactors),
+            style = typography.bodyLargeSemiBold,
+            color = colors.textPrimary,
+            modifier = Modifier.padding(bottom = 12.dp)
+        )
+
+        if (groups.isEmpty() || selectedGroup == null) {
+            Text(
+                text = stringResource(R.string.no_reactors),
+                style = typography.bodyMedium,
+                color = colors.textSecondary,
+                modifier = Modifier.padding(vertical = 24.dp)
+            )
+            return@Column
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+                .padding(bottom = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            groups.forEachIndexed { index, group ->
+                val isSelected = index == selectedIndex
+                Card(
+                    onClick = { selectedIndex = index },
+                    shape = RoundedCornerShape(AppShapes.reactionPillRadius),
+                    colors = CardDefaults.cardColors(
+                        containerColor = if (isSelected)
+                            colors.accent.copy(alpha = 0.2f)
+                        else
+                            colors.surface
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        if (group.emoji != null) {
+                            Text(text = group.emoji)
+                        } else if (group.customEmoji != null) {
+                            AsyncImage(
+                                model = group.customEmoji.imageUrl,
+                                contentDescription = group.customEmoji.name,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = group.count.toString(),
+                            style = typography.labelMedium,
+                            color = if (isSelected) colors.accent else colors.textPrimary
+                        )
+                    }
+                }
+            }
+        }
+
+        if (selectedGroup.reactors.isEmpty()) {
+            Text(
+                text = stringResource(R.string.no_reactors),
+                style = typography.bodyMedium,
+                color = colors.textSecondary,
+                modifier = Modifier.padding(vertical = 24.dp)
+            )
+        } else {
+            selectedGroup.reactors.forEach { actor ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onProfileClick(actor.handle) }
+                        .padding(vertical = 8.dp)
+                ) {
+                    AsyncImage(
+                        model = actor.avatarUrl,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(40.dp)
+                            .clip(CircleShape),
+                        contentScale = ContentScale.Crop
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column {
+                        pub.hackers.android.ui.components.RichDisplayName(
+                            name = actor.name,
+                            fallback = actor.handle,
+                            style = typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                            color = colors.textPrimary
+                        )
+                        Text(
+                            text = actor.handle,
+                            style = typography.labelMedium,
+                            color = colors.textSecondary
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
@@ -42,6 +42,8 @@ data class PostDetailUiState(
     val showQuotesSheet: Boolean = false,
     val quotePosts: List<Post> = emptyList(),
     val isLoadingQuotes: Boolean = false,
+    val showReactorsSheet: Boolean = false,
+    val selectedReactionGroup: ReactionGroup? = null,
 )
 
 @HiltViewModel
@@ -230,6 +232,24 @@ class PostDetailViewModel @Inject constructor(
 
     fun dismissQuotesSheet() {
         _uiState.update { it.copy(showQuotesSheet = false) }
+    }
+
+    fun showReactorsSheet(group: ReactionGroup) {
+        _uiState.update {
+            it.copy(showReactorsSheet = true, selectedReactionGroup = group)
+        }
+    }
+
+    fun showAllReactors() {
+        _uiState.update {
+            it.copy(showReactorsSheet = true, selectedReactionGroup = null)
+        }
+    }
+
+    fun dismissReactorsSheet() {
+        _uiState.update {
+            it.copy(showReactorsSheet = false, selectedReactionGroup = null)
+        }
     }
 
     fun toggleReaction(emoji: String) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,9 @@
     <string name="replies">Replies</string>
     <string name="shares">Shares</string>
     <string name="reactions">Reactions</string>
+    <string name="reactors">Reactors</string>
+    <string name="no_reactors">No reactors yet</string>
+    <string name="reactors_with_emoji">Reacted with %1$s</string>
     <string name="quotes">Quotes</string>
     <string name="share">Share</string>
     <string name="unshare">Unshare</string>

--- a/app/src/test/java/pub/hackers/android/ui/screens/postdetail/PostDetailContentTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/postdetail/PostDetailContentTest.kt
@@ -160,6 +160,7 @@ class PostDetailContentTest {
                     onQuoteClick = {},
                     onSharesClick = {},
                     onQuotesClick = {},
+                    onReactionsClick = {},
                     onExternalShareClick = {},
                 )
             }


### PR DESCRIPTION
## Summary

Adds a bottom sheet that lists who reacted to a post. Open it by tapping a reaction pill (filtered to that emoji) or by tapping the "N reactions" engagement text (shows all groups, default-selected to the first). The sheet has a horizontally-scrollable row of single-selection emoji filter pills at the top and a scrollable list of reactor avatars/handles below. Reactor data is already fetched by the existing `PostDetailQuery.reactors(first: 20)` — no new GraphQL.

> [!NOTE]
> Reactor avatars currently render as the Gravatar mystery-person fallback for many actors due to an upstream server bug — see hackers-pub/hackerspub#252. Once that lands the avatars will populate with no client change.

---
Assisted-By: Claude Code(claude-opus-4-7)