### PR TITLE
Add profile edit screen (name, bio, avatar, links)

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -894,3 +894,32 @@ mutation PublishArticleDraft($id: ID!, $slug: String!, $language: Locale!, $allo
         }
     }
 }
+
+query EditAccount {
+    viewer {
+        id
+        name
+        bio
+        avatarUrl
+        handle
+        links {
+            name
+            url
+        }
+    }
+}
+
+mutation UpdateAccount($input: UpdateAccountInput!) {
+    updateAccount(input: $input) {
+        account {
+            id
+            name
+            bio
+            avatarUrl
+            links {
+                name
+                url
+            }
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -19,6 +19,7 @@ import pub.hackers.android.graphql.CompleteLoginChallengeMutation
 import pub.hackers.android.graphql.CreateNoteMutation
 import pub.hackers.android.graphql.DeleteArticleDraftMutation
 import pub.hackers.android.graphql.DeletePostMutation
+import pub.hackers.android.graphql.EditAccountQuery
 import pub.hackers.android.graphql.GetPasskeyAuthenticationOptionsMutation
 import pub.hackers.android.graphql.GetPasskeyRegistrationOptionsMutation
 import pub.hackers.android.graphql.FollowActorMutation
@@ -49,7 +50,10 @@ import pub.hackers.android.graphql.SharePostMutation
 import pub.hackers.android.graphql.UnblockActorMutation
 import pub.hackers.android.graphql.UnfollowActorMutation
 import pub.hackers.android.graphql.UnsharePostMutation
+import pub.hackers.android.graphql.UpdateAccountMutation
 import pub.hackers.android.graphql.ViewerQuery
+import pub.hackers.android.graphql.type.AccountLinkInput
+import pub.hackers.android.graphql.type.UpdateAccountInput
 import pub.hackers.android.graphql.fragment.ActorFields
 import pub.hackers.android.graphql.fragment.EngagementStatsFields
 import pub.hackers.android.graphql.fragment.MediaFields
@@ -488,6 +492,69 @@ class HackersPubRepository @Inject constructor(
                         )
                     }
                 )
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getEditableAccount(): Result<EditableAccount> {
+        return try {
+            val response = apolloClient.query(EditAccountQuery())
+                .fetchPolicy(FetchPolicy.NetworkOnly)
+                .execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val viewer = response.data?.viewer
+                    ?: return Result.failure(Exception("Not signed in"))
+                Result.success(
+                    EditableAccount(
+                        id = viewer.id,
+                        name = viewer.name,
+                        bio = viewer.bio.toString(),
+                        avatarUrl = viewer.avatarUrl.toString(),
+                        handle = viewer.handle,
+                        links = viewer.links.map { link ->
+                            EditableAccountLink(name = link.name, url = link.url.toString())
+                        }
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun updateAccount(
+        id: String,
+        name: String,
+        bio: String,
+        avatarUrl: String?,
+        links: List<EditableAccountLink>,
+    ): Result<Unit> {
+        return try {
+            val response = apolloClient.mutation(
+                UpdateAccountMutation(
+                    input = UpdateAccountInput(
+                        id = id,
+                        name = Optional.present(name),
+                        bio = Optional.present(bio),
+                        avatarUrl = if (avatarUrl != null) Optional.present(avatarUrl) else Optional.Absent,
+                        links = Optional.present(
+                            links.map { AccountLinkInput(name = it.name, url = it.url) }
+                        ),
+                    )
+                )
+            ).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else if (response.data?.updateAccount?.account == null) {
+                Result.failure(Exception("Update failed"))
+            } else {
+                Result.success(Unit)
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -289,3 +289,19 @@ data class ProfileResult(
     val followsViewer: Boolean = false,
     val viewerBlocks: Boolean = false
 )
+
+@Immutable
+data class EditableAccount(
+    val id: String,
+    val name: String,
+    val bio: String,
+    val avatarUrl: String,
+    val handle: String,
+    val links: List<EditableAccountLink>
+)
+
+@Immutable
+data class EditableAccountLink(
+    val name: String,
+    val url: String
+)

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -48,12 +48,15 @@ import pub.hackers.android.ui.screens.explore.ExploreScreen
 import pub.hackers.android.ui.screens.notifications.NotificationsScreen
 import pub.hackers.android.ui.screens.postdetail.PostByUrlResolverScreen
 import pub.hackers.android.ui.screens.postdetail.PostDetailScreen
+import pub.hackers.android.ui.screens.editprofile.EditProfileScreen
 import pub.hackers.android.ui.screens.profile.ProfileScreen
 import pub.hackers.android.ui.screens.recommendedactors.RecommendedActorsScreen
 import pub.hackers.android.ui.screens.search.SearchScreen
 import pub.hackers.android.ui.screens.settings.SettingsScreen
 import pub.hackers.android.ui.screens.timeline.TimelineScreen
 import pub.hackers.android.ui.screens.webview.WebViewScreen
+
+private const val PROFILE_REFRESH_KEY = "profile_refresh"
 
 sealed class Screen(
     val route: String,
@@ -140,6 +143,7 @@ sealed class DetailScreen(val route: String) {
         }
     }
     data object Drafts : DetailScreen("drafts")
+    data object EditProfile : DetailScreen("edit-profile")
     data object WebView : DetailScreen("webview?url={url}") {
         fun createRoute(url: String): String {
             val encoded = android.net.Uri.encode(url)
@@ -557,8 +561,15 @@ fun HackersPubApp(
                 arguments = listOf(navArgument("handle") { type = NavType.StringType })
             ) { backStackEntry ->
                 val handle = backStackEntry.arguments?.getString("handle") ?: return@composable
+                val profileRefreshFlag = backStackEntry.savedStateHandle
+                    .getStateFlow(PROFILE_REFRESH_KEY, false)
+                    .collectAsState()
                 ProfileScreen(
                     handle = handle,
+                    refreshSignal = profileRefreshFlag.value,
+                    onRefreshConsumed = {
+                        backStackEntry.savedStateHandle[PROFILE_REFRESH_KEY] = false
+                    },
                     onNavigateBack = {
                         navController.popBackStack()
                     },
@@ -573,6 +584,23 @@ fun HackersPubApp(
                     },
                     onQuoteClick = { postId ->
                         navController.navigate(DetailScreen.Compose.createRoute(quoteOf = postId))
+                    },
+                    onEditProfileClick = {
+                        navController.navigate(DetailScreen.EditProfile.route)
+                    }
+                )
+            }
+
+            composable(DetailScreen.EditProfile.route) {
+                EditProfileScreen(
+                    onNavigateBack = {
+                        navController.popBackStack()
+                    },
+                    onSaved = {
+                        navController.previousBackStackEntry
+                            ?.savedStateHandle
+                            ?.set(PROFILE_REFRESH_KEY, true)
+                        navController.popBackStack()
                     }
                 )
             }

--- a/app/src/main/java/pub/hackers/android/ui/screens/editprofile/AvatarPicker.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/editprofile/AvatarPicker.kt
@@ -1,0 +1,53 @@
+package pub.hackers.android.ui.screens.editprofile
+
+import android.content.ContentResolver
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.util.Base64
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+
+private const val MAX_AVATAR_EDGE_PX = 1024
+private const val JPEG_QUALITY = 85
+
+/**
+ * Reads [uri] from [contentResolver], downscales to at most [MAX_AVATAR_EDGE_PX] on the longer
+ * edge, re-encodes as JPEG, and returns a `data:image/jpeg;base64,...` URL.
+ *
+ * Matches the web client's flow: the server fetches the avatar from the data URL on
+ * updateAccount. Runs on Dispatchers.IO because decode + re-encode is blocking.
+ */
+suspend fun encodeAvatarAsDataUrl(
+    contentResolver: ContentResolver,
+    uri: Uri,
+): Result<String> = withContext(Dispatchers.IO) {
+    runCatching {
+        val bitmap = contentResolver.openInputStream(uri).use { input ->
+            requireNotNull(input) { "Cannot open input stream for $uri" }
+            BitmapFactory.decodeStream(input)
+                ?: error("Failed to decode image")
+        }
+
+        val scaled = downscale(bitmap, MAX_AVATAR_EDGE_PX)
+        val bytes = ByteArrayOutputStream().use { out ->
+            scaled.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, out)
+            out.toByteArray()
+        }
+        if (scaled !== bitmap) scaled.recycle()
+        bitmap.recycle()
+
+        val base64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
+        "data:image/jpeg;base64,$base64"
+    }
+}
+
+private fun downscale(source: Bitmap, maxEdge: Int): Bitmap {
+    val longer = maxOf(source.width, source.height)
+    if (longer <= maxEdge) return source
+    val scale = maxEdge.toFloat() / longer
+    val newWidth = (source.width * scale).toInt().coerceAtLeast(1)
+    val newHeight = (source.height * scale).toInt().coerceAtLeast(1)
+    return Bitmap.createScaledBitmap(source, newWidth, newHeight, true)
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/editprofile/EditProfileScreen.kt
@@ -1,0 +1,311 @@
+package pub.hackers.android.ui.screens.editprofile
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil3.compose.AsyncImage
+import pub.hackers.android.R
+import pub.hackers.android.ui.components.ErrorMessage
+import pub.hackers.android.ui.components.FullScreenLoading
+import pub.hackers.android.ui.components.LargeTitleHeader
+import pub.hackers.android.ui.theme.LocalAppColors
+import pub.hackers.android.ui.theme.LocalAppTypography
+
+@Composable
+fun EditProfileScreen(
+    onNavigateBack: () -> Unit,
+    onSaved: () -> Unit,
+    viewModel: EditProfileViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val colors = LocalAppColors.current
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                EditProfileEvent.Saved -> onSaved()
+            }
+        }
+    }
+
+    if (uiState.saveError != null) {
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissSaveError() },
+            title = { Text(stringResource(R.string.action_error)) },
+            text = { Text(uiState.saveError ?: "") },
+            confirmButton = {
+                TextButton(onClick = { viewModel.dismissSaveError() }) {
+                    Text(stringResource(R.string.ok))
+                }
+            }
+        )
+    }
+
+    Scaffold(
+        contentWindowInsets = WindowInsets(0),
+        topBar = {
+            LargeTitleHeader(
+                title = stringResource(R.string.edit_profile_title),
+                leadingContent = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                            tint = colors.accent
+                        )
+                    }
+                },
+                trailingContent = {
+                    TextButton(
+                        onClick = { viewModel.save() },
+                        enabled = !uiState.isSaving && !uiState.isLoading,
+                    ) {
+                        if (uiState.isSaving) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(16.dp),
+                                color = colors.accent,
+                                strokeWidth = 2.dp,
+                            )
+                        } else {
+                            Text(
+                                text = stringResource(R.string.edit_profile_save),
+                                color = colors.accent,
+                            )
+                        }
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        EditProfileContent(
+            uiState = uiState,
+            contentPadding = padding,
+            onNameChange = viewModel::onNameChange,
+            onBioChange = viewModel::onBioChange,
+            onLinkAdd = viewModel::onLinkAdd,
+            onLinkChange = viewModel::onLinkChange,
+            onLinkRemove = viewModel::onLinkRemove,
+            onRetry = viewModel::load,
+        )
+    }
+}
+
+@Composable
+private fun EditProfileContent(
+    uiState: EditProfileUiState,
+    contentPadding: PaddingValues,
+    onNameChange: (String) -> Unit,
+    onBioChange: (String) -> Unit,
+    onLinkAdd: () -> Unit,
+    onLinkChange: (Int, String, String) -> Unit,
+    onLinkRemove: (Int) -> Unit,
+    onRetry: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding),
+    ) {
+        when {
+            uiState.isLoading -> FullScreenLoading()
+            uiState.loadError != null -> ErrorMessage(
+                message = uiState.loadError,
+                onRetry = onRetry,
+            )
+            else -> EditProfileForm(
+                uiState = uiState,
+                onNameChange = onNameChange,
+                onBioChange = onBioChange,
+                onLinkAdd = onLinkAdd,
+                onLinkChange = onLinkChange,
+                onLinkRemove = onLinkRemove,
+            )
+        }
+    }
+}
+
+@Composable
+private fun EditProfileForm(
+    uiState: EditProfileUiState,
+    onNameChange: (String) -> Unit,
+    onBioChange: (String) -> Unit,
+    onLinkAdd: () -> Unit,
+    onLinkChange: (Int, String, String) -> Unit,
+    onLinkRemove: (Int) -> Unit,
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        AvatarSection(
+            avatarUrl = uiState.pendingAvatarDataUrl ?: uiState.avatarUrl,
+        )
+
+        OutlinedTextField(
+            value = uiState.name,
+            onValueChange = onNameChange,
+            label = { Text(stringResource(R.string.edit_profile_name_label)) },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        OutlinedTextField(
+            value = uiState.bio,
+            onValueChange = onBioChange,
+            label = { Text(stringResource(R.string.edit_profile_bio_label)) },
+            placeholder = { Text(stringResource(R.string.edit_profile_bio_hint)) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp),
+        )
+
+        HorizontalDivider(color = colors.divider, thickness = 1.dp)
+
+        Text(
+            text = stringResource(R.string.edit_profile_links_section),
+            style = typography.bodyLargeSemiBold,
+            color = colors.textPrimary,
+        )
+
+        uiState.links.forEachIndexed { index, link ->
+            LinkRow(
+                name = link.name,
+                url = link.url,
+                onNameChange = { onLinkChange(index, it, link.url) },
+                onUrlChange = { onLinkChange(index, link.name, it) },
+                onRemove = { onLinkRemove(index) },
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onLinkAdd() }
+                .padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = null,
+                tint = colors.accent,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = stringResource(R.string.edit_profile_add_link),
+                style = typography.bodyMedium,
+                color = colors.accent,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+    }
+}
+
+@Composable
+private fun AvatarSection(avatarUrl: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        AsyncImage(
+            model = avatarUrl,
+            contentDescription = null,
+            modifier = Modifier
+                .size(96.dp)
+                .clip(CircleShape),
+            contentScale = ContentScale.Crop,
+        )
+    }
+}
+
+@Composable
+private fun LinkRow(
+    name: String,
+    url: String,
+    onNameChange: (String) -> Unit,
+    onUrlChange: (String) -> Unit,
+    onRemove: () -> Unit,
+) {
+    val colors = LocalAppColors.current
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            OutlinedTextField(
+                value = name,
+                onValueChange = onNameChange,
+                label = { Text(stringResource(R.string.edit_profile_link_name)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedTextField(
+                value = url,
+                onValueChange = onUrlChange,
+                label = { Text(stringResource(R.string.edit_profile_link_url)) },
+                singleLine = true,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                    keyboardType = KeyboardType.Uri,
+                ),
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        IconButton(onClick = onRemove) {
+            Icon(
+                imageVector = Icons.Filled.Close,
+                contentDescription = stringResource(R.string.edit_profile_remove_link),
+                tint = colors.textSecondary,
+            )
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/editprofile/EditProfileScreen.kt
@@ -1,5 +1,8 @@
 package pub.hackers.android.ui.screens.editprofile
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -34,15 +37,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil3.compose.AsyncImage
+import kotlinx.coroutines.launch
 import pub.hackers.android.R
 import pub.hackers.android.ui.components.ErrorMessage
 import pub.hackers.android.ui.components.FullScreenLoading
@@ -58,6 +64,19 @@ fun EditProfileScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val colors = LocalAppColors.current
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    val avatarPicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia(),
+    ) { uri ->
+        if (uri != null) {
+            scope.launch {
+                encodeAvatarAsDataUrl(context.contentResolver, uri)
+                    .onSuccess(viewModel::onAvatarPicked)
+            }
+        }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -121,6 +140,11 @@ fun EditProfileScreen(
             contentPadding = padding,
             onNameChange = viewModel::onNameChange,
             onBioChange = viewModel::onBioChange,
+            onPickAvatar = {
+                avatarPicker.launch(
+                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                )
+            },
             onLinkAdd = viewModel::onLinkAdd,
             onLinkChange = viewModel::onLinkChange,
             onLinkRemove = viewModel::onLinkRemove,
@@ -135,6 +159,7 @@ private fun EditProfileContent(
     contentPadding: PaddingValues,
     onNameChange: (String) -> Unit,
     onBioChange: (String) -> Unit,
+    onPickAvatar: () -> Unit,
     onLinkAdd: () -> Unit,
     onLinkChange: (Int, String, String) -> Unit,
     onLinkRemove: (Int) -> Unit,
@@ -155,6 +180,7 @@ private fun EditProfileContent(
                 uiState = uiState,
                 onNameChange = onNameChange,
                 onBioChange = onBioChange,
+                onPickAvatar = onPickAvatar,
                 onLinkAdd = onLinkAdd,
                 onLinkChange = onLinkChange,
                 onLinkRemove = onLinkRemove,
@@ -168,6 +194,7 @@ private fun EditProfileForm(
     uiState: EditProfileUiState,
     onNameChange: (String) -> Unit,
     onBioChange: (String) -> Unit,
+    onPickAvatar: () -> Unit,
     onLinkAdd: () -> Unit,
     onLinkChange: (Int, String, String) -> Unit,
     onLinkRemove: (Int) -> Unit,
@@ -184,6 +211,7 @@ private fun EditProfileForm(
     ) {
         AvatarSection(
             avatarUrl = uiState.pendingAvatarDataUrl ?: uiState.avatarUrl,
+            onPickAvatar = onPickAvatar,
         )
 
         OutlinedTextField(
@@ -247,19 +275,34 @@ private fun EditProfileForm(
 }
 
 @Composable
-private fun AvatarSection(avatarUrl: String) {
-    Row(
+private fun AvatarSection(
+    avatarUrl: String,
+    onPickAvatar: () -> Unit,
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+
+    Column(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         AsyncImage(
             model = avatarUrl,
             contentDescription = null,
             modifier = Modifier
                 .size(96.dp)
-                .clip(CircleShape),
+                .clip(CircleShape)
+                .clickable { onPickAvatar() },
             contentScale = ContentScale.Crop,
         )
+        TextButton(onClick = onPickAvatar) {
+            Text(
+                text = stringResource(R.string.edit_profile_change_avatar),
+                color = colors.accent,
+                style = typography.bodyMedium,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/editprofile/EditProfileViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/editprofile/EditProfileViewModel.kt
@@ -1,0 +1,144 @@
+package pub.hackers.android.ui.screens.editprofile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import pub.hackers.android.data.repository.HackersPubRepository
+import pub.hackers.android.domain.model.EditableAccountLink
+import javax.inject.Inject
+
+data class EditProfileUiState(
+    val id: String = "",
+    val handle: String = "",
+    val name: String = "",
+    val bio: String = "",
+    val avatarUrl: String = "",
+    val pendingAvatarDataUrl: String? = null,
+    val links: List<EditableAccountLink> = emptyList(),
+    val isLoading: Boolean = true,
+    val isSaving: Boolean = false,
+    val loadError: String? = null,
+    val saveError: String? = null,
+)
+
+sealed interface EditProfileEvent {
+    data object Saved : EditProfileEvent
+}
+
+@HiltViewModel
+class EditProfileViewModel @Inject constructor(
+    private val repository: HackersPubRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(EditProfileUiState())
+    val uiState: StateFlow<EditProfileUiState> = _uiState.asStateFlow()
+
+    private val _events = Channel<EditProfileEvent>(Channel.BUFFERED)
+    val events = _events.receiveAsFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, loadError = null) }
+            repository.getEditableAccount()
+                .onSuccess { account ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            id = account.id,
+                            handle = account.handle,
+                            name = account.name,
+                            bio = account.bio,
+                            avatarUrl = account.avatarUrl,
+                            pendingAvatarDataUrl = null,
+                            links = account.links,
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(isLoading = false, loadError = error.message)
+                    }
+                }
+        }
+    }
+
+    fun onNameChange(value: String) {
+        _uiState.update { it.copy(name = value) }
+    }
+
+    fun onBioChange(value: String) {
+        _uiState.update { it.copy(bio = value) }
+    }
+
+    fun onAvatarPicked(dataUrl: String) {
+        _uiState.update { it.copy(pendingAvatarDataUrl = dataUrl) }
+    }
+
+    fun onLinkAdd() {
+        _uiState.update { it.copy(links = it.links + EditableAccountLink(name = "", url = "")) }
+    }
+
+    fun onLinkChange(index: Int, name: String, url: String) {
+        _uiState.update {
+            val updated = it.links.toMutableList()
+            if (index in updated.indices) {
+                updated[index] = EditableAccountLink(name = name, url = url)
+            }
+            it.copy(links = updated)
+        }
+    }
+
+    fun onLinkRemove(index: Int) {
+        _uiState.update {
+            val updated = it.links.toMutableList()
+            if (index in updated.indices) {
+                updated.removeAt(index)
+            }
+            it.copy(links = updated)
+        }
+    }
+
+    fun save() {
+        val state = _uiState.value
+        if (state.isSaving || state.id.isEmpty()) return
+
+        val cleanedLinks = state.links
+            .map { it.copy(name = it.name.trim(), url = it.url.trim()) }
+            .filter { it.name.isNotEmpty() && it.url.isNotEmpty() }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, saveError = null) }
+            repository.updateAccount(
+                id = state.id,
+                name = state.name,
+                bio = state.bio,
+                avatarUrl = state.pendingAvatarDataUrl,
+                links = cleanedLinks,
+            )
+                .onSuccess {
+                    _uiState.update { it.copy(isSaving = false) }
+                    _events.send(EditProfileEvent.Saved)
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(isSaving = false, saveError = error.message)
+                    }
+                }
+        }
+    }
+
+    fun dismissSaveError() {
+        _uiState.update { it.copy(saveError = null) }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
@@ -93,10 +93,20 @@ fun ProfileScreen(
     onProfileClick: (String) -> Unit = {},
     onReplyClick: (String) -> Unit = {},
     onQuoteClick: (String) -> Unit = {},
+    onEditProfileClick: () -> Unit = {},
+    refreshSignal: Boolean = false,
+    onRefreshConsumed: () -> Unit = {},
     viewModel: ProfileViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val selectedTab by viewModel.selectedTab.collectAsState()
+
+    androidx.compose.runtime.LaunchedEffect(refreshSignal) {
+        if (refreshSignal) {
+            viewModel.refresh()
+            onRefreshConsumed()
+        }
+    }
     val listState = rememberLazyListState()
     val context = LocalContext.current
     val colors = LocalAppColors.current
@@ -231,6 +241,7 @@ fun ProfileScreen(
                                 isPerformingAction = uiState.isPerformingAction,
                                 onFollowClick = { viewModel.followActor() },
                                 onUnfollowClick = { viewModel.unfollowActor() },
+                                onEditProfileClick = onEditProfileClick,
                                 onMentionClick = onProfileClick
                             )
                         }
@@ -577,6 +588,7 @@ private fun ProfileHeader(
     isPerformingAction: Boolean,
     onFollowClick: () -> Unit,
     onUnfollowClick: () -> Unit,
+    onEditProfileClick: () -> Unit = {},
     onMentionClick: (String) -> Unit = {}
 ) {
     val colors = LocalAppColors.current
@@ -622,6 +634,24 @@ private fun ProfileHeader(
                 followsViewer = followsViewer,
                 viewerBlocks = viewerBlocks
             )
+        }
+
+        if (isViewer) {
+            Spacer(modifier = Modifier.height(12.dp))
+
+            OutlinedButton(
+                onClick = onEditProfileClick,
+                shape = RoundedCornerShape(20.dp),
+                border = BorderStroke(1.5.dp, colors.buttonOutline),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = colors.accent
+                )
+            ) {
+                Text(
+                    text = stringResource(R.string.edit_profile),
+                    modifier = Modifier.padding(horizontal = 20.dp)
+                )
+            }
         }
 
         if (!isViewer) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,4 +181,20 @@
     <string name="error_generic">Something went wrong</string>
     <string name="error_network">Network error. Please check your connection.</string>
     <string name="retry">Retry</string>
+
+    <!-- Edit profile -->
+    <string name="edit_profile_title">Edit profile</string>
+    <string name="edit_profile">Edit profile</string>
+    <string name="edit_profile_save">Save</string>
+    <string name="edit_profile_name_label">Display name</string>
+    <string name="edit_profile_bio_label">Bio</string>
+    <string name="edit_profile_bio_hint">Markdown supported</string>
+    <string name="edit_profile_links_section">Links</string>
+    <string name="edit_profile_add_link">Add link</string>
+    <string name="edit_profile_link_name">Label</string>
+    <string name="edit_profile_link_url">URL</string>
+    <string name="edit_profile_remove_link">Remove link</string>
+    <string name="edit_profile_change_avatar">Change avatar</string>
+    <string name="edit_profile_avatar_too_large">Image is too large</string>
+    <string name="edit_profile_avatar_unsupported">Unsupported image format</string>
 </resources>

--- a/app/src/test/java/pub/hackers/android/ui/screens/editprofile/EditProfileViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/editprofile/EditProfileViewModelTest.kt
@@ -1,0 +1,226 @@
+package pub.hackers.android.ui.screens.editprofile
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import pub.hackers.android.data.repository.HackersPubRepository
+import pub.hackers.android.domain.model.EditableAccount
+import pub.hackers.android.domain.model.EditableAccountLink
+import pub.hackers.android.testutil.MainDispatcherRule
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EditProfileViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val repository = mockk<HackersPubRepository>(relaxed = true)
+
+    private val sampleAccount = EditableAccount(
+        id = "account-1",
+        name = "Alice",
+        bio = "original bio",
+        avatarUrl = "https://example.com/avatar.png",
+        handle = "@alice@hackers.pub",
+        links = listOf(
+            EditableAccountLink(name = "Blog", url = "https://blog.example"),
+        ),
+    )
+
+    private fun stubLoad(result: EditableAccount = sampleAccount) {
+        coEvery { repository.getEditableAccount() } returns Result.success(result)
+    }
+
+    @Test
+    fun `init loads account and populates state`() = runTest {
+        stubLoad()
+        val vm = EditProfileViewModel(repository)
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertEquals("account-1", state.id)
+        assertEquals("Alice", state.name)
+        assertEquals("original bio", state.bio)
+        assertEquals("https://example.com/avatar.png", state.avatarUrl)
+        assertEquals(1, state.links.size)
+        assertEquals(false, state.isLoading)
+        assertNull(state.loadError)
+    }
+
+    @Test
+    fun `load failure stores loadError`() = runTest {
+        coEvery { repository.getEditableAccount() } returns
+            Result.failure(RuntimeException("not signed in"))
+        val vm = EditProfileViewModel(repository)
+        advanceUntilIdle()
+
+        assertEquals("not signed in", vm.uiState.value.loadError)
+        assertEquals(false, vm.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `edits update state`() = runTest {
+        stubLoad()
+        val vm = EditProfileViewModel(repository)
+        advanceUntilIdle()
+
+        vm.onNameChange("Alice B")
+        vm.onBioChange("new bio")
+        vm.onAvatarPicked("data:image/jpeg;base64,xxx")
+        vm.onLinkAdd()
+        vm.onLinkChange(1, "GitHub", "https://github.com/alice")
+
+        val state = vm.uiState.value
+        assertEquals("Alice B", state.name)
+        assertEquals("new bio", state.bio)
+        assertEquals("data:image/jpeg;base64,xxx", state.pendingAvatarDataUrl)
+        assertEquals(2, state.links.size)
+        assertEquals("GitHub", state.links[1].name)
+    }
+
+    @Test
+    fun `onLinkRemove drops the link at index`() = runTest {
+        stubLoad()
+        val vm = EditProfileViewModel(repository)
+        advanceUntilIdle()
+
+        vm.onLinkRemove(0)
+
+        assertTrue(vm.uiState.value.links.isEmpty())
+    }
+
+    @Test
+    fun `save emits Saved event on success`() = runTest {
+        stubLoad()
+        coEvery {
+            repository.updateAccount(any(), any(), any(), any(), any())
+        } returns Result.success(Unit)
+
+        val vm = EditProfileViewModel(repository)
+        advanceUntilIdle()
+
+        vm.save()
+        advanceUntilIdle()
+
+        val event = vm.events.first()
+        assertEquals(EditProfileEvent.Saved, event)
+        assertEquals(false, vm.uiState.value.isSaving)
+        assertNull(vm.uiState.value.saveError)
+    }
+
+    @Test
+    fun `save omits avatarUrl when none picked`() = runTest {
+        stubLoad()
+        coEvery {
+            repository.updateAccount(any(), any(), any(), any(), any())
+        } returns Result.success(Unit)
+
+        val vm = EditProfileViewModel(repository)
+        advanceUntilIdle()
+        vm.save()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            repository.updateAccount(
+                id = "account-1",
+                name = "Alice",
+                bio = "original bio",
+                avatarUrl = null,
+                links = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `save passes picked avatar data URL through`() = runTest {
+        stubLoad()
+        coEvery {
+            repository.updateAccount(any(), any(), any(), any(), any())
+        } returns Result.success(Unit)
+
+        val vm = EditProfileViewModel(repository)
+        advanceUntilIdle()
+        vm.onAvatarPicked("data:image/jpeg;base64,abc")
+        vm.save()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            repository.updateAccount(
+                id = any(),
+                name = any(),
+                bio = any(),
+                avatarUrl = "data:image/jpeg;base64,abc",
+                links = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `save drops blank links before sending`() = runTest {
+        stubLoad(sampleAccount.copy(links = emptyList()))
+        coEvery {
+            repository.updateAccount(any(), any(), any(), any(), any())
+        } returns Result.success(Unit)
+
+        val vm = EditProfileViewModel(repository)
+        advanceUntilIdle()
+
+        vm.onLinkAdd()
+        vm.onLinkChange(0, "  ", "  ")
+        vm.onLinkAdd()
+        vm.onLinkChange(1, "Site", "https://site.example")
+        vm.save()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            repository.updateAccount(
+                id = any(),
+                name = any(),
+                bio = any(),
+                avatarUrl = any(),
+                links = listOf(EditableAccountLink("Site", "https://site.example")),
+            )
+        }
+    }
+
+    @Test
+    fun `save failure populates saveError and clears isSaving`() = runTest {
+        stubLoad()
+        coEvery {
+            repository.updateAccount(any(), any(), any(), any(), any())
+        } returns Result.failure(RuntimeException("server exploded"))
+
+        val vm = EditProfileViewModel(repository)
+        advanceUntilIdle()
+        vm.save()
+        advanceUntilIdle()
+
+        assertEquals("server exploded", vm.uiState.value.saveError)
+        assertEquals(false, vm.uiState.value.isSaving)
+    }
+
+    @Test
+    fun `dismissSaveError clears saveError`() = runTest {
+        stubLoad()
+        coEvery {
+            repository.updateAccount(any(), any(), any(), any(), any())
+        } returns Result.failure(RuntimeException("x"))
+        val vm = EditProfileViewModel(repository)
+        advanceUntilIdle()
+        vm.save()
+        advanceUntilIdle()
+
+        vm.dismissSaveError()
+
+        assertNull(vm.uiState.value.saveError)
+    }
+}


### PR DESCRIPTION
## Summary

Adds an Edit Profile flow accessible from the user's own profile header. Covers the core editable fields: display name, bio (Markdown), avatar, and account links. Mirrors the web client's strategy of sending the avatar as a `data:` URL to the `updateAccount` mutation rather than introducing a separate file upload.

Navigation uses a `savedStateHandle` flag so the profile refreshes on return without coupling the two ViewModels. Follows repo conventions: `StateFlow<UiState>` for state, `Channel` for one-shot Saved event (§6.3), `NetworkOnly` for the initial load (§7.2), all user-facing text via `stringResource` (§11.1). Scoped to core fields only — username, locales, visibility defaults, and other preferences are out of scope for this PR.

---
Assisted-By: Claude Code(claude-opus-4-7)