### PR TITLE
Rework search UX: filter chips, section headers, locale-aware results

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -260,8 +260,8 @@ query Notifications($after: String) {
     }
 }
 
-query SearchPost($query: String!) {
-    searchPost(query: $query) {
+query SearchPost($query: String!, $languages: [Locale!]) {
+    searchPost(query: $query, languages: $languages) {
         edges {
             node {
                 ...PostFields

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -178,9 +178,17 @@ class HackersPubRepository @Inject constructor(
         }
     }
 
-    suspend fun searchPosts(query: String): Result<List<Post>> {
+    suspend fun searchPosts(
+        query: String,
+        languages: List<String>
+    ): Result<List<Post>> {
         return try {
-            val response = apolloClient.query(SearchPostQuery(query)).execute()
+            val response = apolloClient.query(
+                SearchPostQuery(
+                    query = query,
+                    languages = Optional.present(languages)
+                )
+            ).execute()
 
             if (response.hasErrors()) {
                 Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))

--- a/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -120,13 +121,18 @@ fun SearchScreen(
                             innerTextField()
                         }
 
-                        if (uiState.query.isNotEmpty()) {
-                            IconButton(onClick = { viewModel.clearSearch() }) {
-                                Icon(
-                                    imageVector = Icons.Default.Clear,
-                                    contentDescription = stringResource(R.string.cancel),
-                                    tint = colors.textSecondary
-                                )
+                        Box(
+                            modifier = Modifier.size(48.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            if (uiState.query.isNotEmpty()) {
+                                IconButton(onClick = { viewModel.clearSearch() }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Clear,
+                                        contentDescription = stringResource(R.string.cancel),
+                                        tint = colors.textSecondary
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
@@ -170,6 +170,69 @@ fun SearchScreen(
                             onRetry = { viewModel.search() }
                         )
                     }
+                    uiState.mode == SearchMode.ALL -> {
+                        val hasActors = uiState.actors.isNotEmpty()
+                        val hasPosts = uiState.posts.isNotEmpty()
+                        when {
+                            uiState.hasSearched && !hasActors && !hasPosts -> {
+                                ErrorMessage(message = stringResource(R.string.no_results))
+                            }
+                            hasActors || hasPosts -> {
+                                LazyColumn {
+                                    if (hasActors) {
+                                        item(key = "header-actors") {
+                                            SearchSectionHeader(stringResource(R.string.search_people))
+                                        }
+                                        items(
+                                            items = uiState.actors,
+                                            key = { "actor-${it.id}" }
+                                        ) { actor ->
+                                            SearchActorRow(
+                                                actor = actor,
+                                                onClick = { onProfileClick(actor.handle) }
+                                            )
+                                            HorizontalDivider(
+                                                color = colors.divider,
+                                                thickness = 1.dp,
+                                                modifier = Modifier.padding(horizontal = 16.dp)
+                                            )
+                                        }
+                                    }
+                                    if (hasPosts) {
+                                        item(key = "header-posts") {
+                                            SearchSectionHeader(stringResource(R.string.search_posts))
+                                        }
+                                        items(
+                                            items = uiState.posts,
+                                            key = { "post-${it.id}" }
+                                        ) { post ->
+                                            SearchPostItem(
+                                                post = post,
+                                                onPostClick = onPostClick,
+                                                onProfileClick = onProfileClick,
+                                                onReplyClick = onReplyClick,
+                                                onQuoteClick = onQuoteClick,
+                                                onExternalShare = { shareUrl ->
+                                                    val sendIntent = Intent().apply {
+                                                        action = Intent.ACTION_SEND
+                                                        putExtra(Intent.EXTRA_TEXT, shareUrl)
+                                                        type = "text/plain"
+                                                    }
+                                                    context.startActivity(Intent.createChooser(sendIntent, null))
+                                                }
+                                            )
+                                            HorizontalDivider(
+                                                color = colors.divider,
+                                                thickness = 1.dp,
+                                                modifier = Modifier.padding(horizontal = 16.dp)
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                            else -> SearchHint()
+                        }
+                    }
                     uiState.mode == SearchMode.PEOPLE -> {
                         when {
                             uiState.hasSearched && uiState.actors.isEmpty() -> {
@@ -207,26 +270,20 @@ fun SearchScreen(
                                         items = uiState.posts,
                                         key = { it.id }
                                     ) { post ->
-                                        PostCard(
+                                        SearchPostItem(
                                             post = post,
-                                            onClick = { onPostClick(post.sharedPost?.id ?: post.id) },
+                                            onPostClick = onPostClick,
                                             onProfileClick = onProfileClick,
-                                            onReplyClick = { onReplyClick(post.sharedPost?.id ?: post.id) },
-                                            onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
-                                            onReactionClick = null,
-                                            onExternalShareClick = {
-                                                val displayPost = post.sharedPost ?: post
-                                                val shareUrl = displayPost.url ?: displayPost.iri
-                                                if (shareUrl != null) {
-                                                    val sendIntent = Intent().apply {
-                                                        action = Intent.ACTION_SEND
-                                                        putExtra(Intent.EXTRA_TEXT, shareUrl)
-                                                        type = "text/plain"
-                                                    }
-                                                    context.startActivity(Intent.createChooser(sendIntent, null))
+                                            onReplyClick = onReplyClick,
+                                            onQuoteClick = onQuoteClick,
+                                            onExternalShare = { shareUrl ->
+                                                val sendIntent = Intent().apply {
+                                                    action = Intent.ACTION_SEND
+                                                    putExtra(Intent.EXTRA_TEXT, shareUrl)
+                                                    type = "text/plain"
                                                 }
-                                            },
-                                            onQuotedPostClick = onPostClick
+                                                context.startActivity(Intent.createChooser(sendIntent, null))
+                                            }
                                         )
                                         HorizontalDivider(
                                             color = colors.divider,
@@ -255,6 +312,11 @@ private fun SearchModeChips(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
+        ModeChip(
+            label = stringResource(R.string.search_all),
+            isSelected = selected == SearchMode.ALL,
+            onClick = { onSelect(SearchMode.ALL) }
+        )
         ModeChip(
             label = stringResource(R.string.search_people),
             isSelected = selected == SearchMode.PEOPLE,
@@ -353,4 +415,50 @@ private fun SearchHint() {
             color = colors.textSecondary
         )
     }
+}
+
+@Composable
+private fun SearchSectionHeader(title: String) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = title,
+            style = typography.labelMedium,
+            color = colors.textSecondary,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        )
+        HorizontalDivider(
+            color = colors.divider,
+            thickness = 1.dp,
+            modifier = Modifier.padding(horizontal = 16.dp)
+        )
+    }
+}
+
+@Composable
+private fun SearchPostItem(
+    post: pub.hackers.android.domain.model.Post,
+    onPostClick: (String) -> Unit,
+    onProfileClick: (String) -> Unit,
+    onReplyClick: (String) -> Unit,
+    onQuoteClick: (String) -> Unit,
+    onExternalShare: (String) -> Unit
+) {
+    PostCard(
+        post = post,
+        onClick = { onPostClick(post.sharedPost?.id ?: post.id) },
+        onProfileClick = onProfileClick,
+        onReplyClick = { onReplyClick(post.sharedPost?.id ?: post.id) },
+        onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
+        onReactionClick = null,
+        onExternalShareClick = {
+            val displayPost = post.sharedPost ?: post
+            val shareUrl = displayPost.url ?: displayPost.iri
+            if (shareUrl != null) {
+                onExternalShare(shareUrl)
+            }
+        },
+        onQuotedPostClick = onPostClick
+    )
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
@@ -171,7 +171,8 @@ fun SearchScreen(
                         )
                     }
                     uiState.mode == SearchMode.ALL -> {
-                        val hasActors = uiState.actors.isNotEmpty()
+                        val allActors = uiState.actors.take(5)
+                        val hasActors = allActors.isNotEmpty()
                         val hasPosts = uiState.posts.isNotEmpty()
                         when {
                             uiState.hasSearched && !hasActors && !hasPosts -> {
@@ -184,7 +185,7 @@ fun SearchScreen(
                                             SearchSectionHeader(stringResource(R.string.search_people))
                                         }
                                         items(
-                                            items = uiState.actors,
+                                            items = allActors,
                                             key = { "actor-${it.id}" }
                                         ) { actor ->
                                             SearchActorRow(
@@ -260,14 +261,19 @@ fun SearchScreen(
                         }
                     }
                     else -> {
+                        val postList = if (uiState.mode == SearchMode.TAGS) {
+                            uiState.taggedPosts
+                        } else {
+                            uiState.posts
+                        }
                         when {
-                            uiState.hasSearched && uiState.posts.isEmpty() -> {
+                            uiState.hasSearched && postList.isEmpty() -> {
                                 ErrorMessage(message = stringResource(R.string.no_results))
                             }
-                            uiState.posts.isNotEmpty() -> {
+                            postList.isNotEmpty() -> {
                                 LazyColumn {
                                     items(
-                                        items = uiState.posts,
+                                        items = postList,
                                         key = { it.id }
                                     ) { post ->
                                         SearchPostItem(

--- a/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
@@ -1,16 +1,21 @@
 package pub.hackers.android.ui.screens.search
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -18,6 +23,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -29,6 +36,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -36,11 +44,14 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import android.content.Intent
+import coil3.compose.AsyncImage
 import pub.hackers.android.R
+import pub.hackers.android.domain.model.Actor
 import pub.hackers.android.ui.components.ErrorMessage
 import pub.hackers.android.ui.components.FullScreenLoading
 import pub.hackers.android.ui.components.LargeTitleHeader
 import pub.hackers.android.ui.components.PostCard
+import pub.hackers.android.ui.components.RichDisplayName
 import pub.hackers.android.ui.theme.AppShapes
 import pub.hackers.android.ui.theme.LocalAppColors
 import pub.hackers.android.ui.theme.LocalAppTypography
@@ -140,6 +151,14 @@ fun SearchScreen(
                 modifier = Modifier.fillMaxWidth()
             )
 
+            SearchModeChips(
+                selected = uiState.mode,
+                onSelect = { viewModel.setMode(it) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            )
+
             Box(modifier = Modifier.fillMaxSize()) {
                 when {
                     uiState.isLoading -> {
@@ -151,59 +170,187 @@ fun SearchScreen(
                             onRetry = { viewModel.search() }
                         )
                     }
-                    uiState.hasSearched && uiState.posts.isEmpty() -> {
-                        ErrorMessage(message = stringResource(R.string.no_results))
-                    }
-                    uiState.posts.isNotEmpty() -> {
-                        LazyColumn {
-                            items(
-                                items = uiState.posts,
-                                key = { it.id }
-                            ) { post ->
-                                PostCard(
-                                    post = post,
-                                    onClick = { onPostClick(post.sharedPost?.id ?: post.id) },
-                                    onProfileClick = onProfileClick,
-                                    onReplyClick = { onReplyClick(post.sharedPost?.id ?: post.id) },
-                                    onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
-                                    onReactionClick = null,
-                                    onExternalShareClick = {
-                                        val displayPost = post.sharedPost ?: post
-                                        val shareUrl = displayPost.url ?: displayPost.iri
-                                        if (shareUrl != null) {
-                                            val sendIntent = Intent().apply {
-                                                action = Intent.ACTION_SEND
-                                                putExtra(Intent.EXTRA_TEXT, shareUrl)
-                                                type = "text/plain"
-                                            }
-                                            context.startActivity(Intent.createChooser(sendIntent, null))
-                                        }
-                                    },
-                                    onQuotedPostClick = onPostClick
-                                )
-                                HorizontalDivider(
-                                    color = colors.divider,
-                                    thickness = 1.dp,
-                                    modifier = Modifier.padding(horizontal = 16.dp)
-                                )
+                    uiState.mode == SearchMode.PEOPLE -> {
+                        when {
+                            uiState.hasSearched && uiState.actors.isEmpty() -> {
+                                ErrorMessage(message = stringResource(R.string.no_results))
                             }
+                            uiState.actors.isNotEmpty() -> {
+                                LazyColumn {
+                                    items(
+                                        items = uiState.actors,
+                                        key = { it.id }
+                                    ) { actor ->
+                                        SearchActorRow(
+                                            actor = actor,
+                                            onClick = { onProfileClick(actor.handle) }
+                                        )
+                                        HorizontalDivider(
+                                            color = colors.divider,
+                                            thickness = 1.dp,
+                                            modifier = Modifier.padding(horizontal = 16.dp)
+                                        )
+                                    }
+                                }
+                            }
+                            else -> SearchHint()
                         }
                     }
                     else -> {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(32.dp)
-                        ) {
-                            Text(
-                                text = stringResource(R.string.search_hint),
-                                style = typography.bodyLarge,
-                                color = colors.textSecondary
-                            )
+                        when {
+                            uiState.hasSearched && uiState.posts.isEmpty() -> {
+                                ErrorMessage(message = stringResource(R.string.no_results))
+                            }
+                            uiState.posts.isNotEmpty() -> {
+                                LazyColumn {
+                                    items(
+                                        items = uiState.posts,
+                                        key = { it.id }
+                                    ) { post ->
+                                        PostCard(
+                                            post = post,
+                                            onClick = { onPostClick(post.sharedPost?.id ?: post.id) },
+                                            onProfileClick = onProfileClick,
+                                            onReplyClick = { onReplyClick(post.sharedPost?.id ?: post.id) },
+                                            onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
+                                            onReactionClick = null,
+                                            onExternalShareClick = {
+                                                val displayPost = post.sharedPost ?: post
+                                                val shareUrl = displayPost.url ?: displayPost.iri
+                                                if (shareUrl != null) {
+                                                    val sendIntent = Intent().apply {
+                                                        action = Intent.ACTION_SEND
+                                                        putExtra(Intent.EXTRA_TEXT, shareUrl)
+                                                        type = "text/plain"
+                                                    }
+                                                    context.startActivity(Intent.createChooser(sendIntent, null))
+                                                }
+                                            },
+                                            onQuotedPostClick = onPostClick
+                                        )
+                                        HorizontalDivider(
+                                            color = colors.divider,
+                                            thickness = 1.dp,
+                                            modifier = Modifier.padding(horizontal = 16.dp)
+                                        )
+                                    }
+                                }
+                            }
+                            else -> SearchHint()
                         }
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun SearchModeChips(
+    selected: SearchMode,
+    onSelect: (SearchMode) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        ModeChip(
+            label = stringResource(R.string.search_people),
+            isSelected = selected == SearchMode.PEOPLE,
+            onClick = { onSelect(SearchMode.PEOPLE) }
+        )
+        ModeChip(
+            label = stringResource(R.string.search_posts),
+            isSelected = selected == SearchMode.POSTS,
+            onClick = { onSelect(SearchMode.POSTS) }
+        )
+        ModeChip(
+            label = stringResource(R.string.search_tags),
+            isSelected = selected == SearchMode.TAGS,
+            onClick = { onSelect(SearchMode.TAGS) }
+        )
+    }
+}
+
+@Composable
+private fun ModeChip(
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    FilterChip(
+        selected = isSelected,
+        onClick = onClick,
+        label = { Text(label) },
+        colors = FilterChipDefaults.filterChipColors(
+            containerColor = colors.background,
+            labelColor = colors.textBody,
+            selectedContainerColor = colors.accent,
+            selectedLabelColor = colors.background
+        ),
+        border = FilterChipDefaults.filterChipBorder(
+            enabled = true,
+            selected = isSelected,
+            borderColor = colors.buttonOutline,
+            selectedBorderColor = colors.accent
+        )
+    )
+}
+
+@Composable
+private fun SearchActorRow(
+    actor: Actor,
+    onClick: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AsyncImage(
+            model = actor.avatarUrl,
+            contentDescription = actor.name,
+            modifier = Modifier
+                .size(48.dp)
+                .clip(CircleShape)
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            RichDisplayName(
+                name = actor.name,
+                fallback = actor.handle,
+                style = typography.bodyLargeSemiBold,
+                color = colors.textPrimary
+            )
+            Text(
+                text = actor.handle,
+                style = typography.labelSmall,
+                color = colors.textSecondary
+            )
+        }
+    }
+}
+
+@Composable
+private fun SearchHint() {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.search_hint),
+            style = typography.bodyLarge,
+            color = colors.textSecondary
+        )
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
@@ -111,7 +111,7 @@ fun SearchScreen(
                                 color = colors.surface,
                                 shape = RoundedCornerShape(AppShapes.searchBarRadius)
                             )
-                            .padding(horizontal = 12.dp, vertical = 12.dp),
+                            .padding(horizontal = 12.dp, vertical = 4.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Icon(
@@ -156,7 +156,7 @@ fun SearchScreen(
                 onSelect = { viewModel.setMode(it) },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .padding(horizontal = 16.dp, vertical = 4.dp)
             )
 
             Box(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/search/SearchViewModel.kt
@@ -14,11 +14,11 @@ import pub.hackers.android.domain.model.Actor
 import pub.hackers.android.domain.model.Post
 import javax.inject.Inject
 
-enum class SearchMode { PEOPLE, POSTS, TAGS }
+enum class SearchMode { ALL, PEOPLE, POSTS, TAGS }
 
 data class SearchUiState(
     val query: String = "",
-    val mode: SearchMode = SearchMode.POSTS,
+    val mode: SearchMode = SearchMode.ALL,
     val actors: List<Actor> = emptyList(),
     val posts: List<Post> = emptyList(),
     val isLoading: Boolean = false,
@@ -84,6 +84,20 @@ class SearchViewModel @Inject constructor(
                 }
 
             when (mode) {
+                SearchMode.ALL -> {
+                    val handleQuery = rawQuery.removePrefix("@")
+                    repository.searchActorsByHandle(handleQuery, limit = 5)
+                        .onSuccess { actors ->
+                            _uiState.update { it.copy(actors = actors) }
+                        }
+                    repository.searchPosts(rawQuery)
+                        .onSuccess { posts ->
+                            _uiState.update { it.copy(posts = posts, isLoading = false) }
+                        }
+                        .onFailure { error ->
+                            _uiState.update { it.copy(error = error.message, isLoading = false) }
+                        }
+                }
                 SearchMode.PEOPLE -> {
                     val handleQuery = rawQuery.removePrefix("@")
                     repository.searchActorsByHandle(handleQuery, limit = 30)

--- a/app/src/main/java/pub/hackers/android/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/search/SearchViewModel.kt
@@ -1,5 +1,6 @@
 package pub.hackers.android.ui.screens.search
 
+import android.os.LocaleList
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -76,11 +77,12 @@ class SearchViewModel @Inject constructor(
 
             val handleQuery = rawQuery.removePrefix("@")
             val tagQuery = if (rawQuery.startsWith("#")) rawQuery else "#$rawQuery"
+            val languages = systemLanguageTags()
 
             val objectDeferred = async { repository.searchObject(rawQuery) }
             val actorsDeferred = async { repository.searchActorsByHandle(handleQuery, limit = 30) }
-            val postsDeferred = async { repository.searchPosts(rawQuery) }
-            val tagsDeferred = async { repository.searchPosts(tagQuery) }
+            val postsDeferred = async { repository.searchPosts(rawQuery, languages) }
+            val tagsDeferred = async { repository.searchPosts(tagQuery, languages) }
 
             val objectResult = objectDeferred.await()
             val actorsResult = actorsDeferred.await()
@@ -135,5 +137,14 @@ class SearchViewModel @Inject constructor(
     fun selectRecentSearch(query: String) {
         _uiState.update { it.copy(query = query) }
         search()
+    }
+
+    private fun systemLanguageTags(): List<String> {
+        val locales = LocaleList.getDefault()
+        val tags = (0 until locales.size())
+            .map { locales[it].language }
+            .filter { it.isNotBlank() }
+            .distinct()
+        return tags.ifEmpty { listOf("en") }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/search/SearchViewModel.kt
@@ -14,8 +14,11 @@ import pub.hackers.android.domain.model.Actor
 import pub.hackers.android.domain.model.Post
 import javax.inject.Inject
 
+enum class SearchMode { PEOPLE, POSTS, TAGS }
+
 data class SearchUiState(
     val query: String = "",
+    val mode: SearchMode = SearchMode.POSTS,
     val actors: List<Actor> = emptyList(),
     val posts: List<Post> = emptyList(),
     val isLoading: Boolean = false,
@@ -46,56 +49,66 @@ class SearchViewModel @Inject constructor(
         _uiState.update { it.copy(query = query) }
     }
 
+    fun setMode(mode: SearchMode) {
+        if (_uiState.value.mode == mode) return
+        _uiState.update { it.copy(mode = mode) }
+        if (_uiState.value.hasSearched && _uiState.value.query.isNotBlank()) {
+            search()
+        }
+    }
+
     fun search() {
-        val query = _uiState.value.query.trim()
-        if (query.isEmpty()) return
+        val rawQuery = _uiState.value.query.trim()
+        if (rawQuery.isEmpty()) return
+        val mode = _uiState.value.mode
 
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, error = null, hasSearched = true, resolvedObjectUrl = null, actors = emptyList()) }
+            _uiState.update {
+                it.copy(
+                    isLoading = true,
+                    error = null,
+                    hasSearched = true,
+                    resolvedObjectUrl = null,
+                    actors = emptyList(),
+                    posts = emptyList()
+                )
+            }
 
-            // Save to recent searches
-            preferencesManager.addRecentSearch(query)
+            preferencesManager.addRecentSearch(rawQuery)
 
-            // Try searchObject first for URL/handle resolution
-            repository.searchObject(query)
+            repository.searchObject(rawQuery)
                 .onSuccess { url ->
                     if (url != null) {
                         _uiState.update { it.copy(resolvedObjectUrl = url) }
                     }
                 }
 
-            // Search actors if query looks like a handle
-            if (query.startsWith("@") || query.contains("@")) {
-                val handleQuery = query.removePrefix("@")
-                repository.searchActorsByHandle(handleQuery, limit = 5)
-                    .onSuccess { actors ->
-                        _uiState.update { it.copy(actors = actors) }
+            when (mode) {
+                SearchMode.PEOPLE -> {
+                    val handleQuery = rawQuery.removePrefix("@")
+                    repository.searchActorsByHandle(handleQuery, limit = 30)
+                        .onSuccess { actors ->
+                            _uiState.update { it.copy(actors = actors, isLoading = false) }
+                        }
+                        .onFailure { error ->
+                            _uiState.update { it.copy(error = error.message, isLoading = false) }
+                        }
+                }
+                SearchMode.POSTS, SearchMode.TAGS -> {
+                    val postQuery = if (mode == SearchMode.TAGS && !rawQuery.startsWith("#")) {
+                        "#$rawQuery"
+                    } else {
+                        rawQuery
                     }
+                    repository.searchPosts(postQuery)
+                        .onSuccess { posts ->
+                            _uiState.update { it.copy(posts = posts, isLoading = false) }
+                        }
+                        .onFailure { error ->
+                            _uiState.update { it.copy(error = error.message, isLoading = false) }
+                        }
+                }
             }
-
-            // Always search posts too
-            repository.searchPosts(query)
-                .onSuccess { posts ->
-                    // Deduplicate: remove actors whose IDs appear in post authors
-                    val postActorIds = posts.map { it.actor.id }.toSet()
-                    val dedupedActors = _uiState.value.actors.filter { it.id !in postActorIds }
-
-                    _uiState.update {
-                        it.copy(
-                            posts = posts,
-                            actors = dedupedActors,
-                            isLoading = false
-                        )
-                    }
-                }
-                .onFailure { error ->
-                    _uiState.update {
-                        it.copy(
-                            error = error.message,
-                            isLoading = false
-                        )
-                    }
-                }
         }
     }
 
@@ -105,7 +118,7 @@ class SearchViewModel @Inject constructor(
 
     fun clearSearch() {
         _uiState.update {
-            SearchUiState(recentSearches = it.recentSearches)
+            SearchUiState(recentSearches = it.recentSearches, mode = it.mode)
         }
     }
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/search/SearchViewModel.kt
@@ -3,6 +3,7 @@ package pub.hackers.android.ui.screens.search
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,6 +22,7 @@ data class SearchUiState(
     val mode: SearchMode = SearchMode.ALL,
     val actors: List<Actor> = emptyList(),
     val posts: List<Post> = emptyList(),
+    val taggedPosts: List<Post> = emptyList(),
     val isLoading: Boolean = false,
     val hasSearched: Boolean = false,
     val error: String? = null,
@@ -50,17 +52,12 @@ class SearchViewModel @Inject constructor(
     }
 
     fun setMode(mode: SearchMode) {
-        if (_uiState.value.mode == mode) return
         _uiState.update { it.copy(mode = mode) }
-        if (_uiState.value.hasSearched && _uiState.value.query.isNotBlank()) {
-            search()
-        }
     }
 
     fun search() {
         val rawQuery = _uiState.value.query.trim()
         if (rawQuery.isEmpty()) return
-        val mode = _uiState.value.mode
 
         viewModelScope.launch {
             _uiState.update {
@@ -70,58 +67,45 @@ class SearchViewModel @Inject constructor(
                     hasSearched = true,
                     resolvedObjectUrl = null,
                     actors = emptyList(),
-                    posts = emptyList()
+                    posts = emptyList(),
+                    taggedPosts = emptyList()
                 )
             }
 
             preferencesManager.addRecentSearch(rawQuery)
 
-            repository.searchObject(rawQuery)
-                .onSuccess { url ->
-                    if (url != null) {
-                        _uiState.update { it.copy(resolvedObjectUrl = url) }
-                    }
-                }
+            val handleQuery = rawQuery.removePrefix("@")
+            val tagQuery = if (rawQuery.startsWith("#")) rawQuery else "#$rawQuery"
 
-            when (mode) {
-                SearchMode.ALL -> {
-                    val handleQuery = rawQuery.removePrefix("@")
-                    repository.searchActorsByHandle(handleQuery, limit = 5)
-                        .onSuccess { actors ->
-                            _uiState.update { it.copy(actors = actors) }
-                        }
-                    repository.searchPosts(rawQuery)
-                        .onSuccess { posts ->
-                            _uiState.update { it.copy(posts = posts, isLoading = false) }
-                        }
-                        .onFailure { error ->
-                            _uiState.update { it.copy(error = error.message, isLoading = false) }
-                        }
-                }
-                SearchMode.PEOPLE -> {
-                    val handleQuery = rawQuery.removePrefix("@")
-                    repository.searchActorsByHandle(handleQuery, limit = 30)
-                        .onSuccess { actors ->
-                            _uiState.update { it.copy(actors = actors, isLoading = false) }
-                        }
-                        .onFailure { error ->
-                            _uiState.update { it.copy(error = error.message, isLoading = false) }
-                        }
-                }
-                SearchMode.POSTS, SearchMode.TAGS -> {
-                    val postQuery = if (mode == SearchMode.TAGS && !rawQuery.startsWith("#")) {
-                        "#$rawQuery"
-                    } else {
-                        rawQuery
-                    }
-                    repository.searchPosts(postQuery)
-                        .onSuccess { posts ->
-                            _uiState.update { it.copy(posts = posts, isLoading = false) }
-                        }
-                        .onFailure { error ->
-                            _uiState.update { it.copy(error = error.message, isLoading = false) }
-                        }
-                }
+            val objectDeferred = async { repository.searchObject(rawQuery) }
+            val actorsDeferred = async { repository.searchActorsByHandle(handleQuery, limit = 30) }
+            val postsDeferred = async { repository.searchPosts(rawQuery) }
+            val tagsDeferred = async { repository.searchPosts(tagQuery) }
+
+            val objectResult = objectDeferred.await()
+            val actorsResult = actorsDeferred.await()
+            val postsResult = postsDeferred.await()
+            val tagsResult = tagsDeferred.await()
+
+            val resolvedUrl = objectResult.getOrNull()
+            val actors = actorsResult.getOrDefault(emptyList())
+            val posts = postsResult.getOrDefault(emptyList())
+            val taggedPosts = tagsResult.getOrDefault(emptyList())
+
+            val anySuccess =
+                actorsResult.isSuccess || postsResult.isSuccess || tagsResult.isSuccess
+            val firstError = listOf(actorsResult, postsResult, tagsResult)
+                .firstNotNullOfOrNull { it.exceptionOrNull() }
+
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    resolvedObjectUrl = resolvedUrl,
+                    actors = actors,
+                    posts = posts,
+                    taggedPosts = taggedPosts,
+                    error = if (!anySuccess) firstError?.message else null
+                )
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,7 @@
     <string name="search_users">Users</string>
     <string name="search_people">People</string>
     <string name="search_tags">Tags</string>
+    <string name="search_all">All</string>
     <string name="search_accounts">Accounts</string>
     <string name="search_recent">Recent Searches</string>
     <string name="search_clear_recent">Clear</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,8 @@
     <string name="search_hint">Search posts or users</string>
     <string name="search_posts">Posts</string>
     <string name="search_users">Users</string>
+    <string name="search_people">People</string>
+    <string name="search_tags">Tags</string>
     <string name="search_accounts">Accounts</string>
     <string name="search_recent">Recent Searches</string>
     <string name="search_clear_recent">Clear</string>


### PR DESCRIPTION
## Summary

Six commits on `fix/search-ux` overhaul the search screen. The clear-button slot is reserved so the input row no longer grows on first keystroke; vertical padding is tightened across the header stack. Results now branch through `All / People / Posts / Tags` filter chips, with `All` rendering dedicated `People` and `Posts` sections. Search fans out actors, keyword posts, and hashtag posts concurrently on Enter and caches each bucket, so chip switching is instant. Finally, `searchPost` now sends the user's system locales — without them the server silently filters everything out for authed users.

---
Assisted-By: Claude Code(claude-opus-4-7)