### PR TITLE
Apply Ubuntu Mono to code blocks in post cards

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/components/CodeBlockView.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/CodeBlockView.kt
@@ -18,8 +18,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
@@ -27,7 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import pub.hackers.android.R
+import pub.hackers.android.ui.theme.UbuntuMonoFontFamily
 
 private val SPAN_REGEX = Regex("""<span([^>]*)>([\s\S]*?)</span>""")
 private val STYLE_ATTR_REGEX = Regex("""style=["']([^"']*)["']""")
@@ -49,13 +47,6 @@ private data class CodeCacheKey(
 )
 
 private val codeCache = LruCache<CodeCacheKey, AnnotatedString>(CODE_CACHE_MAX_ENTRIES)
-
-private val UbuntuMonoFontFamily = FontFamily(
-    Font(R.font.ubuntu_mono_regular, FontWeight.Normal),
-    Font(R.font.ubuntu_mono_bold, FontWeight.Bold),
-    Font(R.font.ubuntu_mono_italic, FontWeight.Normal, FontStyle.Italic),
-    Font(R.font.ubuntu_mono_bold_italic, FontWeight.Bold, FontStyle.Italic),
-)
 
 private fun parseAndCacheCode(
     key: CodeCacheKey,

--- a/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.text.ParagraphStyle
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.BaselineShift
@@ -37,6 +36,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import pub.hackers.android.ui.theme.LocalAppColors
 import pub.hackers.android.ui.theme.LocalAppTypography
+import pub.hackers.android.ui.theme.UbuntuMonoFontFamily
 import java.net.URI
 
 val LocalFontScale = compositionLocalOf { 1f }
@@ -575,7 +575,7 @@ internal fun parseHtmlToAnnotatedString(
                             if (hasContent) append("\n\n")
                             preDepth++
                             pushStyle(SpanStyle(
-                                fontFamily = FontFamily.Monospace,
+                                fontFamily = UbuntuMonoFontFamily,
                                 background = codeBg,
                                 fontSize = 0.875.em
                             ))
@@ -587,7 +587,7 @@ internal fun parseHtmlToAnnotatedString(
                             if (preDepth == 0) {
                                 // Only style inline <code>, not <pre><code>
                                 pushStyle(SpanStyle(
-                                    fontFamily = FontFamily.Monospace,
+                                    fontFamily = UbuntuMonoFontFamily,
                                     background = codeBg,
                                     fontSize = 0.875.em
                                 ))

--- a/app/src/main/java/pub/hackers/android/ui/theme/Fonts.kt
+++ b/app/src/main/java/pub/hackers/android/ui/theme/Fonts.kt
@@ -1,0 +1,14 @@
+package pub.hackers.android.ui.theme
+
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import pub.hackers.android.R
+
+val UbuntuMonoFontFamily = FontFamily(
+    Font(R.font.ubuntu_mono_regular, FontWeight.Normal),
+    Font(R.font.ubuntu_mono_bold, FontWeight.Bold),
+    Font(R.font.ubuntu_mono_italic, FontWeight.Normal, FontStyle.Italic),
+    Font(R.font.ubuntu_mono_bold_italic, FontWeight.Bold, FontStyle.Italic),
+)


### PR DESCRIPTION
## Summary
Post-card previews rendered code through `parseHtmlToAnnotatedString`'s flat path, which was still falling back to the generic `FontFamily.Monospace` while `CodeBlockView` already used Ubuntu Mono. Extract `UbuntuMonoFontFamily` into `ui/theme/Fonts.kt` and reuse it for `<pre>` and inline `<code>` in `HtmlContent` so timelines and other preview surfaces match the article/detail typography.

---
Assisted-By: Claude Code(claude-opus-4-7)