### PR TITLE
Add table of contents to article detail

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -432,6 +432,11 @@ query PostDetail($id: ID!, $repliesAfter: String) {
                 }
             }
         }
+        ... on Article {
+            contents {
+                toc
+            }
+        }
     }
 }
 

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -226,6 +226,12 @@ class HackersPubRepository @Inject constructor(
                         visibility = node.visibility.toPostVisibility()
                     )
 
+                    val toc = response.data?.node?.onArticle?.contents
+                        ?.firstOrNull()
+                        ?.toc
+                        ?.let { parseTocJson(it) }
+                        ?: emptyList()
+
                     val reactionGroups = node.reactionGroups.mapNotNull { group ->
                         when {
                             group.onEmojiReactionGroup != null -> ReactionGroup(
@@ -264,7 +270,8 @@ class HackersPubRepository @Inject constructor(
                             reactionGroups = reactionGroups,
                             replies = replies,
                             hasMoreReplies = node.replies.pageInfo.hasNextPage,
-                            repliesEndCursor = node.replies.pageInfo.endCursor
+                            repliesEndCursor = node.replies.pageInfo.endCursor,
+                            toc = toc,
                         )
                     )
                 }
@@ -1598,4 +1605,5 @@ class HackersPubRepository @Inject constructor(
             else -> value
         }
     }
+
 }

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -244,7 +244,16 @@ data class PostDetailResult(
     val reactionGroups: List<ReactionGroup>,
     val replies: List<Post>,
     val hasMoreReplies: Boolean,
-    val repliesEndCursor: String?
+    val repliesEndCursor: String?,
+    val toc: List<TocItem> = emptyList(),
+)
+
+@Immutable
+data class TocItem(
+    val id: String,
+    val level: Int,
+    val title: String,
+    val children: List<TocItem>,
 )
 
 @Immutable

--- a/app/src/main/java/pub/hackers/android/domain/model/TocParser.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/TocParser.kt
@@ -1,0 +1,20 @@
+package pub.hackers.android.domain.model
+
+private const val MAX_TOC_DEPTH = 16
+
+fun parseTocJson(value: Any?): List<TocItem> = parseTocJson(value, depth = 0)
+
+private fun parseTocJson(value: Any?, depth: Int): List<TocItem> {
+    if (depth >= MAX_TOC_DEPTH) return emptyList()
+    val list = value as? List<*> ?: return emptyList()
+    return list.mapNotNull { parseTocItem(it, depth) }
+}
+
+private fun parseTocItem(value: Any?, depth: Int): TocItem? {
+    val map = value as? Map<*, *> ?: return null
+    val id = map["id"] as? String ?: return null
+    val title = map["title"] as? String ?: return null
+    val level = (map["level"] as? Number)?.toInt() ?: return null
+    val children = parseTocJson(map["children"], depth + 1)
+    return TocItem(id = id, level = level, title = title, children = children)
+}

--- a/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
@@ -2,16 +2,17 @@ package pub.hackers.android.ui.components
 
 import android.util.LruCache
 import androidx.annotation.VisibleForTesting
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.relocation.BringIntoViewRequester
-import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.Text
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
@@ -212,7 +213,7 @@ fun HtmlContent(
     onMentionClick: ((handle: String) -> Unit)? = null,
     onLinkClick: ((url: String) -> Unit)? = null,
     onTextClick: (() -> Unit)? = null,
-    headingAnchor: ((id: String) -> BringIntoViewRequester?)? = null,
+    onHeadingPositioned: ((id: String, coordinates: LayoutCoordinates) -> Unit)? = null,
 ) {
     val uriHandler = LocalUriHandler.current
     val colors = LocalAppColors.current
@@ -254,7 +255,7 @@ fun HtmlContent(
         )
     } else {
         // Full mode: block-based rendering with syntax-highlighted code blocks
-        val splitHeadings = headingAnchor != null
+        val splitHeadings = onHeadingPositioned != null
         val blocks = remember(normalizedHtml, splitHeadings) {
             splitIntoBlocks(normalizedHtml, splitHeadings = splitHeadings)
         }
@@ -330,21 +331,26 @@ fun HtmlContent(
                                 fontWeight = FontWeight.Bold,
                             )
                         }
-                        val requester = block.anchorId?.let { id -> headingAnchor?.invoke(id) }
-                        val headingModifier = if (requester != null) {
-                            Modifier.bringIntoViewRequester(requester)
-                        } else {
-                            Modifier
-                        }
-                        if (headingAnnotated.isNotEmpty()) {
-                            ClickableText(
-                                text = headingAnnotated,
-                                style = headingStyle,
-                                modifier = headingModifier,
-                                onClick = { offset ->
-                                    handleClick(headingAnnotated, offset, uriHandler, onMentionClick, onLinkClick, onTextClick)
-                                }
-                            )
+                        val anchorId = block.anchorId
+                        val wrapperModifier = Modifier
+                            .fillMaxWidth()
+                            .let { base ->
+                                if (anchorId != null && onHeadingPositioned != null) {
+                                    base.onGloballyPositioned { coords ->
+                                        onHeadingPositioned(anchorId, coords)
+                                    }
+                                } else base
+                            }
+                        Box(modifier = wrapperModifier) {
+                            if (headingAnnotated.isNotEmpty()) {
+                                ClickableText(
+                                    text = headingAnnotated,
+                                    style = headingStyle,
+                                    onClick = { offset ->
+                                        handleClick(headingAnnotated, offset, uriHandler, onMentionClick, onLinkClick, onTextClick)
+                                    }
+                                )
+                            }
                         }
                     }
                 }
@@ -506,7 +512,9 @@ private fun extractHeadingBlocks(html: String): List<ContentBlock> {
         val level = match.groupValues[1].toInt()
         val attrs = match.groupValues[2]
         val inner = match.groupValues[3]
-        val anchorId = parseAttributes(attrs)["id"]
+        // Server prefixes heading anchors with "{docId}--{slug}" but the TOC
+        // JSON only returns the bare slug, so strip the prefix to match.
+        val anchorId = parseAttributes(attrs)["id"]?.substringAfter("--")
         out.add(ContentBlock.Heading(level = level, anchorId = anchorId, innerHtml = inner))
         cursor = match.range.last + 1
     }

--- a/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -56,6 +58,7 @@ internal sealed class ContentBlock {
     data class Text(val html: String) : ContentBlock()
     data class Code(val codeHtml: String) : ContentBlock()
     data class List(val html: String) : ContentBlock()
+    data class Heading(val level: Int, val anchorId: String?, val innerHtml: String) : ContentBlock()
 }
 
 @VisibleForTesting
@@ -74,6 +77,10 @@ private val TAG_REGEX = Regex("""<(/?)(\w+)([^>]*)>""")
 private val ATTR_REGEX = Regex("""([\w-]+)=["']([^"']*)["']""")
 private val PRE_CODE_REGEX = Regex(
     """<pre[^>]*>\s*<code[^>]*>([\s\S]*?)</code>\s*</pre>""",
+    RegexOption.IGNORE_CASE
+)
+private val HEADING_REGEX = Regex(
+    """<h([1-6])([^>]*)>([\s\S]*?)</h\1>""",
     RegexOption.IGNORE_CASE
 )
 private val EMPTY_PARAGRAPH_REGEX = Regex(
@@ -204,7 +211,8 @@ fun HtmlContent(
     contentStyle: HtmlContentStyle = HtmlContentStyle.Compact,
     onMentionClick: ((handle: String) -> Unit)? = null,
     onLinkClick: ((url: String) -> Unit)? = null,
-    onTextClick: (() -> Unit)? = null
+    onTextClick: (() -> Unit)? = null,
+    headingAnchor: ((id: String) -> BringIntoViewRequester?)? = null,
 ) {
     val uriHandler = LocalUriHandler.current
     val colors = LocalAppColors.current
@@ -246,7 +254,10 @@ fun HtmlContent(
         )
     } else {
         // Full mode: block-based rendering with syntax-highlighted code blocks
-        val blocks = remember(normalizedHtml) { splitIntoBlocks(normalizedHtml) }
+        val splitHeadings = headingAnchor != null
+        val blocks = remember(normalizedHtml, splitHeadings) {
+            splitIntoBlocks(normalizedHtml, splitHeadings = splitHeadings)
+        }
 
         Column(modifier = modifier) {
             blocks.forEachIndexed { index, block ->
@@ -298,6 +309,43 @@ fun HtmlContent(
                         CodeBlockView(
                             codeHtml = block.codeHtml
                         )
+                    }
+                    is ContentBlock.Heading -> {
+                        val headingAnnotated = rememberParsedHtml(
+                            block.innerHtml,
+                            linkColor,
+                            hashtagColor,
+                            mentionBg,
+                            codeBg,
+                            contentStyle,
+                        )
+                        val headingStyle = remember(bodyStyle, block.level) {
+                            bodyStyle.copy(
+                                fontSize = bodyStyle.fontSize * when (block.level) {
+                                    1 -> 1.5f
+                                    2 -> 1.3f
+                                    3 -> 1.15f
+                                    else -> 1.0f
+                                },
+                                fontWeight = FontWeight.Bold,
+                            )
+                        }
+                        val requester = block.anchorId?.let { id -> headingAnchor?.invoke(id) }
+                        val headingModifier = if (requester != null) {
+                            Modifier.bringIntoViewRequester(requester)
+                        } else {
+                            Modifier
+                        }
+                        if (headingAnnotated.isNotEmpty()) {
+                            ClickableText(
+                                text = headingAnnotated,
+                                style = headingStyle,
+                                modifier = headingModifier,
+                                onClick = { offset ->
+                                    handleClick(headingAnnotated, offset, uriHandler, onMentionClick, onLinkClick, onTextClick)
+                                }
+                            )
+                        }
                     }
                 }
             }
@@ -413,7 +461,7 @@ private fun handleClick(
 }
 
 @VisibleForTesting
-internal fun splitIntoBlocks(html: String): List<ContentBlock> {
+internal fun splitIntoBlocks(html: String, splitHeadings: Boolean = false): List<ContentBlock> {
     val blocks = mutableListOf<ContentBlock>()
     var lastEnd = 0
     val source = html.trim()
@@ -440,7 +488,34 @@ internal fun splitIntoBlocks(html: String): List<ContentBlock> {
         blocks.addAll(splitTextAndListBlocks(source))
     }
 
-    return blocks
+    if (!splitHeadings) return blocks
+
+    return blocks.flatMap { block ->
+        if (block is ContentBlock.Text) extractHeadingBlocks(block.html) else listOf(block)
+    }
+}
+
+private fun extractHeadingBlocks(html: String): List<ContentBlock> {
+    val out = mutableListOf<ContentBlock>()
+    var cursor = 0
+    for (match in HEADING_REGEX.findAll(html)) {
+        if (match.range.first > cursor) {
+            val before = html.substring(cursor, match.range.first)
+            if (before.isNotBlank()) out.add(ContentBlock.Text(before))
+        }
+        val level = match.groupValues[1].toInt()
+        val attrs = match.groupValues[2]
+        val inner = match.groupValues[3]
+        val anchorId = parseAttributes(attrs)["id"]
+        out.add(ContentBlock.Heading(level = level, anchorId = anchorId, innerHtml = inner))
+        cursor = match.range.last + 1
+    }
+    if (cursor < html.length) {
+        val tail = html.substring(cursor)
+        if (tail.isNotBlank()) out.add(ContentBlock.Text(tail))
+    }
+    if (out.isEmpty()) out.add(ContentBlock.Text(html))
+    return out
 }
 
 @VisibleForTesting
@@ -1114,5 +1189,7 @@ private fun blockSpacing(previous: ContentBlock, current: ContentBlock) = when {
     previous is ContentBlock.Code || current is ContentBlock.Code -> 8.dp
     previous is ContentBlock.List && current is ContentBlock.List -> 4.dp
     previous is ContentBlock.List || current is ContentBlock.List -> 16.dp
+    current is ContentBlock.Heading -> 16.dp
+    previous is ContentBlock.Heading -> 8.dp
     else -> 0.dp
 }

--- a/app/src/main/java/pub/hackers/android/ui/components/TocPanel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/TocPanel.kt
@@ -43,7 +43,6 @@ fun TocPanel(
     val typography = LocalAppTypography.current
 
     var expanded by remember { mutableStateOf(false) }
-    val baseLevel = remember(items) { items.minOf { it.level } }
 
     Column(
         modifier = modifier
@@ -76,17 +75,29 @@ fun TocPanel(
         }
 
         AnimatedVisibility(visible = expanded) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 4.dp)
-            ) {
-                items.forEach { item ->
-                    TocEntry(item = item, baseLevel = baseLevel, onClick = onAnchorClick)
-                }
-                Spacer(modifier = Modifier.height(4.dp))
-            }
+            TocList(
+                items = items,
+                onAnchorClick = onAnchorClick,
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+            )
         }
+    }
+}
+
+@Composable
+fun TocList(
+    items: List<TocItem>,
+    onAnchorClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (items.isEmpty()) return
+    val baseLevel = remember(items) { items.minOf { it.level } }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        items.forEach { item ->
+            TocEntry(item = item, baseLevel = baseLevel, onClick = onAnchorClick)
+        }
+        Spacer(modifier = Modifier.height(4.dp))
     }
 }
 

--- a/app/src/main/java/pub/hackers/android/ui/components/TocPanel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/TocPanel.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
@@ -21,14 +20,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.launch
 import pub.hackers.android.R
 import pub.hackers.android.domain.model.TocItem
 import pub.hackers.android.ui.theme.LocalAppColors
@@ -37,14 +34,13 @@ import pub.hackers.android.ui.theme.LocalAppTypography
 @Composable
 fun TocPanel(
     items: List<TocItem>,
-    anchorRequester: (String) -> BringIntoViewRequester,
+    onAnchorClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (items.isEmpty()) return
 
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
-    val scope = rememberCoroutineScope()
 
     var expanded by remember { mutableStateOf(false) }
     val baseLevel = remember(items) { items.minOf { it.level } }
@@ -86,15 +82,7 @@ fun TocPanel(
                     .padding(horizontal = 12.dp, vertical = 4.dp)
             ) {
                 items.forEach { item ->
-                    TocEntry(
-                        item = item,
-                        baseLevel = baseLevel,
-                        onClick = { id ->
-                            scope.launch {
-                                anchorRequester(id).bringIntoView()
-                            }
-                        }
-                    )
+                    TocEntry(item = item, baseLevel = baseLevel, onClick = onAnchorClick)
                 }
                 Spacer(modifier = Modifier.height(4.dp))
             }

--- a/app/src/main/java/pub/hackers/android/ui/components/TocPanel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/TocPanel.kt
@@ -1,0 +1,130 @@
+package pub.hackers.android.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import pub.hackers.android.R
+import pub.hackers.android.domain.model.TocItem
+import pub.hackers.android.ui.theme.LocalAppColors
+import pub.hackers.android.ui.theme.LocalAppTypography
+
+@Composable
+fun TocPanel(
+    items: List<TocItem>,
+    anchorRequester: (String) -> BringIntoViewRequester,
+    modifier: Modifier = Modifier,
+) {
+    if (items.isEmpty()) return
+
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+    val scope = rememberCoroutineScope()
+
+    var expanded by remember { mutableStateOf(false) }
+    val baseLevel = remember(items) { items.minOf { it.level } }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .border(
+                width = 1.dp,
+                color = colors.divider,
+                shape = RoundedCornerShape(8.dp),
+            )
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { expanded = !expanded }
+                .padding(horizontal = 12.dp, vertical = 10.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.table_of_contents),
+                style = typography.bodyLargeSemiBold,
+                color = colors.textPrimary,
+                modifier = Modifier.weight(1f),
+            )
+            Icon(
+                imageVector = if (expanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                contentDescription = null,
+                tint = colors.textSecondary,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+
+        AnimatedVisibility(visible = expanded) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 4.dp)
+            ) {
+                items.forEach { item ->
+                    TocEntry(
+                        item = item,
+                        baseLevel = baseLevel,
+                        onClick = { id ->
+                            scope.launch {
+                                anchorRequester(id).bringIntoView()
+                            }
+                        }
+                    )
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun TocEntry(
+    item: TocItem,
+    baseLevel: Int,
+    onClick: (String) -> Unit,
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+    val indent = ((item.level - baseLevel).coerceAtLeast(0) * 12).dp
+
+    Text(
+        text = item.title,
+        style = typography.bodyMedium.copy(
+            color = colors.accent,
+            fontWeight = if (item.level <= baseLevel) FontWeight.SemiBold else FontWeight.Normal,
+        ),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick(item.id) }
+            .padding(start = indent, top = 6.dp, bottom = 6.dp),
+    )
+
+    item.children.forEach { child ->
+        TocEntry(item = child, baseLevel = baseLevel, onClick = onClick)
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/components/TocPanel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/TocPanel.kt
@@ -1,6 +1,7 @@
 package pub.hackers.android.ui.components
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -23,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -36,6 +38,7 @@ fun TocPanel(
     items: List<TocItem>,
     onAnchorClick: (String) -> Unit,
     modifier: Modifier = Modifier,
+    activeId: String? = null,
 ) {
     if (items.isEmpty()) return
 
@@ -79,6 +82,7 @@ fun TocPanel(
                 items = items,
                 onAnchorClick = onAnchorClick,
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                activeId = activeId,
             )
         }
     }
@@ -89,13 +93,14 @@ fun TocList(
     items: List<TocItem>,
     onAnchorClick: (String) -> Unit,
     modifier: Modifier = Modifier,
+    activeId: String? = null,
 ) {
     if (items.isEmpty()) return
     val baseLevel = remember(items) { items.minOf { it.level } }
 
     Column(modifier = modifier.fillMaxWidth()) {
         items.forEach { item ->
-            TocEntry(item = item, baseLevel = baseLevel, onClick = onAnchorClick)
+            TocEntry(item = item, baseLevel = baseLevel, activeId = activeId, onClick = onAnchorClick)
         }
         Spacer(modifier = Modifier.height(4.dp))
     }
@@ -105,25 +110,32 @@ fun TocList(
 private fun TocEntry(
     item: TocItem,
     baseLevel: Int,
+    activeId: String?,
     onClick: (String) -> Unit,
 ) {
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
     val indent = ((item.level - baseLevel).coerceAtLeast(0) * 12).dp
+    val isActive = item.id == activeId
 
     Text(
         text = item.title,
         style = typography.bodyMedium.copy(
-            color = colors.accent,
-            fontWeight = if (item.level <= baseLevel) FontWeight.SemiBold else FontWeight.Normal,
+            color = if (isActive) colors.accent else colors.textBody,
+            fontWeight = when {
+                isActive -> FontWeight.Bold
+                item.level <= baseLevel -> FontWeight.SemiBold
+                else -> FontWeight.Normal
+            },
         ),
         modifier = Modifier
             .fillMaxWidth()
             .clickable { onClick(item.id) }
-            .padding(start = indent, top = 6.dp, bottom = 6.dp),
+            .background(if (isActive) colors.accent.copy(alpha = 0.10f) else Color.Transparent)
+            .padding(start = indent + 4.dp, end = 4.dp, top = 6.dp, bottom = 6.dp),
     )
 
     item.children.forEach { child ->
-        TocEntry(item = child, baseLevel = baseLevel, onClick = onClick)
+        TocEntry(item = child, baseLevel = baseLevel, activeId = activeId, onClick = onClick)
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -70,6 +70,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -173,6 +175,23 @@ fun PostDetailScreen(
     }
     val tocAvailable = uiState.post?.typename == "Article" && uiState.toc.isNotEmpty()
 
+    var activeHeadingId by remember(postId) { mutableStateOf<String?>(null) }
+    LaunchedEffect(lazyListState, postId) {
+        snapshotFlow {
+            lazyListState.firstVisibleItemIndex to lazyListState.firstVisibleItemScrollOffset
+        }.collect { (firstIdx, scrollOffset) ->
+            val body = bodyItemCoords
+            val offsets = if (body != null && body.isAttached) {
+                headingCoords.entries.mapNotNull { (id, coords) ->
+                    if (!coords.isAttached) null
+                    else id to body.localPositionOf(coords, Offset.Zero).y
+                }.toMap()
+            } else emptyMap()
+            val active = computeActiveHeadingId(offsets, firstIdx, scrollOffset)
+            if (active != activeHeadingId) activeHeadingId = active
+        }
+    }
+
     // Navigate back after successful deletion
     LaunchedEffect(uiState.isDeleted) {
         if (uiState.isDeleted) {
@@ -212,6 +231,7 @@ fun PostDetailScreen(
                         showTocSheet = false
                         onAnchorClick(id)
                     },
+                    activeId = activeHeadingId,
                 )
             }
         }
@@ -444,6 +464,7 @@ fun PostDetailScreen(
                         headingCoords = headingCoords,
                         onBodyPositioned = { bodyItemCoords = it },
                         onAnchorClick = onAnchorClick,
+                        activeHeadingId = activeHeadingId,
                         onProfileClick = onProfileClick,
                         onPostClick = onPostClick,
                         onReplyClick = { onReplyClick(postId) },
@@ -539,6 +560,7 @@ internal fun PostDetailContent(
     headingCoords: MutableMap<String, LayoutCoordinates> = remember(post.id) { mutableMapOf() },
     onBodyPositioned: (LayoutCoordinates) -> Unit = {},
     onAnchorClick: (String) -> Unit = {},
+    activeHeadingId: String? = null,
     onProfileClick: (String) -> Unit,
     onPostClick: (String) -> Unit,
     onShareClick: () -> Unit,
@@ -675,6 +697,7 @@ internal fun PostDetailContent(
                     TocPanel(
                         items = toc,
                         onAnchorClick = onAnchorClick,
+                        activeId = activeHeadingId,
                     )
                     Spacer(modifier = Modifier.height(12.dp))
                 }
@@ -1521,4 +1544,26 @@ private fun WebViewSheetContent(url: String) {
             modifier = Modifier.fillMaxSize()
         )
     }
+}
+
+/**
+ * Last heading whose top has scrolled to or above the viewport top is "active".
+ * Offsets are in pixels relative to the body item's top; scroll offsets come
+ * from [androidx.compose.foundation.lazy.LazyListState].
+ */
+internal fun computeActiveHeadingId(
+    headingOffsetsInBody: Map<String, Float>,
+    firstVisibleItemIndex: Int,
+    firstVisibleItemScrollOffset: Int,
+): String? {
+    if (headingOffsetsInBody.isEmpty()) return null
+    val scrollPast = if (firstVisibleItemIndex > 0) {
+        Float.MAX_VALUE
+    } else {
+        firstVisibleItemScrollOffset.toFloat()
+    }
+    return headingOffsetsInBody.entries
+        .filter { (_, y) -> y <= scrollPast }
+        .maxByOrNull { (_, y) -> y }
+        ?.key
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -112,7 +112,11 @@ import pub.hackers.android.ui.components.PostCard
 import pub.hackers.android.ui.components.QuotedPostPreview
 import pub.hackers.android.ui.components.ReactionPicker
 import pub.hackers.android.ui.components.TocPanel
-import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
 import pub.hackers.android.ui.theme.AppShapes
 import pub.hackers.android.ui.theme.LocalAppColors
 import pub.hackers.android.ui.theme.LocalAppTypography
@@ -487,12 +491,33 @@ internal fun PostDetailContent(
 
     val navBarBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
 
+    val lazyListState = rememberLazyListState()
+    val headingCoords = remember(post.id) { mutableMapOf<String, LayoutCoordinates>() }
+    var bodyItemCoords by remember { mutableStateOf<LayoutCoordinates?>(null) }
+    val onAnchorClick: (String) -> Unit = remember(post.id) {
+        { id ->
+            // Heading ids in HTML are prefixed with "{docId}--"; TOC JSON uses
+            // bare slugs. Strip on both sides so the lookup is symmetric.
+            val hc = headingCoords[id.substringAfter("--")]
+            val ic = bodyItemCoords
+            if (hc != null && hc.isAttached && ic != null && ic.isAttached) {
+                val offsetInItem = (hc.positionInWindow().y - ic.positionInWindow().y).toInt()
+                scope.launch {
+                    lazyListState.animateScrollToItem(0, offsetInItem.coerceAtLeast(0))
+                }
+            }
+        }
+    }
+
     LazyColumn(
-        contentPadding = PaddingValues(bottom = navBarBottom + 96.dp)
+        state = lazyListState,
+        contentPadding = PaddingValues(bottom = navBarBottom + 96.dp),
     ) {
         item {
             Column(
-                modifier = Modifier.padding(12.dp)
+                modifier = Modifier
+                    .padding(12.dp)
+                    .onGloballyPositioned { bodyItemCoords = it }
             ) {
                 // Reply target preview
                 val replyTarget = post.replyTarget
@@ -580,18 +605,15 @@ internal fun PostDetailContent(
                     }
                 }
 
-                val anchorRequester = remember(post.id) {
-                    val anchors = mutableMapOf<String, BringIntoViewRequester>()
-                    val get: (String) -> BringIntoViewRequester = { id ->
-                        anchors.getOrPut(id) { BringIntoViewRequester() }
+                val onHeadingPositioned: (String, LayoutCoordinates) -> Unit =
+                    remember(post.id) {
+                        { id, coords -> headingCoords[id] = coords }
                     }
-                    get
-                }
 
                 if (isArticle && toc.isNotEmpty() && !showTranslated) {
                     TocPanel(
                         items = toc,
-                        anchorRequester = anchorRequester,
+                        onAnchorClick = onAnchorClick,
                     )
                     Spacer(modifier = Modifier.height(12.dp))
                 }
@@ -610,7 +632,7 @@ internal fun PostDetailContent(
                         modifier = Modifier.fillMaxWidth(),
                         contentStyle = HtmlContentStyle.Prose,
                         onMentionClick = onProfileClick,
-                        headingAnchor = if (isArticle) anchorRequester else null,
+                        onHeadingPositioned = if (isArticle) onHeadingPositioned else null,
                     )
                 }
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -111,9 +112,12 @@ import pub.hackers.android.ui.components.MediaImage
 import pub.hackers.android.ui.components.PostCard
 import pub.hackers.android.ui.components.QuotedPostPreview
 import pub.hackers.android.ui.components.ReactionPicker
+import pub.hackers.android.ui.components.TocList
 import pub.hackers.android.ui.components.TocPanel
-import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.filled.FormatListBulleted
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
@@ -146,6 +150,28 @@ fun PostDetailScreen(
     var showDeleteConfirmation by remember { mutableStateOf(false) }
     var showShareConfirmation by remember { mutableStateOf(false) }
     var webViewUrl by remember { mutableStateOf<String?>(null) }
+    var showTocSheet by remember { mutableStateOf(false) }
+
+    val screenScope = rememberCoroutineScope()
+    val lazyListState = rememberLazyListState()
+    val headingCoords = remember(postId) { mutableMapOf<String, LayoutCoordinates>() }
+    var bodyItemCoords by remember { mutableStateOf<LayoutCoordinates?>(null) }
+    val onAnchorClick: (String) -> Unit = remember(postId) {
+        { id ->
+            val hc = headingCoords[id.substringAfter("--")]
+            val ic = bodyItemCoords
+            if (hc != null && hc.isAttached && ic != null && ic.isAttached) {
+                val offsetInItem = (hc.positionInWindow().y - ic.positionInWindow().y).toInt()
+                screenScope.launch {
+                    lazyListState.animateScrollToItem(0, offsetInItem.coerceAtLeast(0))
+                }
+            }
+        }
+    }
+    val onScrollToTop: () -> Unit = remember(lazyListState, screenScope) {
+        { screenScope.launch { lazyListState.animateScrollToItem(0, 0) } }
+    }
+    val tocAvailable = uiState.post?.typename == "Article" && uiState.toc.isNotEmpty()
 
     // Navigate back after successful deletion
     LaunchedEffect(uiState.isDeleted) {
@@ -161,6 +187,33 @@ fun PostDetailScreen(
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
         ) {
             WebViewSheetContent(url = webViewUrl!!)
+        }
+    }
+
+    if (showTocSheet && tocAvailable) {
+        ModalBottomSheet(
+            onDismissRequest = { showTocSheet = false },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        ) {
+            Column(
+                modifier = Modifier
+                    .navigationBarsPadding()
+                    .padding(horizontal = 16.dp, vertical = 12.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.table_of_contents),
+                    style = LocalAppTypography.current.titleMedium,
+                    color = colors.textPrimary,
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
+                TocList(
+                    items = uiState.toc,
+                    onAnchorClick = { id ->
+                        showTocSheet = false
+                        onAnchorClick(id)
+                    },
+                )
+            }
         }
     }
 
@@ -313,18 +366,36 @@ fun PostDetailScreen(
                         )
                     }
                 },
-                trailingContent = if (uiState.canDelete) {
+                trailingContent = if (tocAvailable || uiState.canDelete) {
                     {
-                        PostDetailActionMenu(
-                            isDeleting = uiState.isDeleting,
-                            onDelete = {
-                                if (confirmBeforeDelete) {
-                                    showDeleteConfirmation = true
-                                } else {
-                                    viewModel.deletePost()
-                                }
+                        if (tocAvailable) {
+                            IconButton(onClick = { showTocSheet = true }) {
+                                Icon(
+                                    imageVector = Icons.Filled.FormatListBulleted,
+                                    contentDescription = stringResource(R.string.table_of_contents),
+                                    tint = colors.accent,
+                                )
                             }
-                        )
+                            IconButton(onClick = onScrollToTop) {
+                                Icon(
+                                    imageVector = Icons.Filled.KeyboardArrowUp,
+                                    contentDescription = stringResource(R.string.scroll_to_top),
+                                    tint = colors.accent,
+                                )
+                            }
+                        }
+                        if (uiState.canDelete) {
+                            PostDetailActionMenu(
+                                isDeleting = uiState.isDeleting,
+                                onDelete = {
+                                    if (confirmBeforeDelete) {
+                                        showDeleteConfirmation = true
+                                    } else {
+                                        viewModel.deletePost()
+                                    }
+                                }
+                            )
+                        }
                     }
                 } else null
             )
@@ -369,6 +440,10 @@ fun PostDetailScreen(
                         reactionGroups = uiState.reactionGroups,
                         toc = uiState.toc,
                         replies = replies,
+                        lazyListState = lazyListState,
+                        headingCoords = headingCoords,
+                        onBodyPositioned = { bodyItemCoords = it },
+                        onAnchorClick = onAnchorClick,
                         onProfileClick = onProfileClick,
                         onPostClick = onPostClick,
                         onReplyClick = { onReplyClick(postId) },
@@ -460,6 +535,10 @@ internal fun PostDetailContent(
     reactionGroups: List<ReactionGroup>,
     toc: List<TocItem>,
     replies: LazyPagingItems<Post>,
+    lazyListState: LazyListState = rememberLazyListState(),
+    headingCoords: MutableMap<String, LayoutCoordinates> = remember(post.id) { mutableMapOf() },
+    onBodyPositioned: (LayoutCoordinates) -> Unit = {},
+    onAnchorClick: (String) -> Unit = {},
     onProfileClick: (String) -> Unit,
     onPostClick: (String) -> Unit,
     onShareClick: () -> Unit,
@@ -491,24 +570,6 @@ internal fun PostDetailContent(
 
     val navBarBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
 
-    val lazyListState = rememberLazyListState()
-    val headingCoords = remember(post.id) { mutableMapOf<String, LayoutCoordinates>() }
-    var bodyItemCoords by remember { mutableStateOf<LayoutCoordinates?>(null) }
-    val onAnchorClick: (String) -> Unit = remember(post.id) {
-        { id ->
-            // Heading ids in HTML are prefixed with "{docId}--"; TOC JSON uses
-            // bare slugs. Strip on both sides so the lookup is symmetric.
-            val hc = headingCoords[id.substringAfter("--")]
-            val ic = bodyItemCoords
-            if (hc != null && hc.isAttached && ic != null && ic.isAttached) {
-                val offsetInItem = (hc.positionInWindow().y - ic.positionInWindow().y).toInt()
-                scope.launch {
-                    lazyListState.animateScrollToItem(0, offsetInItem.coerceAtLeast(0))
-                }
-            }
-        }
-    }
-
     LazyColumn(
         state = lazyListState,
         contentPadding = PaddingValues(bottom = navBarBottom + 96.dp),
@@ -517,7 +578,7 @@ internal fun PostDetailContent(
             Column(
                 modifier = Modifier
                     .padding(12.dp)
-                    .onGloballyPositioned { bodyItemCoords = it }
+                    .onGloballyPositioned(onBodyPositioned)
             ) {
                 // Reply target preview
                 val replyTarget = post.replyTarget

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -99,6 +99,7 @@ import kotlinx.coroutines.withContext
 import pub.hackers.android.R
 import pub.hackers.android.domain.model.Post
 import pub.hackers.android.domain.model.ReactionGroup
+import pub.hackers.android.domain.model.TocItem
 import pub.hackers.android.ui.components.ErrorMessage
 import pub.hackers.android.ui.components.FullScreenLoading
 import pub.hackers.android.ui.components.HtmlContent
@@ -110,6 +111,8 @@ import pub.hackers.android.ui.components.MediaImage
 import pub.hackers.android.ui.components.PostCard
 import pub.hackers.android.ui.components.QuotedPostPreview
 import pub.hackers.android.ui.components.ReactionPicker
+import pub.hackers.android.ui.components.TocPanel
+import androidx.compose.foundation.relocation.BringIntoViewRequester
 import pub.hackers.android.ui.theme.AppShapes
 import pub.hackers.android.ui.theme.LocalAppColors
 import pub.hackers.android.ui.theme.LocalAppTypography
@@ -360,6 +363,7 @@ fun PostDetailScreen(
                     PostDetailContent(
                         post = resolvedPost,
                         reactionGroups = uiState.reactionGroups,
+                        toc = uiState.toc,
                         replies = replies,
                         onProfileClick = onProfileClick,
                         onPostClick = onPostClick,
@@ -450,6 +454,7 @@ private fun PostDetailActionMenu(
 internal fun PostDetailContent(
     post: Post,
     reactionGroups: List<ReactionGroup>,
+    toc: List<TocItem>,
     replies: LazyPagingItems<Post>,
     onProfileClick: (String) -> Unit,
     onPostClick: (String) -> Unit,
@@ -575,6 +580,22 @@ internal fun PostDetailContent(
                     }
                 }
 
+                val anchorRequester = remember(post.id) {
+                    val anchors = mutableMapOf<String, BringIntoViewRequester>()
+                    val get: (String) -> BringIntoViewRequester = { id ->
+                        anchors.getOrPut(id) { BringIntoViewRequester() }
+                    }
+                    get
+                }
+
+                if (isArticle && toc.isNotEmpty() && !showTranslated) {
+                    TocPanel(
+                        items = toc,
+                        anchorRequester = anchorRequester,
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
+
                 val translatedText = translatedContent
                 if (showTranslated && translatedText != null) {
                     Text(
@@ -588,7 +609,8 @@ internal fun PostDetailContent(
                         html = post.content,
                         modifier = Modifier.fillMaxWidth(),
                         contentStyle = HtmlContentStyle.Prose,
-                        onMentionClick = onProfileClick
+                        onMentionClick = onProfileClick,
+                        headingAnchor = if (isArticle) anchorRequester else null,
                     )
                 }
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
@@ -22,11 +22,13 @@ import pub.hackers.android.data.repository.HackersPubRepository
 import pub.hackers.android.domain.model.Actor
 import pub.hackers.android.domain.model.Post
 import pub.hackers.android.domain.model.ReactionGroup
+import pub.hackers.android.domain.model.TocItem
 import javax.inject.Inject
 
 data class PostDetailUiState(
     val post: Post? = null,
     val reactionGroups: List<ReactionGroup> = emptyList(),
+    val toc: List<TocItem> = emptyList(),
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
     val error: String? = null,
@@ -88,6 +90,7 @@ class PostDetailViewModel @Inject constructor(
                         it.copy(
                             post = result.post,
                             reactionGroups = result.reactionGroups,
+                            toc = result.toc,
                             isLoading = false,
                             canDelete = canDelete
                         )
@@ -119,6 +122,7 @@ class PostDetailViewModel @Inject constructor(
                         it.copy(
                             post = result.post,
                             reactionGroups = result.reactionGroups,
+                            toc = result.toc,
                             isRefreshing = false,
                             canDelete = canDelete
                         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,7 @@
     <string name="show_original">Show original</string>
     <string name="translating">Translating...</string>
     <string name="translation_failed">Translation failed</string>
+    <string name="table_of_contents">Table of contents</string>
 
     <!-- Settings -->
     <string name="settings">Settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,7 @@
     <string name="translating">Translating...</string>
     <string name="translation_failed">Translation failed</string>
     <string name="table_of_contents">Table of contents</string>
+    <string name="scroll_to_top">Scroll to top</string>
 
     <!-- Settings -->
     <string name="settings">Settings</string>

--- a/app/src/test/java/pub/hackers/android/domain/model/TocParserTest.kt
+++ b/app/src/test/java/pub/hackers/android/domain/model/TocParserTest.kt
@@ -1,0 +1,107 @@
+package pub.hackers.android.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TocParserTest {
+
+    @Test
+    fun `parseTocJson returns empty list for null`() {
+        assertTrue(parseTocJson(null).isEmpty())
+    }
+
+    @Test
+    fun `parseTocJson returns empty list for non-list input`() {
+        assertTrue(parseTocJson("not a list").isEmpty())
+        assertTrue(parseTocJson(42).isEmpty())
+        assertTrue(parseTocJson(mapOf("x" to 1)).isEmpty())
+    }
+
+    @Test
+    fun `parseTocJson returns empty for empty list`() {
+        assertTrue(parseTocJson(emptyList<Any>()).isEmpty())
+    }
+
+    @Test
+    fun `parseTocJson parses flat entries`() {
+        val input = listOf(
+            mapOf("id" to "intro", "level" to 1, "title" to "Intro", "children" to emptyList<Any>()),
+            mapOf("id" to "body", "level" to 2, "title" to "Body", "children" to emptyList<Any>()),
+        )
+        val items = parseTocJson(input)
+        assertEquals(2, items.size)
+        assertEquals(TocItem(id = "intro", level = 1, title = "Intro", children = emptyList()), items[0])
+        assertEquals(TocItem(id = "body", level = 2, title = "Body", children = emptyList()), items[1])
+    }
+
+    @Test
+    fun `parseTocJson parses nested children recursively`() {
+        val input = listOf(
+            mapOf(
+                "id" to "root",
+                "level" to 1,
+                "title" to "Root",
+                "children" to listOf(
+                    mapOf(
+                        "id" to "child-a",
+                        "level" to 2,
+                        "title" to "Child A",
+                        "children" to listOf(
+                            mapOf("id" to "leaf", "level" to 3, "title" to "Leaf", "children" to emptyList<Any>())
+                        )
+                    ),
+                    mapOf("id" to "child-b", "level" to 2, "title" to "Child B", "children" to emptyList<Any>())
+                )
+            )
+        )
+
+        val items = parseTocJson(input)
+        assertEquals(1, items.size)
+        val root = items[0]
+        assertEquals("root", root.id)
+        assertEquals(2, root.children.size)
+        assertEquals("child-a", root.children[0].id)
+        assertEquals(1, root.children[0].children.size)
+        assertEquals("leaf", root.children[0].children[0].id)
+        assertEquals(3, root.children[0].children[0].level)
+        assertTrue(root.children[1].children.isEmpty())
+    }
+
+    @Test
+    fun `parseTocJson skips entries missing required fields`() {
+        val input = listOf(
+            mapOf("id" to "ok", "level" to 1, "title" to "OK", "children" to emptyList<Any>()),
+            mapOf("id" to "missing-level", "title" to "nope", "children" to emptyList<Any>()),
+            mapOf("level" to 2, "title" to "no-id", "children" to emptyList<Any>()),
+            mapOf("id" to "no-title", "level" to 2, "children" to emptyList<Any>()),
+            "not-a-map",
+            null,
+        )
+        val items = parseTocJson(input)
+        assertEquals(1, items.size)
+        assertEquals("ok", items[0].id)
+    }
+
+    @Test
+    fun `parseTocJson accepts numeric level as long or double`() {
+        val input = listOf(
+            mapOf("id" to "a", "level" to 2L, "title" to "A", "children" to emptyList<Any>()),
+            mapOf("id" to "b", "level" to 3.0, "title" to "B", "children" to emptyList<Any>()),
+        )
+        val items = parseTocJson(input)
+        assertEquals(2, items.size)
+        assertEquals(2, items[0].level)
+        assertEquals(3, items[1].level)
+    }
+
+    @Test
+    fun `parseTocJson treats missing children as empty list`() {
+        val input = listOf(
+            mapOf("id" to "a", "level" to 1, "title" to "A")
+        )
+        val items = parseTocJson(input)
+        assertEquals(1, items.size)
+        assertTrue(items[0].children.isEmpty())
+    }
+}

--- a/app/src/test/java/pub/hackers/android/ui/components/HtmlContentKtTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/components/HtmlContentKtTest.kt
@@ -219,6 +219,14 @@ class HtmlContentKtTest {
         assertTrue(blocks[1] is ContentBlock.Code)
     }
 
+    @Test
+    fun `splitIntoBlocks strips docId prefix from heading anchor id`() {
+        val html = "<h2 id=\"019d8e52-2525-7593-b0dc-46fb62d6a0fc--tagged-union\">Tagged Union</h2>"
+        val blocks = splitIntoBlocks(html, splitHeadings = true)
+        val heading = blocks[0] as ContentBlock.Heading
+        assertEquals("tagged-union", heading.anchorId)
+    }
+
     // endregion
 
     // region parseHtmlToAnnotatedString

--- a/app/src/test/java/pub/hackers/android/ui/components/HtmlContentKtTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/components/HtmlContentKtTest.kt
@@ -163,6 +163,62 @@ class HtmlContentKtTest {
         assertTrue(blocks[0] is ContentBlock.List)
     }
 
+    @Test
+    fun `splitIntoBlocks does not extract headings by default`() {
+        val html = "<p>intro</p><h2 id=\"sec\">Section</h2><p>body</p>"
+        val blocks = splitIntoBlocks(html)
+        assertEquals(1, blocks.size)
+        assertTrue(blocks[0] is ContentBlock.Text)
+    }
+
+    @Test
+    fun `splitIntoBlocks extracts headings when splitHeadings is true`() {
+        val html = "<p>intro</p><h2 id=\"sec\">Section</h2><p>body</p>"
+        val blocks = splitIntoBlocks(html, splitHeadings = true)
+        assertEquals(3, blocks.size)
+        assertTrue(blocks[0] is ContentBlock.Text)
+        assertTrue(blocks[1] is ContentBlock.Heading)
+        assertTrue(blocks[2] is ContentBlock.Text)
+
+        val heading = blocks[1] as ContentBlock.Heading
+        assertEquals(2, heading.level)
+        assertEquals("sec", heading.anchorId)
+        assertEquals("Section", heading.innerHtml)
+    }
+
+    @Test
+    fun `splitIntoBlocks heading without id leaves anchorId null`() {
+        val html = "<h3>No anchor</h3>"
+        val blocks = splitIntoBlocks(html, splitHeadings = true)
+        assertEquals(1, blocks.size)
+        val heading = blocks[0] as ContentBlock.Heading
+        assertEquals(3, heading.level)
+        assertNull(heading.anchorId)
+        assertEquals("No anchor", heading.innerHtml)
+    }
+
+    @Test
+    fun `splitIntoBlocks splits multiple headings`() {
+        val html = "<h1 id=\"a\">A</h1><p>x</p><h2 id=\"b\">B</h2><p>y</p>"
+        val blocks = splitIntoBlocks(html, splitHeadings = true)
+        assertEquals(4, blocks.size)
+        val h1 = blocks[0] as ContentBlock.Heading
+        val h2 = blocks[2] as ContentBlock.Heading
+        assertEquals("a", h1.anchorId)
+        assertEquals(1, h1.level)
+        assertEquals("b", h2.anchorId)
+        assertEquals(2, h2.level)
+    }
+
+    @Test
+    fun `splitIntoBlocks preserves code blocks when splitHeadings is true`() {
+        val html = "<h2 id=\"s\">Section</h2><pre><code>code</code></pre>"
+        val blocks = splitIntoBlocks(html, splitHeadings = true)
+        assertEquals(2, blocks.size)
+        assertTrue(blocks[0] is ContentBlock.Heading)
+        assertTrue(blocks[1] is ContentBlock.Code)
+    }
+
     // endregion
 
     // region parseHtmlToAnnotatedString

--- a/app/src/test/java/pub/hackers/android/ui/screens/postdetail/ActiveHeadingTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/postdetail/ActiveHeadingTest.kt
@@ -1,0 +1,87 @@
+package pub.hackers.android.ui.screens.postdetail
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ActiveHeadingTest {
+
+    private val threeSections = mapOf(
+        "intro" to 0f,
+        "body" to 600f,
+        "summary" to 1400f,
+    )
+
+    @Test
+    fun `returns null when no headings registered`() {
+        assertNull(
+            computeActiveHeadingId(
+                headingOffsetsInBody = emptyMap(),
+                firstVisibleItemIndex = 0,
+                firstVisibleItemScrollOffset = 0,
+            )
+        )
+    }
+
+    @Test
+    fun `returns first heading when scrolled exactly to its top`() {
+        assertEquals(
+            "intro",
+            computeActiveHeadingId(threeSections, firstVisibleItemIndex = 0, firstVisibleItemScrollOffset = 0)
+        )
+    }
+
+    @Test
+    fun `returns null when scroll is above the first heading`() {
+        val sections = mapOf("intro" to 200f, "body" to 800f)
+        assertNull(
+            computeActiveHeadingId(sections, firstVisibleItemIndex = 0, firstVisibleItemScrollOffset = 0)
+        )
+    }
+
+    @Test
+    fun `picks the nearest heading above the viewport top`() {
+        assertEquals(
+            "body",
+            computeActiveHeadingId(threeSections, firstVisibleItemIndex = 0, firstVisibleItemScrollOffset = 700)
+        )
+    }
+
+    @Test
+    fun `remains on a heading while reading its section`() {
+        // Viewport top sits inside "body"'s section (well before "summary").
+        assertEquals(
+            "body",
+            computeActiveHeadingId(threeSections, firstVisibleItemIndex = 0, firstVisibleItemScrollOffset = 1200)
+        )
+    }
+
+    @Test
+    fun `advances when the next heading scrolls past the viewport top`() {
+        assertEquals(
+            "summary",
+            computeActiveHeadingId(threeSections, firstVisibleItemIndex = 0, firstVisibleItemScrollOffset = 1500)
+        )
+    }
+
+    @Test
+    fun `returns the last heading once the body item has scrolled fully past`() {
+        assertEquals(
+            "summary",
+            computeActiveHeadingId(threeSections, firstVisibleItemIndex = 2, firstVisibleItemScrollOffset = 0)
+        )
+    }
+
+    @Test
+    fun `unordered offset map still resolves the maximum below the scroll line`() {
+        val unordered = mapOf(
+            "summary" to 1400f,
+            "intro" to 0f,
+            "body" to 600f,
+        )
+        assertEquals(
+            "body",
+            computeActiveHeadingId(unordered, firstVisibleItemIndex = 0, firstVisibleItemScrollOffset = 1000)
+        )
+    }
+}

--- a/app/src/test/java/pub/hackers/android/ui/screens/postdetail/PostDetailContentTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/postdetail/PostDetailContentTest.kt
@@ -150,6 +150,7 @@ class PostDetailContentTest {
                 PostDetailContent(
                     post = post,
                     reactionGroups = emptyList(),
+                    toc = emptyList(),
                     replies = replies,
                     onProfileClick = {},
                     onPostClick = {},


### PR DESCRIPTION
## Summary
Adds an inline collapsible TOC above the article body on the article detail screen, plus persistent access from the top app bar via a list-icon that opens a bottom sheet and an up-arrow that scrolls back to the top. The TOC is sourced from the new `ArticleContent.toc` GraphQL field and follows reading position: the currently-viewed section's row is bold with a tinted background in both the inline panel and the sheet.

Tapping a TOC entry smooth-scrolls the LazyColumn so the heading lands at the viewport top, using body-relative layout coordinates so it works inside the single large item that holds the article body. Heading anchors are normalized to bare slugs to handle the backend's `{docId}--{slug}` HTML id prefix while TOC JSON uses bare slugs.

## Test plan
- [x] Unit tests for TOC JSON parsing (`TocParserTest` — 8 cases)
- [x] Unit tests for heading-block HTML splitting incl. docId prefix stripping (`HtmlContentKtTest` — 6 new cases)
- [x] Unit tests for the active-heading selection (`ActiveHeadingTest` — 8 cases)
- [x] Manual: open a Korean article with `{uuid}--{slug}` anchors — TOC list renders, tap scrolls to the heading, active row updates while scrolling
- [x] Manual: open an English article with bare-slug anchors — same behavior
- [x] Manual: verify notes/post-detail are unchanged (no inline TOC, no top-bar icons, no heading-split rendering)
- [x] Manual: top-bar list icon opens bottom sheet; arrow icon scrolls to top; both coexist with existing delete menu and reply FAB

---
Assisted-By: Claude Code(claude-opus-4-7)