### PR TITLE
Make TOC bottom sheet scrollable

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -217,6 +217,7 @@ fun PostDetailScreen(
             Column(
                 modifier = Modifier
                     .navigationBarsPadding()
+                    .verticalScroll(rememberScrollState())
                     .padding(horizontal = 16.dp, vertical = 12.dp)
             ) {
                 Text(


### PR DESCRIPTION
## Summary
The table-of-contents bottom sheet on the article detail screen was wrapping the TOC in a plain `Column`, so long tables of contents got clipped with no way to scroll them. Added `verticalScroll(rememberScrollState())` to that column — Compose scrollable modifiers participate in nested scroll, so the sheet's expand/dismiss gestures still work.

---
Assisted-By: Claude Code(claude-opus-4-7)