### PR TITLE
Mark notifications as read on screen entry

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/extensions.graphqls
+++ b/app/src/main/graphql/pub/hackers/android/extensions.graphqls
@@ -1,0 +1,6 @@
+extend type Mutation {
+    """
+    Marks all notifications as read up to the current time. Returns the timestamp.
+    """
+    markNotificationsAsRead: DateTime!
+}

--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -928,3 +928,7 @@ mutation UpdateAccount($input: UpdateAccountInput!) {
         }
     }
 }
+
+mutation MarkNotificationsAsRead {
+    markNotificationsAsRead
+}

--- a/app/src/main/java/pub/hackers/android/FeatureFlags.kt
+++ b/app/src/main/java/pub/hackers/android/FeatureFlags.kt
@@ -2,4 +2,5 @@ package pub.hackers.android
 
 object FeatureFlags {
     const val PASSKEY_AUTH_ENABLED = false
+    const val MARK_NOTIFICATIONS_AS_READ_ENABLED = false
 }

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -26,6 +26,7 @@ import pub.hackers.android.graphql.FollowActorMutation
 import pub.hackers.android.graphql.LocalTimelineQuery
 import pub.hackers.android.graphql.LoginByPasskeyMutation
 import pub.hackers.android.graphql.LoginByUsernameMutation
+import pub.hackers.android.graphql.MarkNotificationsAsReadMutation
 import pub.hackers.android.graphql.NotificationsQuery
 import pub.hackers.android.graphql.PersonalTimelineQuery
 import pub.hackers.android.graphql.PostQuotesQuery
@@ -176,6 +177,19 @@ class HackersPubRepository @Inject constructor(
                         )
                     )
                 }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun markNotificationsAsRead(): Result<Unit> {
+        return try {
+            val response = apolloClient.mutation(MarkNotificationsAsReadMutation()).execute()
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                Result.success(Unit)
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsViewModel.kt
@@ -7,6 +7,7 @@ import androidx.paging.cachedIn
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import pub.hackers.android.FeatureFlags
 import pub.hackers.android.data.local.NotificationStateManager
 import pub.hackers.android.data.paging.cursorPager
 import pub.hackers.android.data.paging.notificationsPage
@@ -24,6 +25,12 @@ class NotificationsViewModel @Inject constructor(
         cursorPager { after -> repository.notificationsPage(after) }
             .flow
             .cachedIn(viewModelScope)
+
+    init {
+        if (FeatureFlags.MARK_NOTIFICATIONS_AS_READ_ENABLED) {
+            viewModelScope.launch { repository.markNotificationsAsRead() }
+        }
+    }
 
     fun markAsSeen() {
         viewModelScope.launch { notificationStateManager.markAsSeen() }


### PR DESCRIPTION
## Summary
Wires the `markNotificationsAsRead` GraphQL mutation into `NotificationsViewModel.init` so notifications get marked read server-side when the user opens the notifications screen. The call is gated behind `FeatureFlags.MARK_NOTIFICATIONS_AS_READ_ENABLED` (default `false`) and a local schema extension declares the mutation for Apollo codegen — flip the flag and drop the extension once the server deploy exposes the mutation via introspection.

---
Assisted-By: Claude Code(claude-opus-4-7)