### PR TITLE
Optimistically append replies on post detail

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -543,9 +543,7 @@ mutation CreateNote($content: Markdown!, $language: Locale!, $visibility: PostVi
     createNote(input: { content: $content, language: $language, visibility: $visibility, replyTargetId: $replyTargetId, quotedPostId: $quotedPostId }) {
         ... on CreateNotePayload {
             note {
-                id
-                content
-                published
+                ...PostFields
             }
         }
         ... on InvalidInputError {

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -842,24 +842,7 @@ class HackersPubRepository @Inject constructor(
                 val result = response.data?.createNote
                 when {
                     result?.onCreateNotePayload != null -> {
-                        val note = result.onCreateNotePayload.note
-                        Result.success(
-                            Post(
-                                id = note.id,
-                                typename = "Note",
-                                name = null,
-                                published = Instant.parse(note.published.toString()),
-                                summary = null,
-                                content = note.content.toString(),
-                                excerpt = "",
-                                url = null,
-                                viewerHasShared = false,
-                                actor = Actor("", null, "", ""),
-                                media = emptyList(),
-                                engagementStats = EngagementStats(0, 0, 0, 0),
-                                mentions = emptyList()
-                            )
-                        )
+                        Result.success(result.onCreateNotePayload.note.postFields.toPost())
                     }
                     result?.onInvalidInputError != null -> {
                         Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
@@ -50,7 +50,8 @@ data class ComposeUiState(
 @HiltViewModel
 class ComposeViewModel @Inject constructor(
     private val repository: HackersPubRepository,
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val replyPostedSignal: ReplyPostedSignal,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ComposeUiState())
@@ -297,7 +298,10 @@ class ComposeViewModel @Inject constructor(
                 replyTargetId = state.replyToId,
                 quotedPostId = state.quotedPostId
             )
-                .onSuccess {
+                .onSuccess { newPost ->
+                    state.replyToId?.let { replyTargetId ->
+                        replyPostedSignal.emit(ReplyPostedEvent(replyTargetId, newPost))
+                    }
                     _uiState.update { it.copy(isPosting = false, isPosted = true) }
                 }
                 .onFailure { error ->

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ReplyPostedSignal.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ReplyPostedSignal.kt
@@ -1,0 +1,27 @@
+package pub.hackers.android.ui.screens.compose
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import pub.hackers.android.domain.model.Post
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class ReplyPostedEvent(
+    val replyTargetId: String,
+    val reply: Post,
+)
+
+@Singleton
+class ReplyPostedSignal @Inject constructor() {
+    private val _events = MutableSharedFlow<ReplyPostedEvent>(
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    val events: SharedFlow<ReplyPostedEvent> = _events.asSharedFlow()
+
+    fun emit(event: ReplyPostedEvent) {
+        _events.tryEmit(event)
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -449,6 +450,7 @@ fun PostDetailScreen(
                 onRetry = { viewModel.loadPost(postId) },
             ) { resolvedPost ->
                 val replies = viewModel.replies.collectAsLazyPagingItems()
+                val localReplies by viewModel.locallyAddedReplies.collectAsState()
                 PullToRefreshBox(
                     isRefreshing = uiState.isRefreshing,
                     onRefresh = {
@@ -461,6 +463,7 @@ fun PostDetailScreen(
                         reactionGroups = uiState.reactionGroups,
                         toc = uiState.toc,
                         replies = replies,
+                        localReplies = localReplies,
                         lazyListState = lazyListState,
                         headingCoords = headingCoords,
                         onBodyPositioned = { bodyItemCoords = it },
@@ -574,6 +577,7 @@ internal fun PostDetailContent(
     onReactionsClick: () -> Unit,
     onExternalShareClick: () -> Unit,
     onWebViewClick: (String) -> Unit = {},
+    localReplies: List<Post> = emptyList(),
 ) {
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
@@ -990,7 +994,7 @@ internal fun PostDetailContent(
             }
         }
 
-        if (replies.itemCount > 0) {
+        if (replies.itemCount > 0 || localReplies.isNotEmpty()) {
             item {
                 Text(
                     text = stringResource(R.string.replies),
@@ -1018,6 +1022,19 @@ internal fun PostDetailContent(
                 item {
                     LoadingItem()
                 }
+            }
+
+            items(
+                items = localReplies,
+                key = { reply -> "local-${reply.id}" }
+            ) { reply ->
+                PostCard(
+                    post = reply,
+                    onClick = { onPostClick(reply.id) },
+                    onProfileClick = onProfileClick,
+                    onQuotedPostClick = onPostClick
+                )
+                HorizontalDivider(thickness = 0.5.dp, color = colors.divider)
             }
         }
     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
@@ -23,6 +23,7 @@ import pub.hackers.android.domain.model.Actor
 import pub.hackers.android.domain.model.Post
 import pub.hackers.android.domain.model.ReactionGroup
 import pub.hackers.android.domain.model.TocItem
+import pub.hackers.android.ui.screens.compose.ReplyPostedSignal
 import javax.inject.Inject
 
 data class PostDetailUiState(
@@ -53,6 +54,7 @@ class PostDetailViewModel @Inject constructor(
     private val repository: HackersPubRepository,
     private val sessionManager: SessionManager,
     val preferencesManager: PreferencesManager,
+    private val replyPostedSignal: ReplyPostedSignal,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -60,6 +62,12 @@ class PostDetailViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(PostDetailUiState())
     val uiState: StateFlow<PostDetailUiState> = _uiState.asStateFlow()
+
+    // Locally-composed replies appended optimistically after a successful reply
+    // from this screen. Rendered after the paginated replies; cleared on refresh
+    // so the server-authoritative list wins.
+    private val _locallyAddedReplies = MutableStateFlow<List<Post>>(emptyList())
+    val locallyAddedReplies: StateFlow<List<Post>> = _locallyAddedReplies.asStateFlow()
 
     // Replies are paginated independently of the main post payload. The main
     // post, reactionGroups, and sheet/delete/translation state stay in UiState
@@ -73,6 +81,27 @@ class PostDetailViewModel @Inject constructor(
 
     init {
         loadPost(postId)
+        viewModelScope.launch {
+            replyPostedSignal.events.collect { event ->
+                if (event.replyTargetId == postId) {
+                    appendLocalReply(event.reply)
+                }
+            }
+        }
+    }
+
+    private fun appendLocalReply(reply: Post) {
+        _locallyAddedReplies.update { it + reply }
+        _uiState.update { state ->
+            val post = state.post ?: return@update state
+            state.copy(
+                post = post.copy(
+                    engagementStats = post.engagementStats.copy(
+                        replies = post.engagementStats.replies + 1
+                    )
+                )
+            )
+        }
     }
 
     fun loadPost(id: String) {
@@ -108,6 +137,7 @@ class PostDetailViewModel @Inject constructor(
     }
 
     fun refresh() {
+        _locallyAddedReplies.value = emptyList()
         viewModelScope.launch {
             _uiState.update { it.copy(isRefreshing = true) }
 

--- a/app/src/test/java/pub/hackers/android/ui/screens/compose/ComposeViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/compose/ComposeViewModelTest.kt
@@ -40,7 +40,9 @@ class ComposeViewModelTest {
         coEvery { repository.getViewer() } returns Result.success(null)
     }
 
-    private fun newViewModel() = ComposeViewModel(repository, context)
+    private val replyPostedSignal = ReplyPostedSignal()
+
+    private fun newViewModel() = ComposeViewModel(repository, context, replyPostedSignal)
 
     private val sampleActor = Actor(
         id = "actor-1",

--- a/app/src/test/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModelTest.kt
@@ -23,6 +23,7 @@ import pub.hackers.android.domain.model.Post
 import pub.hackers.android.domain.model.PostDetailResult
 import pub.hackers.android.domain.model.ReactionGroup
 import pub.hackers.android.testutil.MainDispatcherRule
+import pub.hackers.android.ui.screens.compose.ReplyPostedEvent
 import pub.hackers.android.ui.screens.compose.ReplyPostedSignal
 import java.time.Instant
 
@@ -225,6 +226,53 @@ class PostDetailViewModelTest {
         vm.dismissDeleteError()
 
         assertNull(vm.uiState.value.deleteError)
+    }
+
+    // endregion
+
+    // region optimistic reply append
+
+    @Test
+    fun `reply event targeting this post appends to locallyAddedReplies`() = runTest {
+        stubLoadPostSuccess(samplePost(id = defaultPostId))
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        val reply = samplePost(id = "reply-1")
+        replyPostedSignal.emit(ReplyPostedEvent(defaultPostId, reply))
+        advanceUntilIdle()
+
+        assertEquals(listOf(reply), vm.locallyAddedReplies.value)
+        assertEquals(1, vm.uiState.value.post?.engagementStats?.replies)
+    }
+
+    @Test
+    fun `reply event targeting a different post is ignored`() = runTest {
+        stubLoadPostSuccess(samplePost(id = defaultPostId))
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        replyPostedSignal.emit(ReplyPostedEvent("other-post", samplePost(id = "reply-1")))
+        advanceUntilIdle()
+
+        assertTrue(vm.locallyAddedReplies.value.isEmpty())
+        assertEquals(0, vm.uiState.value.post?.engagementStats?.replies)
+    }
+
+    @Test
+    fun `refresh clears locallyAddedReplies`() = runTest {
+        stubLoadPostSuccess(samplePost(id = defaultPostId))
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        replyPostedSignal.emit(ReplyPostedEvent(defaultPostId, samplePost(id = "reply-1")))
+        advanceUntilIdle()
+        assertEquals(1, vm.locallyAddedReplies.value.size)
+
+        vm.refresh()
+        advanceUntilIdle()
+
+        assertTrue(vm.locallyAddedReplies.value.isEmpty())
     }
 
     // endregion

--- a/app/src/test/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModelTest.kt
@@ -23,6 +23,7 @@ import pub.hackers.android.domain.model.Post
 import pub.hackers.android.domain.model.PostDetailResult
 import pub.hackers.android.domain.model.ReactionGroup
 import pub.hackers.android.testutil.MainDispatcherRule
+import pub.hackers.android.ui.screens.compose.ReplyPostedSignal
 import java.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -77,9 +78,17 @@ class PostDetailViewModelTest {
         )
     }
 
+    private val replyPostedSignal = ReplyPostedSignal()
+
     private fun newViewModel(): PostDetailViewModel {
         val savedStateHandle = SavedStateHandle(mapOf("postId" to defaultPostId))
-        return PostDetailViewModel(repository, sessionManager, preferencesManager, savedStateHandle)
+        return PostDetailViewModel(
+            repository,
+            sessionManager,
+            preferencesManager,
+            replyPostedSignal,
+            savedStateHandle,
+        )
     }
 
     // region initial load


### PR DESCRIPTION
## Summary
Wires a singleton `ReplyPostedSignal` from `ComposeViewModel` to `PostDetailViewModel` so a successful reply appended from the post/article detail page appears in the replies list without waiting for a pull-to-refresh, and bumps the reply count by one. The `CreateNote` mutation now returns `...PostFields`, giving the client a full `Post` (actor, mentions, engagement, reactions) to render the newly-appended reply card.

---
Assisted-By: Claude Code(claude-opus-4-7)