### PR TITLE
Add article edit + draft preview, move scroll-to-top to FAB

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -816,6 +816,7 @@ mutation SaveArticleDraft($title: String!, $content: Markdown!, $tags: [String!]
                 id
                 title
                 content
+                contentHtml
                 tags
                 created
                 updated
@@ -867,6 +868,7 @@ query ArticleDraft($id: ID!) {
         id
         title
         content
+        contentHtml
         tags
         created
         updated

--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -935,13 +935,13 @@ query ArticleForEdit($id: ID!) {
     node(id: $id) {
         ... on Article {
             id
-            name
             tags
-            language
             allowLlmTranslation
             contents {
-                language
+                title
                 rawContent
+                language
+                originalLanguage
             }
         }
     }

--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -930,3 +930,51 @@ mutation UpdateAccount($input: UpdateAccountInput!) {
 mutation MarkNotificationsAsRead {
     markNotificationsAsRead
 }
+
+query ArticleForEdit($id: ID!) {
+    node(id: $id) {
+        ... on Article {
+            id
+            name
+            tags
+            language
+            allowLlmTranslation
+            contents {
+                language
+                rawContent
+            }
+        }
+    }
+}
+
+mutation UpdateArticle(
+    $articleId: ID!,
+    $title: String,
+    $content: Markdown,
+    $tags: [String!],
+    $language: Locale,
+    $allowLlmTranslation: Boolean
+) {
+    updateArticle(input: {
+        articleId: $articleId,
+        title: $title,
+        content: $content,
+        tags: $tags,
+        language: $language,
+        allowLlmTranslation: $allowLlmTranslation
+    }) {
+        ... on UpdateArticlePayload {
+            article {
+                id
+                name
+                url
+            }
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+    }
+}

--- a/app/src/main/graphql/pub/hackers/android/schema.graphqls
+++ b/app/src/main/graphql/pub/hackers/android/schema.graphqls
@@ -502,6 +502,11 @@ type ArticleContent implements Node {
 
   published: DateTime!
 
+  """
+  The raw markdown content for editing.
+  """
+  rawContent: Markdown!
+
   summary: String
 
   summaryStarted: DateTime
@@ -946,6 +951,8 @@ type Mutation {
   unsharePost(input: UnsharePostInput!): UnsharePostResult!
 
   updateAccount(input: UpdateAccountInput!): UpdateAccountPayload!
+
+  updateArticle(input: UpdateArticleInput!): UpdateArticleResult!
 
   uploadMedia(input: UploadMediaInput!): UploadMediaResult!
 
@@ -1978,6 +1985,30 @@ type UpdateAccountPayload {
 
   clientMutationId: ID
 }
+
+input UpdateArticleInput {
+  allowLlmTranslation: Boolean
+
+  articleId: ID!
+
+  clientMutationId: ID
+
+  content: Markdown
+
+  language: Locale
+
+  tags: [String!]
+
+  title: String
+}
+
+type UpdateArticlePayload {
+  article: Article!
+
+  clientMutationId: ID
+}
+
+union UpdateArticleResult = InvalidInputError|NotAuthenticatedError|UpdateArticlePayload
 
 input UploadMediaInput {
   clientMutationId: ID

--- a/app/src/main/java/pub/hackers/android/FeatureFlags.kt
+++ b/app/src/main/java/pub/hackers/android/FeatureFlags.kt
@@ -3,4 +3,5 @@ package pub.hackers.android
 object FeatureFlags {
     const val PASSKEY_AUTH_ENABLED = false
     const val MARK_NOTIFICATIONS_AS_READ_ENABLED = false
+    const val ARTICLE_EDIT_ENABLED = false
 }

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -1241,6 +1241,7 @@ class HackersPubRepository @Inject constructor(
                                 id = draft.id,
                                 title = draft.title,
                                 content = draft.content.toString(),
+                                contentHtml = draft.contentHtml.toString(),
                                 tags = draft.tags,
                                 created = Instant.parse(draft.created.toString()),
                                 updated = Instant.parse(draft.updated.toString())
@@ -1343,6 +1344,7 @@ class HackersPubRepository @Inject constructor(
                         id = node.id,
                         title = node.title,
                         content = node.content.toString(),
+                        contentHtml = "",
                         tags = node.tags,
                         created = Instant.parse(node.created.toString()),
                         updated = Instant.parse(node.updated.toString())
@@ -1371,6 +1373,7 @@ class HackersPubRepository @Inject constructor(
                         id = draft.id,
                         title = draft.title,
                         content = draft.content.toString(),
+                        contentHtml = draft.contentHtml.toString(),
                         tags = draft.tags,
                         created = Instant.parse(draft.created.toString()),
                         updated = Instant.parse(draft.updated.toString())

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -1393,17 +1393,16 @@ class HackersPubRepository @Inject constructor(
             } else {
                 val article = response.data?.node?.onArticle
                     ?: return Result.failure(Exception("Article not found"))
-                val language = article.language ?: article.contents.firstOrNull()?.language?.toString() ?: ""
-                val rawContent = article.contents.firstOrNull { it.language.toString() == language }?.rawContent
-                    ?: article.contents.firstOrNull()?.rawContent
+                val original = article.contents.firstOrNull { it.originalLanguage == null }
+                    ?: article.contents.firstOrNull()
                     ?: return Result.failure(Exception("Article content not found"))
                 Result.success(
                     EditableArticle(
                         id = article.id,
-                        title = article.name.orEmpty(),
-                        content = rawContent.toString(),
+                        title = original.title,
+                        content = original.rawContent.toString(),
                         tags = article.tags,
-                        language = language,
+                        language = original.language.toString(),
                         allowLlmTranslation = article.allowLlmTranslation
                     )
                 )

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.withContext
 import pub.hackers.android.domain.model.*
 import pub.hackers.android.graphql.ArticleDraftQuery
 import pub.hackers.android.graphql.ArticleDraftsQuery
+import pub.hackers.android.graphql.ArticleForEditQuery
 import pub.hackers.android.graphql.ActorArticlesQuery
 import pub.hackers.android.graphql.ActorByHandleQuery
 import pub.hackers.android.graphql.ActorNotesQuery
@@ -52,6 +53,7 @@ import pub.hackers.android.graphql.UnblockActorMutation
 import pub.hackers.android.graphql.UnfollowActorMutation
 import pub.hackers.android.graphql.UnsharePostMutation
 import pub.hackers.android.graphql.UpdateAccountMutation
+import pub.hackers.android.graphql.UpdateArticleMutation
 import pub.hackers.android.graphql.ViewerQuery
 import pub.hackers.android.graphql.type.AccountLinkInput
 import pub.hackers.android.graphql.type.UpdateAccountInput
@@ -1374,6 +1376,84 @@ class HackersPubRepository @Inject constructor(
                         updated = Instant.parse(draft.updated.toString())
                     )
                 )
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getEditableArticle(articleId: String): Result<EditableArticle> {
+        return try {
+            val response = apolloClient.query(ArticleForEditQuery(articleId))
+                .fetchPolicy(FetchPolicy.NetworkOnly)
+                .execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val article = response.data?.node?.onArticle
+                    ?: return Result.failure(Exception("Article not found"))
+                val language = article.language ?: article.contents.firstOrNull()?.language?.toString() ?: ""
+                val rawContent = article.contents.firstOrNull { it.language.toString() == language }?.rawContent
+                    ?: article.contents.firstOrNull()?.rawContent
+                    ?: return Result.failure(Exception("Article content not found"))
+                Result.success(
+                    EditableArticle(
+                        id = article.id,
+                        title = article.name.orEmpty(),
+                        content = rawContent.toString(),
+                        tags = article.tags,
+                        language = language,
+                        allowLlmTranslation = article.allowLlmTranslation
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun updateArticle(
+        articleId: String,
+        title: String,
+        content: String,
+        tags: List<String>,
+        language: String,
+        allowLlmTranslation: Boolean
+    ): Result<PublishedArticle> {
+        return try {
+            val response = apolloClient.mutation(
+                UpdateArticleMutation(
+                    articleId = articleId,
+                    title = Optional.present(title),
+                    content = Optional.present(content),
+                    tags = Optional.present(tags),
+                    language = Optional.present(language),
+                    allowLlmTranslation = Optional.present(allowLlmTranslation)
+                )
+            ).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.updateArticle
+                when {
+                    result?.onUpdateArticlePayload != null -> {
+                        val article = result.onUpdateArticlePayload.article
+                        Result.success(
+                            PublishedArticle(
+                                id = article.id,
+                                name = article.name,
+                                url = article.url?.toString()
+                            )
+                        )
+                    }
+                    result?.onInvalidInputError != null ->
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    result?.onNotAuthenticatedError != null ->
+                        Result.failure(Exception("Not authenticated"))
+                    else -> Result.failure(Exception("Unknown error"))
+                }
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -288,6 +288,16 @@ data class PublishedArticle(
 )
 
 @Immutable
+data class EditableArticle(
+    val id: String,
+    val title: String,
+    val content: String,
+    val tags: List<String>,
+    val language: String,
+    val allowLlmTranslation: Boolean
+)
+
+@Immutable
 data class ProfileResult(
     val actor: Actor,
     val bio: String?,

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -275,6 +275,7 @@ data class ArticleDraft(
     val id: String,
     val title: String,
     val content: String,
+    val contentHtml: String,
     val tags: List<String>,
     val created: Instant,
     val updated: Instant

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -137,9 +137,13 @@ sealed class DetailScreen(val route: String) {
         }
     }
     data object RecommendedActors : DetailScreen("recommended-actors")
-    data object ComposeArticle : DetailScreen("compose-article?draftId={draftId}") {
-        fun createRoute(draftId: String? = null): String {
-            return if (draftId != null) "compose-article?draftId=$draftId" else "compose-article"
+    data object ComposeArticle : DetailScreen("compose-article?draftId={draftId}&articleId={articleId}") {
+        fun createRoute(draftId: String? = null, articleId: String? = null): String {
+            val params = buildList {
+                if (draftId != null) add("draftId=$draftId")
+                if (articleId != null) add("articleId=$articleId")
+            }
+            return if (params.isEmpty()) "compose-article" else "compose-article?" + params.joinToString("&")
         }
     }
     data object Drafts : DetailScreen("drafts")
@@ -532,6 +536,9 @@ fun HackersPubApp(
                     onPostClick = { id ->
                         navController.navigate(DetailScreen.PostDetail.createRoute(id))
                     },
+                    onEditArticleClick = { id ->
+                        navController.navigate(DetailScreen.ComposeArticle.createRoute(articleId = id))
+                    },
                     isLoggedIn = isLoggedIn
                 )
             }
@@ -612,18 +619,29 @@ fun HackersPubApp(
                         type = NavType.StringType
                         nullable = true
                         defaultValue = null
+                    },
+                    navArgument("articleId") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
                     }
                 )
             ) { backStackEntry ->
                 val draftId = backStackEntry.arguments?.getString("draftId")
+                val articleId = backStackEntry.arguments?.getString("articleId")
                 ComposeArticleScreen(
                     draftId = draftId,
+                    articleId = articleId,
                     onSaveSuccess = {
                         navController.popBackStack()
                     },
-                    onPublishSuccess = { articleId ->
-                        navController.popBackStack()
-                        navController.navigate(DetailScreen.PostDetail.createRoute(articleId))
+                    onPublishSuccess = { updatedId ->
+                        if (articleId != null) {
+                            navController.popBackStack()
+                        } else {
+                            navController.popBackStack()
+                            navController.navigate(DetailScreen.PostDetail.createRoute(updatedId))
+                        }
                     },
                     onNavigateBack = {
                         navController.popBackStack()

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
@@ -56,6 +56,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import pub.hackers.android.R
+import pub.hackers.android.ui.components.HtmlContent
+import pub.hackers.android.ui.components.HtmlContentStyle
+import pub.hackers.android.ui.components.markdownToHtml
 import pub.hackers.android.ui.theme.AppShapes
 import pub.hackers.android.ui.theme.LocalAppColors
 import pub.hackers.android.ui.theme.LocalAppTypography
@@ -220,9 +223,29 @@ fun ComposeArticleScreen(
 
                 Spacer(modifier = Modifier.height(16.dp))
                 HorizontalDivider(color = colors.divider)
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(8.dp))
 
-                // Content field
+                // Edit / Preview toggle
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    ComposePreviewToggle(
+                        label = stringResource(R.string.compose_edit),
+                        selected = !uiState.isPreview,
+                        onClick = { viewModel.setPreview(false) }
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    ComposePreviewToggle(
+                        label = stringResource(R.string.compose_preview),
+                        selected = uiState.isPreview,
+                        onClick = { viewModel.setPreview(true) }
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // Content field / preview
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(4.dp),
@@ -233,39 +256,59 @@ fun ComposeArticleScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(400.dp)
-                            .clickable(
-                                interactionSource = remember { MutableInteractionSource() },
-                                indication = null
-                            ) {
-                                contentFocusRequester.requestFocus()
-                                keyboardController?.show()
-                            }
+                            .then(
+                                if (!uiState.isPreview) Modifier.clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null
+                                ) {
+                                    contentFocusRequester.requestFocus()
+                                    keyboardController?.show()
+                                } else Modifier
+                            )
                             .padding(16.dp)
                     ) {
-                        BasicTextField(
-                            value = uiState.content,
-                            onValueChange = { viewModel.updateContent(it) },
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .focusRequester(contentFocusRequester),
-                            enabled = !uiState.isSaving && !uiState.isPublishing,
-                            textStyle = typography.bodyLarge.copy(
-                                color = colors.textBody
-                            ),
-                            cursorBrush = SolidColor(colors.composeAccent),
-                            decorationBox = { innerTextField ->
-                                Box {
-                                    if (uiState.content.isEmpty()) {
-                                        Text(
-                                            text = stringResource(R.string.article_content_hint),
-                                            style = typography.bodyLarge,
-                                            color = colors.textSecondary
-                                        )
-                                    }
-                                    innerTextField()
+                        if (uiState.isPreview) {
+                            if (uiState.content.isBlank()) {
+                                Text(
+                                    text = stringResource(R.string.compose_preview_empty),
+                                    style = typography.bodyLarge,
+                                    color = colors.textSecondary
+                                )
+                            } else {
+                                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                                    HtmlContent(
+                                        html = markdownToHtml(uiState.content),
+                                        modifier = Modifier.fillMaxWidth(),
+                                        contentStyle = HtmlContentStyle.Prose
+                                    )
                                 }
                             }
-                        )
+                        } else {
+                            BasicTextField(
+                                value = uiState.content,
+                                onValueChange = { viewModel.updateContent(it) },
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .focusRequester(contentFocusRequester),
+                                enabled = !uiState.isSaving && !uiState.isPublishing,
+                                textStyle = typography.bodyLarge.copy(
+                                    color = colors.textBody
+                                ),
+                                cursorBrush = SolidColor(colors.composeAccent),
+                                decorationBox = { innerTextField ->
+                                    Box {
+                                        if (uiState.content.isEmpty()) {
+                                            Text(
+                                                text = stringResource(R.string.article_content_hint),
+                                                style = typography.bodyLarge,
+                                                color = colors.textSecondary
+                                            )
+                                        }
+                                        innerTextField()
+                                    }
+                                }
+                            )
+                        }
                     }
                 }
             }
@@ -480,4 +523,22 @@ fun ComposeArticleScreen(
             }
         }
     }
+}
+
+@Composable
+private fun ComposePreviewToggle(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+    Text(
+        text = label,
+        style = typography.labelMedium,
+        color = if (selected) colors.composeAccent else colors.textSecondary,
+        modifier = Modifier
+            .clickable(onClick = onClick)
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    )
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -55,7 +56,10 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.material3.CircularProgressIndicator
 import pub.hackers.android.R
+import pub.hackers.android.ui.components.HtmlContent
+import pub.hackers.android.ui.components.HtmlContentStyle
 import pub.hackers.android.ui.theme.AppShapes
 import pub.hackers.android.ui.theme.LocalAppColors
 import pub.hackers.android.ui.theme.LocalAppTypography
@@ -220,9 +224,40 @@ fun ComposeArticleScreen(
 
                 Spacer(modifier = Modifier.height(16.dp))
                 HorizontalDivider(color = colors.divider)
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(8.dp))
 
-                // Content field
+                if (!uiState.isEditMode) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        if (uiState.isLoadingPreview) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(16.dp),
+                                strokeWidth = 2.dp,
+                                color = colors.composeAccent
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                        }
+                        ComposePreviewToggle(
+                            label = stringResource(R.string.compose_edit),
+                            selected = !uiState.isPreview,
+                            enabled = !uiState.isLoadingPreview,
+                            onClick = { if (uiState.isPreview) viewModel.togglePreview() }
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        ComposePreviewToggle(
+                            label = stringResource(R.string.compose_preview),
+                            selected = uiState.isPreview,
+                            enabled = !uiState.isLoadingPreview,
+                            onClick = { if (!uiState.isPreview) viewModel.togglePreview() }
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+
+                // Content field / preview
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(4.dp),
@@ -233,39 +268,59 @@ fun ComposeArticleScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(400.dp)
-                            .clickable(
-                                interactionSource = remember { MutableInteractionSource() },
-                                indication = null
-                            ) {
-                                contentFocusRequester.requestFocus()
-                                keyboardController?.show()
-                            }
+                            .then(
+                                if (!uiState.isPreview) Modifier.clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null
+                                ) {
+                                    contentFocusRequester.requestFocus()
+                                    keyboardController?.show()
+                                } else Modifier
+                            )
                             .padding(16.dp)
                     ) {
-                        BasicTextField(
-                            value = uiState.content,
-                            onValueChange = { viewModel.updateContent(it) },
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .focusRequester(contentFocusRequester),
-                            enabled = !uiState.isSaving && !uiState.isPublishing,
-                            textStyle = typography.bodyLarge.copy(
-                                color = colors.textBody
-                            ),
-                            cursorBrush = SolidColor(colors.composeAccent),
-                            decorationBox = { innerTextField ->
-                                Box {
-                                    if (uiState.content.isEmpty()) {
-                                        Text(
-                                            text = stringResource(R.string.article_content_hint),
-                                            style = typography.bodyLarge,
-                                            color = colors.textSecondary
-                                        )
-                                    }
-                                    innerTextField()
+                        if (uiState.isPreview) {
+                            if (uiState.previewHtml.isBlank()) {
+                                Text(
+                                    text = stringResource(R.string.compose_preview_empty),
+                                    style = typography.bodyLarge,
+                                    color = colors.textSecondary
+                                )
+                            } else {
+                                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                                    HtmlContent(
+                                        html = uiState.previewHtml,
+                                        modifier = Modifier.fillMaxWidth(),
+                                        contentStyle = HtmlContentStyle.Prose
+                                    )
                                 }
                             }
-                        )
+                        } else {
+                            BasicTextField(
+                                value = uiState.content,
+                                onValueChange = { viewModel.updateContent(it) },
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .focusRequester(contentFocusRequester),
+                                enabled = !uiState.isSaving && !uiState.isPublishing,
+                                textStyle = typography.bodyLarge.copy(
+                                    color = colors.textBody
+                                ),
+                                cursorBrush = SolidColor(colors.composeAccent),
+                                decorationBox = { innerTextField ->
+                                    Box {
+                                        if (uiState.content.isEmpty()) {
+                                            Text(
+                                                text = stringResource(R.string.article_content_hint),
+                                                style = typography.bodyLarge,
+                                                color = colors.textSecondary
+                                            )
+                                        }
+                                        innerTextField()
+                                    }
+                                }
+                            )
+                        }
                     }
                 }
             }
@@ -480,4 +535,24 @@ fun ComposeArticleScreen(
             }
         }
     }
+}
+
+@Composable
+private fun ComposePreviewToggle(
+    label: String,
+    selected: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+    Text(
+        text = label,
+        style = typography.labelMedium,
+        color = if (selected) colors.composeAccent else colors.textSecondary,
+        modifier = Modifier
+            .clickable(enabled = enabled, onClick = onClick)
+            .alpha(if (enabled) 1f else 0.5f)
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    )
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
@@ -56,9 +56,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import pub.hackers.android.R
-import pub.hackers.android.ui.components.HtmlContent
-import pub.hackers.android.ui.components.HtmlContentStyle
-import pub.hackers.android.ui.components.markdownToHtml
 import pub.hackers.android.ui.theme.AppShapes
 import pub.hackers.android.ui.theme.LocalAppColors
 import pub.hackers.android.ui.theme.LocalAppTypography
@@ -223,29 +220,9 @@ fun ComposeArticleScreen(
 
                 Spacer(modifier = Modifier.height(16.dp))
                 HorizontalDivider(color = colors.divider)
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(16.dp))
 
-                // Edit / Preview toggle
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End
-                ) {
-                    ComposePreviewToggle(
-                        label = stringResource(R.string.compose_edit),
-                        selected = !uiState.isPreview,
-                        onClick = { viewModel.setPreview(false) }
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    ComposePreviewToggle(
-                        label = stringResource(R.string.compose_preview),
-                        selected = uiState.isPreview,
-                        onClick = { viewModel.setPreview(true) }
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                // Content field / preview
+                // Content field
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(4.dp),
@@ -256,59 +233,39 @@ fun ComposeArticleScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(400.dp)
-                            .then(
-                                if (!uiState.isPreview) Modifier.clickable(
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    indication = null
-                                ) {
-                                    contentFocusRequester.requestFocus()
-                                    keyboardController?.show()
-                                } else Modifier
-                            )
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) {
+                                contentFocusRequester.requestFocus()
+                                keyboardController?.show()
+                            }
                             .padding(16.dp)
                     ) {
-                        if (uiState.isPreview) {
-                            if (uiState.content.isBlank()) {
-                                Text(
-                                    text = stringResource(R.string.compose_preview_empty),
-                                    style = typography.bodyLarge,
-                                    color = colors.textSecondary
-                                )
-                            } else {
-                                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                                    HtmlContent(
-                                        html = markdownToHtml(uiState.content),
-                                        modifier = Modifier.fillMaxWidth(),
-                                        contentStyle = HtmlContentStyle.Prose
-                                    )
+                        BasicTextField(
+                            value = uiState.content,
+                            onValueChange = { viewModel.updateContent(it) },
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .focusRequester(contentFocusRequester),
+                            enabled = !uiState.isSaving && !uiState.isPublishing,
+                            textStyle = typography.bodyLarge.copy(
+                                color = colors.textBody
+                            ),
+                            cursorBrush = SolidColor(colors.composeAccent),
+                            decorationBox = { innerTextField ->
+                                Box {
+                                    if (uiState.content.isEmpty()) {
+                                        Text(
+                                            text = stringResource(R.string.article_content_hint),
+                                            style = typography.bodyLarge,
+                                            color = colors.textSecondary
+                                        )
+                                    }
+                                    innerTextField()
                                 }
                             }
-                        } else {
-                            BasicTextField(
-                                value = uiState.content,
-                                onValueChange = { viewModel.updateContent(it) },
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .focusRequester(contentFocusRequester),
-                                enabled = !uiState.isSaving && !uiState.isPublishing,
-                                textStyle = typography.bodyLarge.copy(
-                                    color = colors.textBody
-                                ),
-                                cursorBrush = SolidColor(colors.composeAccent),
-                                decorationBox = { innerTextField ->
-                                    Box {
-                                        if (uiState.content.isEmpty()) {
-                                            Text(
-                                                text = stringResource(R.string.article_content_hint),
-                                                style = typography.bodyLarge,
-                                                color = colors.textSecondary
-                                            )
-                                        }
-                                        innerTextField()
-                                    }
-                                }
-                            )
-                        }
+                        )
                     }
                 }
             }
@@ -523,22 +480,4 @@ fun ComposeArticleScreen(
             }
         }
     }
-}
-
-@Composable
-private fun ComposePreviewToggle(
-    label: String,
-    selected: Boolean,
-    onClick: () -> Unit
-) {
-    val colors = LocalAppColors.current
-    val typography = LocalAppTypography.current
-    Text(
-        text = label,
-        style = typography.labelMedium,
-        color = if (selected) colors.composeAccent else colors.textSecondary,
-        modifier = Modifier
-            .clickable(onClick = onClick)
-            .padding(horizontal = 8.dp, vertical = 4.dp)
-    )
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleScreen.kt
@@ -63,6 +63,7 @@ import pub.hackers.android.ui.theme.LocalAppTypography
 @Composable
 fun ComposeArticleScreen(
     draftId: String? = null,
+    articleId: String? = null,
     onSaveSuccess: () -> Unit,
     onPublishSuccess: (articleId: String) -> Unit,
     onNavigateBack: () -> Unit,
@@ -80,6 +81,10 @@ fun ComposeArticleScreen(
 
     LaunchedEffect(draftId) {
         draftId?.let { viewModel.loadDraft(it) }
+    }
+
+    LaunchedEffect(articleId) {
+        articleId?.let { viewModel.loadArticleForEdit(it) }
     }
 
     LaunchedEffect(uiState.isSaved) {
@@ -108,13 +113,14 @@ fun ComposeArticleScreen(
     }
 
     LaunchedEffect(Unit) {
-        if (draftId == null) {
+        if (draftId == null && articleId == null) {
             titleFocusRequester.requestFocus()
         }
     }
 
     val saveEnabled = uiState.title.isNotBlank() && !uiState.isSaving && !uiState.isPublishing
     val publishEnabled = uiState.title.isNotBlank() && !uiState.isSaving && !uiState.isPublishing
+    val updateEnabled = uiState.title.isNotBlank() && !uiState.isLoadingArticle && !uiState.isPublishing
 
     Scaffold(
         contentWindowInsets = WindowInsets(0),
@@ -135,7 +141,9 @@ fun ComposeArticleScreen(
                     )
                 }
                 Text(
-                    text = stringResource(R.string.compose_article),
+                    text = stringResource(
+                        if (uiState.isEditMode) R.string.edit_article else R.string.compose_article
+                    ),
                     style = typography.titleLarge,
                     color = colors.textPrimary,
                     modifier = Modifier.align(Alignment.Center)
@@ -392,8 +400,38 @@ fun ComposeArticleScreen(
                 }
             }
 
-            // Bottom bar with Save Draft + Publish buttons
-            if (!uiState.showPublishFields) {
+            // Bottom bar — Update button in edit mode, Save Draft + Publish otherwise
+            if (uiState.isEditMode) {
+                HorizontalDivider(color = colors.divider)
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    Button(
+                        onClick = { viewModel.updateArticle() },
+                        enabled = updateEnabled,
+                        shape = RoundedCornerShape(AppShapes.pillRadius),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = colors.composeAccent,
+                            contentColor = colors.composeOnAccent,
+                            disabledContainerColor = colors.composeAccent,
+                            disabledContentColor = colors.composeOnAccent,
+                        ),
+                        modifier = Modifier.alpha(if (updateEnabled) 1f else 0.4f)
+                    ) {
+                        Text(
+                            text = if (uiState.isPublishing) {
+                                stringResource(R.string.updating_article)
+                            } else {
+                                stringResource(R.string.update_article)
+                            },
+                            color = colors.composeOnAccent
+                        )
+                    }
+                }
+            } else if (!uiState.showPublishFields) {
                 HorizontalDivider(color = colors.divider)
                 Row(
                     modifier = Modifier

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
@@ -34,7 +34,6 @@ data class ComposeArticleUiState(
     val isPublished: Boolean = false,
     val publishedArticleId: String? = null,
     val publishedArticleUrl: String? = null,
-    val isPreview: Boolean = false,
     val error: String? = null
 )
 
@@ -163,10 +162,6 @@ class ComposeArticleViewModel @Inject constructor(
 
     fun updateAllowLlmTranslation(allow: Boolean) {
         _uiState.update { it.copy(allowLlmTranslation = allow) }
-    }
-
-    fun setPreview(preview: Boolean) {
-        _uiState.update { it.copy(isPreview = preview) }
     }
 
     fun saveDraft() {

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
@@ -21,6 +21,9 @@ data class ComposeArticleUiState(
     val content: String = "",
     val tags: String = "",
     val draftId: String? = null,
+    val articleId: String? = null,
+    val isEditMode: Boolean = false,
+    val isLoadingArticle: Boolean = false,
     val isSaving: Boolean = false,
     val isSaved: Boolean = false,
     val slug: String = "",
@@ -60,6 +63,73 @@ class ComposeArticleViewModel @Inject constructor(
                 }
                 .onFailure { error ->
                     _uiState.update { it.copy(error = error.message) }
+                }
+        }
+    }
+
+    fun loadArticleForEdit(articleId: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingArticle = true, isEditMode = true, articleId = articleId) }
+            repository.getEditableArticle(articleId)
+                .onSuccess { article ->
+                    _uiState.update {
+                        it.copy(
+                            title = article.title,
+                            content = article.content,
+                            tags = article.tags.joinToString(", "),
+                            language = article.language.ifBlank { it.language },
+                            allowLlmTranslation = article.allowLlmTranslation,
+                            isLoadingArticle = false
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(error = error.message, isLoadingArticle = false)
+                    }
+                }
+        }
+    }
+
+    fun updateArticle() {
+        val state = _uiState.value
+        val articleId = state.articleId ?: return
+        if (state.title.isBlank()) {
+            _uiState.update { it.copy(error = "Title is required") }
+            return
+        }
+        if (state.isPublishing) return
+
+        val tagsList = state.tags
+            .split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPublishing = true, error = null) }
+
+            repository.updateArticle(
+                articleId = articleId,
+                title = state.title,
+                content = state.content,
+                tags = tagsList,
+                language = state.language,
+                allowLlmTranslation = state.allowLlmTranslation
+            )
+                .onSuccess { article ->
+                    _uiState.update {
+                        it.copy(
+                            isPublishing = false,
+                            isPublished = true,
+                            publishedArticleId = article.id,
+                            publishedArticleUrl = article.url
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(error = error.message, isPublishing = false)
+                    }
                 }
         }
     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
@@ -34,6 +34,7 @@ data class ComposeArticleUiState(
     val isPublished: Boolean = false,
     val publishedArticleId: String? = null,
     val publishedArticleUrl: String? = null,
+    val isPreview: Boolean = false,
     val error: String? = null
 )
 
@@ -162,6 +163,10 @@ class ComposeArticleViewModel @Inject constructor(
 
     fun updateAllowLlmTranslation(allow: Boolean) {
         _uiState.update { it.copy(allowLlmTranslation = allow) }
+    }
+
+    fun setPreview(preview: Boolean) {
+        _uiState.update { it.copy(isPreview = preview) }
     }
 
     fun saveDraft() {

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeArticleViewModel.kt
@@ -34,6 +34,10 @@ data class ComposeArticleUiState(
     val isPublished: Boolean = false,
     val publishedArticleId: String? = null,
     val publishedArticleUrl: String? = null,
+    val isPreview: Boolean = false,
+    val previewHtml: String = "",
+    val previewContent: String? = null,
+    val isLoadingPreview: Boolean = false,
     val error: String? = null
 )
 
@@ -56,7 +60,9 @@ class ComposeArticleViewModel @Inject constructor(
                             content = draft.content,
                             tags = draft.tags.joinToString(", "),
                             draftId = draft.id,
-                            slug = generateSlug(draft.title)
+                            slug = generateSlug(draft.title),
+                            previewHtml = draft.contentHtml,
+                            previewContent = draft.content
                         )
                     }
                     detectLanguage(draft.content)
@@ -164,6 +170,51 @@ class ComposeArticleViewModel @Inject constructor(
         _uiState.update { it.copy(allowLlmTranslation = allow) }
     }
 
+    fun togglePreview() {
+        val state = _uiState.value
+        if (state.isPreview) {
+            _uiState.update { it.copy(isPreview = false) }
+            return
+        }
+        if (state.title.isBlank()) {
+            _uiState.update { it.copy(error = "Title is required") }
+            return
+        }
+        if (state.content == state.previewContent && state.previewHtml.isNotEmpty()) {
+            _uiState.update { it.copy(isPreview = true) }
+            return
+        }
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingPreview = true, error = null) }
+            val tagsList = state.tags
+                .split(",")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+            repository.saveArticleDraft(
+                title = state.title,
+                content = state.content,
+                tags = tagsList,
+                id = state.draftId
+            )
+                .onSuccess { draft ->
+                    _uiState.update {
+                        it.copy(
+                            draftId = draft.id,
+                            previewHtml = draft.contentHtml,
+                            previewContent = draft.content,
+                            isPreview = true,
+                            isLoadingPreview = false
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(error = error.message, isLoadingPreview = false)
+                    }
+                }
+        }
+    }
+
     fun saveDraft() {
         val state = _uiState.value
         if (state.title.isBlank()) {
@@ -191,7 +242,9 @@ class ComposeArticleViewModel @Inject constructor(
                         it.copy(
                             isSaving = false,
                             isSaved = true,
-                            draftId = draft.id
+                            draftId = draft.id,
+                            previewHtml = draft.contentHtml,
+                            previewContent = draft.content
                         )
                     }
                 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -464,6 +464,7 @@ fun PostDetailScreen(
             ) {
                 FloatingActionButton(
                     onClick = onScrollToTop,
+                    shape = CircleShape,
                     containerColor = colors.surface,
                     contentColor = colors.accent
                 ) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.filled.Repeat
@@ -140,6 +141,7 @@ fun PostDetailScreen(
     onReplyClick: (String) -> Unit,
     onQuoteClick: (String) -> Unit = {},
     onPostClick: (String) -> Unit,
+    onEditArticleClick: (String) -> Unit = {},
     isLoggedIn: Boolean = true,
     viewModel: PostDetailViewModel = hiltViewModel()
 ) {
@@ -388,7 +390,7 @@ fun PostDetailScreen(
                         )
                     }
                 },
-                trailingContent = if (tocAvailable || uiState.canDelete) {
+                trailingContent = if (tocAvailable || uiState.canDelete || uiState.canEdit) {
                     {
                         if (tocAvailable) {
                             IconButton(onClick = { showTocSheet = true }) {
@@ -406,9 +408,12 @@ fun PostDetailScreen(
                                 )
                             }
                         }
-                        if (uiState.canDelete) {
+                        if (uiState.canDelete || uiState.canEdit) {
                             PostDetailActionMenu(
                                 isDeleting = uiState.isDeleting,
+                                canEdit = uiState.canEdit,
+                                canDelete = uiState.canDelete,
+                                onEdit = { onEditArticleClick(postId) },
                                 onDelete = {
                                     if (confirmBeforeDelete) {
                                         showDeleteConfirmation = true
@@ -512,6 +517,9 @@ fun PostDetailScreen(
 @Composable
 private fun PostDetailActionMenu(
     isDeleting: Boolean,
+    canEdit: Boolean,
+    canDelete: Boolean,
+    onEdit: () -> Unit,
     onDelete: () -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -529,26 +537,49 @@ private fun PostDetailActionMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false }
         ) {
-            DropdownMenuItem(
-                text = {
-                    Text(
-                        text = stringResource(R.string.delete_post),
-                        color = colors.reaction
-                    )
-                },
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Filled.Delete,
-                        contentDescription = null,
-                        tint = colors.reaction
-                    )
-                },
-                onClick = {
-                    expanded = false
-                    onDelete()
-                },
-                enabled = !isDeleting
-            )
+            if (canEdit) {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = stringResource(R.string.edit_article),
+                            color = colors.textPrimary
+                        )
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Filled.Edit,
+                            contentDescription = null,
+                            tint = colors.textPrimary
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onEdit()
+                    }
+                )
+            }
+            if (canDelete) {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = stringResource(R.string.delete_post),
+                            color = colors.reaction
+                        )
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = null,
+                            tint = colors.reaction
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onDelete()
+                    },
+                    enabled = !isDeleting
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -56,8 +56,9 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.LargeFloatingActionButton
 import androidx.compose.runtime.derivedStateOf
+import androidx.compose.ui.zIndex
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -434,37 +435,16 @@ fun PostDetailScreen(
             )
         },
         floatingActionButton = {
-            Column(
-                horizontalAlignment = Alignment.End,
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                AnimatedVisibility(
-                    visible = showScrollToTop,
-                    enter = fadeIn() + scaleIn(),
-                    exit = fadeOut() + scaleOut()
+            if (uiState.post != null && isLoggedIn) {
+                FloatingActionButton(
+                    onClick = { onReplyClick(postId) },
+                    containerColor = colors.composeAccent,
+                    contentColor = colors.composeOnAccent
                 ) {
-                    SmallFloatingActionButton(
-                        onClick = onScrollToTop,
-                        containerColor = colors.surface,
-                        contentColor = colors.accent
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.KeyboardArrowUp,
-                            contentDescription = stringResource(R.string.scroll_to_top)
-                        )
-                    }
-                }
-                if (uiState.post != null && isLoggedIn) {
-                    FloatingActionButton(
-                        onClick = { onReplyClick(postId) },
-                        containerColor = colors.composeAccent,
-                        contentColor = colors.composeOnAccent
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.Reply,
-                            contentDescription = stringResource(R.string.reply)
-                        )
-                    }
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.Reply,
+                        contentDescription = stringResource(R.string.reply)
+                    )
                 }
             }
         }
@@ -474,6 +454,27 @@ fun PostDetailScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
+            AnimatedVisibility(
+                visible = showScrollToTop,
+                enter = fadeIn() + scaleIn(),
+                exit = fadeOut() + scaleOut(),
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 12.dp, end = 16.dp)
+                    .zIndex(1f)
+            ) {
+                LargeFloatingActionButton(
+                    onClick = onScrollToTop,
+                    containerColor = colors.surface,
+                    contentColor = colors.accent
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.KeyboardArrowUp,
+                        contentDescription = stringResource(R.string.scroll_to_top),
+                        modifier = Modifier.size(36.dp)
+                    )
+                }
+            }
             val post = uiState.post
             PostDetailStateDispatch(
                 post = post,

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -56,7 +56,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.LargeFloatingActionButton
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.zIndex
 import androidx.compose.material3.HorizontalDivider
@@ -463,15 +462,14 @@ fun PostDetailScreen(
                     .padding(top = 12.dp, end = 16.dp)
                     .zIndex(1f)
             ) {
-                LargeFloatingActionButton(
+                FloatingActionButton(
                     onClick = onScrollToTop,
                     containerColor = colors.surface,
                     contentColor = colors.accent
                 ) {
                     Icon(
                         imageVector = Icons.Filled.KeyboardArrowUp,
-                        contentDescription = stringResource(R.string.scroll_to_top),
-                        modifier = Modifier.size(36.dp)
+                        contentDescription = stringResource(R.string.scroll_to_top)
                     )
                 }
             }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -50,7 +50,14 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -177,6 +184,12 @@ fun PostDetailScreen(
         { screenScope.launch { lazyListState.animateScrollToItem(0, 0) } }
     }
     val tocAvailable = uiState.post?.typename == "Article" && uiState.toc.isNotEmpty()
+    val showScrollToTop by remember {
+        derivedStateOf {
+            lazyListState.firstVisibleItemIndex > 0 ||
+                lazyListState.firstVisibleItemScrollOffset > 600
+        }
+    }
 
     var activeHeadingId by remember(postId) { mutableStateOf<String?>(null) }
     LaunchedEffect(lazyListState, postId) {
@@ -400,13 +413,6 @@ fun PostDetailScreen(
                                     tint = colors.accent,
                                 )
                             }
-                            IconButton(onClick = onScrollToTop) {
-                                Icon(
-                                    imageVector = Icons.Filled.KeyboardArrowUp,
-                                    contentDescription = stringResource(R.string.scroll_to_top),
-                                    tint = colors.accent,
-                                )
-                            }
                         }
                         if (uiState.canDelete || uiState.canEdit) {
                             PostDetailActionMenu(
@@ -428,16 +434,37 @@ fun PostDetailScreen(
             )
         },
         floatingActionButton = {
-            if (uiState.post != null && isLoggedIn) {
-                FloatingActionButton(
-                    onClick = { onReplyClick(postId) },
-                    containerColor = colors.composeAccent,
-                    contentColor = colors.composeOnAccent
+            Column(
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                AnimatedVisibility(
+                    visible = showScrollToTop,
+                    enter = fadeIn() + scaleIn(),
+                    exit = fadeOut() + scaleOut()
                 ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.Reply,
-                        contentDescription = stringResource(R.string.reply)
-                    )
+                    SmallFloatingActionButton(
+                        onClick = onScrollToTop,
+                        containerColor = colors.surface,
+                        contentColor = colors.accent
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.KeyboardArrowUp,
+                            contentDescription = stringResource(R.string.scroll_to_top)
+                        )
+                    }
+                }
+                if (uiState.post != null && isLoggedIn) {
+                    FloatingActionButton(
+                        onClick = { onReplyClick(postId) },
+                        containerColor = colors.composeAccent,
+                        contentColor = colors.composeOnAccent
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.Reply,
+                            contentDescription = stringResource(R.string.reply)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
@@ -34,6 +34,7 @@ data class PostDetailUiState(
     val isRefreshing: Boolean = false,
     val error: String? = null,
     val canDelete: Boolean = false,
+    val canEdit: Boolean = false,
     val isDeleting: Boolean = false,
     val deleteError: String? = null,
     val isDeleted: Boolean = false,
@@ -111,9 +112,10 @@ class PostDetailViewModel @Inject constructor(
             repository.getPostDetail(id)
                 .onSuccess { result ->
                     val viewerHandle = sessionManager.userHandle.first()
-                    val canDelete = viewerHandle != null &&
+                    val isOwner = viewerHandle != null &&
                         result.post.actor.handle.equals(viewerHandle, ignoreCase = true) &&
                         result.post.sharedPost == null
+                    val canEdit = isOwner && result.post.typename == "Article"
 
                     _uiState.update {
                         it.copy(
@@ -121,7 +123,8 @@ class PostDetailViewModel @Inject constructor(
                             reactionGroups = result.reactionGroups,
                             toc = result.toc,
                             isLoading = false,
-                            canDelete = canDelete
+                            canDelete = isOwner,
+                            canEdit = canEdit
                         )
                     }
                 }
@@ -144,9 +147,10 @@ class PostDetailViewModel @Inject constructor(
             repository.getPostDetail(postId)
                 .onSuccess { result ->
                     val viewerHandle = sessionManager.userHandle.first()
-                    val canDelete = viewerHandle != null &&
+                    val isOwner = viewerHandle != null &&
                         result.post.actor.handle.equals(viewerHandle, ignoreCase = true) &&
                         result.post.sharedPost == null
+                    val canEdit = isOwner && result.post.typename == "Article"
 
                     _uiState.update {
                         it.copy(
@@ -154,7 +158,8 @@ class PostDetailViewModel @Inject constructor(
                             reactionGroups = result.reactionGroups,
                             toc = result.toc,
                             isRefreshing = false,
-                            canDelete = canDelete
+                            canDelete = isOwner,
+                            canEdit = canEdit
                         )
                     }
                 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
@@ -115,7 +115,9 @@ class PostDetailViewModel @Inject constructor(
                     val isOwner = viewerHandle != null &&
                         result.post.actor.handle.equals(viewerHandle, ignoreCase = true) &&
                         result.post.sharedPost == null
-                    val canEdit = isOwner && result.post.typename == "Article"
+                    val canEdit = isOwner &&
+                        result.post.typename == "Article" &&
+                        pub.hackers.android.FeatureFlags.ARTICLE_EDIT_ENABLED
 
                     _uiState.update {
                         it.copy(
@@ -150,7 +152,9 @@ class PostDetailViewModel @Inject constructor(
                     val isOwner = viewerHandle != null &&
                         result.post.actor.handle.equals(viewerHandle, ignoreCase = true) &&
                         result.post.sharedPost == null
-                    val canEdit = isOwner && result.post.typename == "Article"
+                    val canEdit = isOwner &&
+                        result.post.typename == "Article" &&
+                        pub.hackers.android.FeatureFlags.ARTICLE_EDIT_ENABLED
 
                     _uiState.update {
                         it.copy(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,9 @@
     <string name="publish_confirm_title">Publish Article</string>
     <string name="article_slug_required">Slug is required</string>
     <string name="allow_llm_translation">Allow LLM translation</string>
+    <string name="edit_article">Edit Article</string>
+    <string name="update_article">Update</string>
+    <string name="updating_article">Updating…</string>
 
     <!-- Drafts -->
     <string name="my_drafts">My Drafts</string>


### PR DESCRIPTION
## Summary
Adds an Edit entry to the article detail action menu (gated by `ARTICLE_EDIT_ENABLED`, off by default until `updateArticle` is deployed to prod) that opens `ComposeArticleScreen` preloaded from the original `ArticleContent` and commits changes via the new `updateArticle` mutation. Also adds a server-rendered preview toggle for draft composition that calls `saveArticleDraft` and renders the returned `contentHtml`. Lastly, moves scroll-to-top out of the crowded top bar into a circular FAB pinned to the content's top-right that fades in only after scrolling past the fold.

---
Assisted-By: Claude Code(claude-opus-4-7)