### PR TITLE
Fix Compose, startup, and lint issues

### DIFF
--- a/CONVENTION.md
+++ b/CONVENTION.md
@@ -157,6 +157,19 @@ Composable parameters follow the Compose API Guidelines for `Modifier`:
 
 This is an established convention in the project — see commit `0e92f03` (PR #86) which refactored `HtmlContent` specifically to fix a violation, and every `ui/components/*.kt` Composable follows the pattern.
 
+### §5.5 Read configuration from Compose state
+
+When a Composable needs locale / screen / orientation-dependent values from the current Android configuration, read `LocalConfiguration.current` instead of reaching through `LocalContext.current.resources.configuration`.
+
+- `LocalContext.current.resources.configuration` is not tracked as Compose state, so configuration changes can leave the caller with stale values.
+- `LocalConfiguration.current` invalidates and recomposes correctly when the `Configuration` changes.
+- If code only needs resources lookup (`getString`, dimensions, etc.), `stringResource(...)` and other Compose resource APIs remain preferred. Use `LocalConfiguration.current` specifically when you need the `Configuration` object itself.
+
+Reference examples:
+
+- `ui/components/PostCard.kt` translation locale selection
+- `ui/screens/postdetail/PostDetailScreen.kt` translation locale selection
+
 ---
 
 ## §6 ViewModel and state

--- a/CONVENTION.md
+++ b/CONVENTION.md
@@ -296,6 +296,14 @@ The `debug` build type sets `applicationIdSuffix = ".dev"` and ships a distinct 
 
 `release` build type has `isMinifyEnabled = true`. Don't disable minification to "make debugging easier" — add the missing keep rule instead.
 
+### §10.5 Run lint before pushing
+
+Run `./gradlew :app:lintDebug` after finishing each task and again right before `git push`. The target is **0 errors** — warnings are tolerated but new warnings should be justified in the PR body.
+
+Lint catches problems that `compileDebugKotlin` and unit tests do not: manifest issues, API-level traps (§13), resource hygiene, and typographic issues. Compilation passing does not mean lint passes.
+
+For a **genuine false positive** (e.g., the AGP 9.1.1 `Instantiatable` bug on `@AndroidEntryPoint` activities), suppress narrowly at the single call site with `tools:ignore="..."` or a `//noinspection` comment, and cite the upstream issue in the commit message. Do not disable a check globally via `lintOptions { disable ... }` — it hides future real failures of the same kind.
+
 ---
 
 ## §11 Localization and accessibility
@@ -373,6 +381,7 @@ AI code-completion tools frequently suggest API calls that match the intent but 
 | §6.3 | One-shot events → `Channel` / `SharedFlow` |
 | §7.1 | Repository returns `Result<T>` |
 | §10.1 | Dependencies → Version Catalog |
+| §10.5 | Run `./gradlew :app:lintDebug` before pushing; target 0 errors |
 | §11.1 | No hardcoded user-facing strings |
 | §11.2 | `contentDescription` on interactive icons |
 | §12.2 | Don't commit generated Apollo code |

--- a/CONVENTION.md
+++ b/CONVENTION.md
@@ -306,6 +306,8 @@ All user-visible text goes through `stringResource(R.string.xxx)`. No string lit
 
 String keys are descriptive: `error_no_network`, not `msg3`.
 
+Use the single ellipsis character (`…`) instead of three periods (`...`) in user-facing strings.
+
 ### §11.2 `contentDescription` on interactive icons
 
 Every `Icon`, `IconButton`, `AsyncImage` that carries meaning requires a `contentDescription`, usually sourced from `stringResource`. Decorative-only icons pass `contentDescription = null` explicitly — the argument is never omitted.

--- a/CONVENTION.md
+++ b/CONVENTION.md
@@ -170,6 +170,19 @@ Reference examples:
 - `ui/components/PostCard.kt` translation locale selection
 - `ui/screens/postdetail/PostDetailScreen.kt` translation locale selection
 
+### §5.6 Avoid unnecessary `LocalContext` and `Activity` dependencies
+
+Do not read `LocalContext.current` just to satisfy an obsolete parameter or to pass context through layers that do not need it. In Compose, every `LocalContext.current` read is still a composition-local dependency; keep it scoped to the smallest call site that actually uses Android context APIs.
+
+- Prefer removing the context parameter entirely when the callee already owns the context it needs.
+- Prefer `Context` over `Activity` unless the called API explicitly requires an `Activity` or an activity-bound lifecycle/window token.
+- Do not cast `LocalContext.current as Activity` speculatively. If an API can operate with `Context`, keep the UI and ViewModel signatures context-free or `Context`-based.
+
+Reference examples:
+
+- Passkey sign-in uses the `PasskeyManager`'s injected application context instead of threading an `Activity` through `SignInScreen` / `SignInViewModel`.
+- Passkey registration accepts a `Context` from `SettingsScreen` only where Credential Manager registration is initiated.
+
 ---
 
 ## §6 ViewModel and state

--- a/CONVENTION.md
+++ b/CONVENTION.md
@@ -183,6 +183,18 @@ Reference examples:
 - Passkey sign-in uses the `PasskeyManager`'s injected application context instead of threading an `Activity` through `SignInScreen` / `SignInViewModel`.
 - Passkey registration accepts a `Context` from `SettingsScreen` only where Credential Manager registration is initiated.
 
+### §5.7 Do not read frequently changing state in composition
+
+Values annotated with `@FrequentlyChangingValue` should not be read directly in Composable function bodies. Reading them during composition makes that composition depend on high-frequency updates and can cause avoidable recompositions.
+
+- Use `derivedStateOf` only when the derived result changes much less often than the source value, such as reducing scroll position to "at top" / "not at top".
+- Use `snapshotFlow` inside `LaunchedEffect` when a frequently changing value needs to drive state updates or side effects without being read directly by composition.
+- Prefer layout- or draw-phase reads, such as lambda-based modifiers, when the value only affects placement or drawing.
+
+Reference example:
+
+- `ui/screens/compose/ComposeScreen.kt` mention autocomplete observes text-field scroll with `snapshotFlow` and feeds a calculated popup offset into composition.
+
 ---
 
 ## §6 ViewModel and state

--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ app/src/main/java/pub/hackers/android/
    ./gradlew generateApolloSources
    ```
 
+### Before pushing
+
+Run lint after finishing each task and again right before `git push` to catch any new errors you introduced:
+
+```bash
+./gradlew :app:lintDebug
+```
+
+Target is **0 errors**. For a genuine false positive (e.g., AGP bug), suppress narrowly at the single site with a comment or `tools:ignore="..."` — never disable the check globally. See [CONVENTION.md §10.5](./CONVENTION.md).
+
 ## GraphQL
 
 The app uses Apollo GraphQL to communicate with the Hackers' Pub API at `https://hackers.pub/graphql`.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.HackersPub">
+            android:theme="@style/Theme.HackersPub"
+            tools:ignore="Instantiatable">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -71,7 +71,12 @@
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"
-            tools:node="remove" />
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                tools:node="remove" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/pub/hackers/android/data/auth/PasskeyManager.kt
+++ b/app/src/main/java/pub/hackers/android/data/auth/PasskeyManager.kt
@@ -1,7 +1,6 @@
 package pub.hackers.android.data.auth
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -32,14 +31,14 @@ class PasskeyManager @Inject constructor(
     private val credentialManager = CredentialManager.create(context)
 
     @RequiresApi(Build.VERSION_CODES.P)
-    suspend fun authenticate(optionsJson: String, activity: Activity): String {
+    suspend fun authenticate(optionsJson: String): String {
         android.util.Log.d("PasskeyAuth", "authenticate: creating request with options: ${optionsJson.take(200)}")
         val request = GetCredentialRequest(
             listOf(GetPublicKeyCredentialOption(optionsJson))
         )
         android.util.Log.d("PasskeyAuth", "authenticate: calling getCredential")
         try {
-            val result = credentialManager.getCredential(activity, request)
+            val result = credentialManager.getCredential(context, request)
             android.util.Log.d("PasskeyAuth", "authenticate: got result, credential type=${result.credential.type}")
             val credential = result.credential as PublicKeyCredential
             android.util.Log.d("PasskeyAuth", "authenticate: success")
@@ -52,11 +51,11 @@ class PasskeyManager @Inject constructor(
 
     @SuppressLint("PublicKeyCredential")
     @RequiresApi(Build.VERSION_CODES.P)
-    suspend fun register(optionsJson: String, activity: Activity): String {
+    suspend fun register(optionsJson: String, context: Context): String {
         android.util.Log.d("PasskeyAuth", "register: creating request")
         val request = CreatePublicKeyCredentialRequest(optionsJson)
         try {
-            val result = credentialManager.createCredential(activity, request)
+            val result = credentialManager.createCredential(context, request)
             android.util.Log.d("PasskeyAuth", "register: success")
             val credential = result as CreatePublicKeyCredentialResponse
             return credential.registrationResponseJson

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
@@ -405,6 +406,9 @@ private fun NoteCard(
 
                 // Inline translate link
                 if (!isTranslating && translationError == null) {
+                    // Read Configuration from composition state so locale changes
+                    // trigger recomposition instead of serving stale values.
+                    val configuration = LocalConfiguration.current
                     Text(
                         text = if (showTranslated) stringResource(R.string.show_original) else stringResource(
                             R.string.translate
@@ -425,7 +429,7 @@ private fun NoteCard(
                                 }
 
                                 val targetLanguageTag = androidx.core.os.ConfigurationCompat
-                                    .getLocales(context.resources.configuration)
+                                    .getLocales(configuration)
                                     .get(0)?.language ?: Locale.getDefault().language
                                 scope.launch {
                                     isTranslating = true

--- a/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInScreen.kt
@@ -1,6 +1,5 @@
 package pub.hackers.android.ui.screens.auth
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
@@ -40,7 +39,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -111,10 +109,9 @@ fun SignInScreen(
                         pub.hackers.android.FeatureFlags.PASSKEY_AUTH_ENABLED &&
                         Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
                     ) {
-                        val activity = LocalContext.current as Activity
                         {
                             keyboardController?.hide()
-                            viewModel.signInWithPasskey(activity)
+                            viewModel.signInWithPasskey()
                         }
                     } else null,
                     isLoading = uiState.isLoading

--- a/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/auth/SignInViewModel.kt
@@ -152,7 +152,7 @@ class SignInViewModel @Inject constructor(
     }
 
     @RequiresApi(Build.VERSION_CODES.P)
-    fun signInWithPasskey(activity: Activity) {
+    fun signInWithPasskey() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
 
@@ -164,7 +164,7 @@ class SignInViewModel @Inject constructor(
                     .getOrThrow()
                 android.util.Log.d("PasskeyAuth", "Step 2: Got options: $optionsJson")
 
-                val authResponse = passkeyManager.authenticate(optionsJson, activity)
+                val authResponse = passkeyManager.authenticate(optionsJson)
                 android.util.Log.d("PasskeyAuth", "Step 3: Got auth response: $authResponse")
 
                 val authResponseMap = jsonToMap(org.json.JSONObject(authResponse))

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -48,9 +48,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -58,7 +57,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.boundsInWindow
@@ -136,13 +134,10 @@ fun ComposeScreen(
     // Track cursor and text field positions for popup placement
     var cursorRect by remember { mutableStateOf(Rect.Zero) }
     var textFieldBounds by remember { mutableStateOf(Rect.Zero) }
-    var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
     val scrollState = rememberScrollState()
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
     val density = LocalDensity.current
-    val popupHeight = with(density) { 200.dp.toPx() } // Estimated popup height
-    val coroutineScope = rememberCoroutineScope()
     val mentionPopupPaddingPx = with(density) { 16.dp.toPx() }
     val mentionPopupWidthPx = with(density) { 280.dp.toPx() }
     val mentionPopupYOffsetPx = with(density) { 20.dp.toPx() }
@@ -305,7 +300,6 @@ fun ComposeScreen(
                                     )
                                 },
                                 onTextLayout = { result: TextLayoutResult ->
-                                    textLayoutResult = result
                                     // Update cursor position
                                     val cursorPos = textFieldValue.selection.start
                                         .coerceIn(0, textFieldValue.text.length)

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -84,6 +85,34 @@ import pub.hackers.android.ui.theme.LocalAppColors
 import pub.hackers.android.ui.theme.LocalAppTypography
 import kotlin.math.roundToInt
 
+private data class MentionPopupPositionInputs(
+    val scrollY: Int,
+    val cursorRect: Rect,
+    val textFieldBounds: Rect,
+)
+
+private fun calculateMentionPopupOffset(
+    inputs: MentionPopupPositionInputs,
+    paddingPx: Float,
+    popupWidthPx: Float,
+    popupYOffsetPx: Float,
+): IntOffset {
+    val cursorYInBox = inputs.cursorRect.bottom - inputs.scrollY + paddingPx
+    val cursorXInBox = inputs.cursorRect.left + paddingPx
+    val visibleCursorY = cursorYInBox.coerceIn(
+        paddingPx,
+        inputs.textFieldBounds.height - paddingPx
+    )
+
+    return IntOffset(
+        x = cursorXInBox.roundToInt().coerceIn(
+            0,
+            (inputs.textFieldBounds.width - popupWidthPx).toInt().coerceAtLeast(0)
+        ),
+        y = (visibleCursorY + popupYOffsetPx).roundToInt()
+    )
+}
+
 @Composable
 fun ComposeScreen(
     replyToId: String?,
@@ -114,6 +143,32 @@ fun ComposeScreen(
     val density = LocalDensity.current
     val popupHeight = with(density) { 200.dp.toPx() } // Estimated popup height
     val coroutineScope = rememberCoroutineScope()
+    val mentionPopupPaddingPx = with(density) { 16.dp.toPx() }
+    val mentionPopupWidthPx = with(density) { 280.dp.toPx() }
+    val mentionPopupYOffsetPx = with(density) { 20.dp.toPx() }
+    var mentionPopupOffset by remember { mutableStateOf(IntOffset.Zero) }
+
+    LaunchedEffect(
+        scrollState,
+        mentionPopupPaddingPx,
+        mentionPopupWidthPx,
+        mentionPopupYOffsetPx
+    ) {
+        snapshotFlow {
+            MentionPopupPositionInputs(
+                scrollY = scrollState.value,
+                cursorRect = cursorRect,
+                textFieldBounds = textFieldBounds,
+            )
+        }.collect { inputs ->
+            mentionPopupOffset = calculateMentionPopupOffset(
+                inputs = inputs,
+                paddingPx = mentionPopupPaddingPx,
+                popupWidthPx = mentionPopupWidthPx,
+                popupYOffsetPx = mentionPopupYOffsetPx,
+            )
+        }
+    }
 
     // Auto-scroll to keep cursor visible when text overflows
     LaunchedEffect(cursorRect) {
@@ -287,25 +342,9 @@ fun ComposeScreen(
 
                     // Mention autocomplete popup
                     if (uiState.mentionSuggestions.isNotEmpty() || uiState.isLoadingMentions) {
-                        // Calculate cursor position accounting for padding and scroll
-                        val paddingPx = with(density) { 16.dp.toPx() }
-                        val cursorYInBox = cursorRect.bottom - scrollState.value + paddingPx
-                        val cursorXInBox = cursorRect.left + paddingPx
-
-                        // Clamp to visible area
-                        val visibleCursorY =
-                            cursorYInBox.coerceIn(paddingPx, textFieldBounds.height - paddingPx)
-
                         Popup(
                             alignment = Alignment.TopStart,
-                            offset = IntOffset(
-                                x = cursorXInBox.roundToInt().coerceIn(
-                                    0,
-                                    (textFieldBounds.width - with(density) { 280.dp.toPx() }).toInt()
-                                        .coerceAtLeast(0)
-                                ),
-                                y = (visibleCursorY + with(density) { 20.dp.toPx() }).roundToInt()
-                            ),
+                            offset = mentionPopupOffset,
                             properties = PopupProperties(focusable = false)
                         ) {
                             MentionAutocomplete(

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -69,8 +69,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -579,6 +579,9 @@ internal fun PostDetailContent(
                 }
 
                 if (!isTranslating && translationError == null) {
+                    // Read Configuration from composition state so locale changes
+                    // trigger recomposition instead of serving stale values.
+                    val configuration = LocalConfiguration.current
                     Text(
                         text = if (showTranslated) stringResource(R.string.show_original) else stringResource(
                             R.string.translate
@@ -597,7 +600,7 @@ internal fun PostDetailContent(
                                     return@clickable
                                 }
                                 val targetLanguageTag = androidx.core.os.ConfigurationCompat
-                                    .getLocales(context.resources.configuration)
+                                    .getLocales(configuration)
                                     .get(0)?.language ?: Locale.getDefault().language
                                 scope.launch {
                                     isTranslating = true

--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsScreen.kt
@@ -1,6 +1,4 @@
 package pub.hackers.android.ui.screens.settings
-
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -419,7 +417,7 @@ fun SettingsScreen(
     // Add passkey dialog
     if (passkeyEnabled && showAddPasskeyDialog) {
         var passkeyName by remember { mutableStateOf("") }
-        val activity = LocalContext.current as Activity
+        val context = LocalContext.current
 
         AlertDialog(
             onDismissRequest = { showAddPasskeyDialog = false },
@@ -441,7 +439,7 @@ fun SettingsScreen(
                 TextButton(
                     onClick = {
                         showAddPasskeyDialog = false
-                        viewModel.registerPasskey(passkeyName.ifBlank { "Android" }, activity)
+                        viewModel.registerPasskey(passkeyName.ifBlank { "Android" }, context)
                     },
                     enabled = !uiState.isRegisteringPasskey
                 ) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/settings/SettingsViewModel.kt
@@ -1,6 +1,4 @@
 package pub.hackers.android.ui.screens.settings
-
-import android.app.Activity
 import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
@@ -241,7 +239,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     @RequiresApi(Build.VERSION_CODES.P)
-    fun registerPasskey(name: String, activity: Activity) {
+    fun registerPasskey(name: String, context: Context) {
         val accountId = _uiState.value.accountId ?: run {
             android.util.Log.e("PasskeyAuth", "registerPasskey: accountId is null")
             return
@@ -254,7 +252,7 @@ class SettingsViewModel @Inject constructor(
                     .getOrThrow()
                 android.util.Log.d("PasskeyAuth", "registerPasskey: got options")
 
-                val registrationResponse = passkeyManager.register(optionsJson, activity)
+                val registrationResponse = passkeyManager.register(optionsJson, context)
                 android.util.Log.d("PasskeyAuth", "registerPasskey: got registration response: ${registrationResponse.take(200)}")
 
                 // Parse and re-serialize to ensure clean JSON, then convert to Map for Apollo

--- a/app/src/main/java/pub/hackers/android/ui/theme/Theme.kt
+++ b/app/src/main/java/pub/hackers/android/ui/theme/Theme.kt
@@ -1,6 +1,9 @@
 package pub.hackers.android.ui.theme
 
+import android.annotation.SuppressLint
+import android.content.Context
 import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
@@ -93,6 +96,11 @@ private fun dynamicAppColors(scheme: ColorScheme, dark: Boolean) = AppColorSchem
     hashtag = if (dark) DarkAppColors.hashtag else LightAppColors.hashtag,
 )
 
+@RequiresApi(Build.VERSION_CODES.S)
+@SuppressLint("NewApi")
+private fun dynamicColorSchemeFor(context: Context, darkTheme: Boolean): ColorScheme =
+    if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+
 @Composable
 fun HackersPubTheme(
     themeMode: ThemeMode = ThemeMode.SYSTEM,
@@ -109,8 +117,7 @@ fun HackersPubTheme(
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
 
     val colorScheme = when {
-        dynamicAvailable ->
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        dynamicAvailable -> dynamicColorSchemeFor(context, darkTheme)
         darkTheme -> darkColorSchemeFrom(DarkAppColors)
         else -> lightColorSchemeFrom(LightAppColors)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,7 +118,7 @@
     <string name="download">Download</string>
     <string name="translate">Translate</string>
     <string name="show_original">Show original</string>
-    <string name="translating">Translating...</string>
+    <string name="translating">Translating…</string>
     <string name="translation_failed">Translation failed</string>
 
     <!-- Settings -->

--- a/app/src/test/java/pub/hackers/android/ui/screens/auth/SignInViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/auth/SignInViewModelTest.kt
@@ -48,10 +48,10 @@ class SignInViewModelTest {
         val expectedMessage = "No passkey found."
         every { context.getString(R.string.no_passkey_registered) } returns expectedMessage
         coEvery { repository.getPasskeyAuthenticationOptions(any()) } returns Result.success("{}")
-        coEvery { passkeyManager.authenticate(any(), any()) } throws NoCredentialException()
+        coEvery { passkeyManager.authenticate(any()) } throws NoCredentialException()
 
         val vm = newViewModel()
-        vm.signInWithPasskey(activity)
+        vm.signInWithPasskey()
         advanceUntilIdle()
 
         assertEquals(expectedMessage, vm.uiState.value.error)
@@ -62,10 +62,10 @@ class SignInViewModelTest {
     @Test
     fun `signInWithPasskey shows exception message on generic failure`() = runTest {
         coEvery { repository.getPasskeyAuthenticationOptions(any()) } returns Result.success("{}")
-        coEvery { passkeyManager.authenticate(any(), any()) } throws RuntimeException("timeout")
+        coEvery { passkeyManager.authenticate(any()) } throws RuntimeException("timeout")
 
         val vm = newViewModel()
-        vm.signInWithPasskey(activity)
+        vm.signInWithPasskey()
         advanceUntilIdle()
 
         assertEquals("timeout", vm.uiState.value.error)


### PR DESCRIPTION
## Summary
이 PR은 Compose/startup/lint 관련 여러 소규모 수정과 문서 갱신을 묶어 처리합니다.

## Commits
- `3c9fa9c` **Use context for passkey flows** — passkey 로그인/등록 경로에서 불필요한 Activity 전달을 제거하고 `Context`만 주입하도록 정리
- `8fc4d14` **Use LocalConfiguration for translation locale** — translation locale을 `Configuration`에서 안정적으로 읽도록 `LocalConfiguration`으로 전환
- `123c987` **Remove WorkManager startup initializer** — 공용 `InitializationProvider`는 유지하되 WorkManager의 App Startup initializer만 제거
- `24a5c72` **Guard dynamic color API calls** — dynamic color API 호출을 API 31 헬퍼로 감싸 `NewApi` 경고 제거
- `956a1d1` **Document context dependency conventions** — Compose에서 `Context`/`Configuration` 주입 관례를 문서화
- `5705cb2` **Avoid recomposition from compose scroll state** — compose 멘션 팝업 스크롤 state 읽기를 `snapshotFlow`로 이동해 불필요한 recomposition 제거
- `e804210` **Document frequently changing state convention** — 자주 변경되는 state를 composition 밖에서 읽는 규칙 문서화
- `4edcc15` **Use ellipsis character in strings** — 문자열 ellipsis를 유니코드 문자로 통일 (`TypographyEllipsis` lint)
- `c38339e` **Suppress Instantiatable lint on MainActivity** — AGP 9.1.1 lint의 false positive(`MainActivity must extend android.app.Activity`)를 해당 activity 한정으로 `tools:ignore=\"Instantiatable\"` suppress. MainActivity는 실제로 `ComponentActivity`를 상속하고 public no-arg ctor를 가지므로 안전. 원인은 오래된 AGP classpath 해석 버그([issuetracker/196406778](https://issuetracker.google.com/issues/196406778), [Thomas-Boutin/InstantiateErrorAGP](https://github.com/Thomas-Boutin/InstantiateErrorAGP)).
- `aeb59b6` **Require lint check before pushing** — 컴파일/유닛 테스트는 manifest·API 레벨·리소스 hygiene·typographic 규칙을 커버하지 않음. 작업 완료 후와 push 직전에 `./gradlew :app:lintDebug`를 돌려 신규 에러(목표 0)를 잡도록 README의 Building 섹션과 CONVENTION §10.5에 규칙화. 진짜 false positive인 경우엔 호출부 한정 suppress만 허용하고 전역 disable은 금지.
- `b3c0d38` **Remove dead state in ComposeScreen** — 멘션 팝업 리팩터링 이후 남아 있던 `textLayoutResult` state, `popupHeight` 추정값, 미사용 `rememberCoroutineScope` 핸들과 관련 import(`Color`, `rememberCoroutineScope`)를 정리

## Verification
- `./gradlew :app:compileDebugKotlin`
- `./gradlew testDebugUnitTest`
- `./gradlew :app:lintDebug` — 이전에 남아 있던 `RemoveWorkManagerInitializer`, `LocalContextConfigurationRead`, `ExportedContentProvider`, `NewApi`, `FrequentlyChangingValue`, `TypographyEllipsis`, `Instantiatable` 모두 해소, **0 errors**