### PR TITLE
Fix HTML trailing newline accessibility crash

### DIFF
--- a/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/HtmlContent.kt
@@ -981,7 +981,15 @@ internal fun parseHtmlToAnnotatedString(
                 pos = tagMatch.range.last + 1
             }
         }
+    }.trimTrailingLineBreaks()
+}
+
+private fun AnnotatedString.trimTrailingLineBreaks(): AnnotatedString {
+    var end = text.length
+    while (end > 0 && text[end - 1] == '\n') {
+        end--
     }
+    return if (end == text.length) this else subSequence(0, end)
 }
 
 private fun appendStyledText(

--- a/app/src/test/java/pub/hackers/android/ui/components/HtmlContentKtTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/components/HtmlContentKtTest.kt
@@ -437,6 +437,18 @@ class HtmlContentKtTest {
     }
 
     @Test
+    fun `parseHtmlToAnnotatedString removes trailing line breaks`() {
+        val result = parseHtmlToAnnotatedString("Hello<br>", linkColor, hashtagColor, mentionBg, codeBg)
+        assertEquals("Hello", result.text)
+    }
+
+    @Test
+    fun `parseHtmlToAnnotatedString removes compact list trailing line break`() {
+        val result = parseHtmlToAnnotatedString("<ul><li>item</li></ul>", linkColor, hashtagColor, mentionBg, codeBg)
+        assertEquals("\u2022 item", result.text)
+    }
+
+    @Test
     fun `parseHtmlToAnnotatedString decodes entities in text`() {
         val result = parseHtmlToAnnotatedString("<p>A &amp; B</p>", linkColor, hashtagColor, mentionBg, codeBg)
         assertEquals("A & B", result.text)


### PR DESCRIPTION
## Summary
- Trim only trailing rendered line breaks from parsed HTML `AnnotatedString` output.
- Preserve interior newlines and paragraph/list formatting while avoiding a trailing text boundary that can crash Compose accessibility.
- Add regression tests for trailing `<br>` and compact list output.

## Crash Context
Crashlytics issue: https://console.firebase.google.com/u/0/project/hackerspub-android/crashlytics/app/android:pub.hackers.android/issues/970e0c4edebb1afa31c7867b373dec64?time=7d&types=crash&sessionEventKey=69E6FD270331000138BB1A3827BF86CE_2209511287297688744

Relevant stack trace path:

```text
Fatal Exception: java.lang.IllegalArgumentException: Found paragraph index -2 should be in range [0, 1).
Debug info: index=2420, paragraphs=[[0, 2420)]
  at androidx.compose.ui.text.MultiParagraphKt.findParagraphByIndex(MultiParagraph.kt:1244)
  at androidx.compose.ui.text.MultiParagraph.getBoundingBox(MultiParagraph.kt:647)
  at androidx.compose.ui.text.TextLayoutResult.getBoundingBox(TextLayoutResult.kt:503)
  at androidx.compose.ui.platform.AndroidComposeViewAccessibilityDelegateCompat.addExtraDataToAccessibilityNodeInfoHelper(AndroidComposeViewAccessibilityDelegateCompat.android.kt:1785)
```

The key detail is `index=2420` with `paragraphs=[[0, 2420)]`: accessibility requested a character bounding box at the paragraph end boundary. That boundary can happen when our HTML parser leaves a trailing rendered newline in a `ClickableText` node. A trailing newline is part of the text range but does not have a drawable glyph bounding box inside the laid-out paragraph.

This looks like a Compose text/accessibility bug as well: Compose should defensively ignore the request or return `null` for that character-location entry instead of crashing the app. Since the app can avoid feeding this vulnerable trailing boundary without changing user-visible content, this PR normalizes the parsed HTML output by trimming only trailing `\n` characters.

## Verification
```text
./gradlew testDebugUnitTest --tests pub.hackers.android.ui.components.HtmlContentKtTest
BUILD SUCCESSFUL
```
