### PR TITLE
Enable passkey authentication

### DIFF
--- a/app/src/main/java/pub/hackers/android/FeatureFlags.kt
+++ b/app/src/main/java/pub/hackers/android/FeatureFlags.kt
@@ -1,6 +1,6 @@
 package pub.hackers.android
 
 object FeatureFlags {
-    const val PASSKEY_AUTH_ENABLED = false
+    const val PASSKEY_AUTH_ENABLED = true
     const val MARK_NOTIFICATIONS_AS_READ_ENABLED = false
 }


### PR DESCRIPTION
## Summary
Enable the passkey authentication feature flag so passkey support is active in the Android client. On Android 9 and newer, this exposes passkey sign-in on the username step and the passkeys management section in Settings; older devices continue using the existing email verification flow.

## Why
- Make the shipped passkey flow available behind the existing platform gate.
- Keep behavior unchanged on devices that do not support the Credentials API requirement.

## Before and After
| Before | After |
|--------|-------|
| Passkey auth stayed hidden because `PASSKEY_AUTH_ENABLED` was `false`. | Passkey auth is enabled on Android 9+ where the UI already gates support. |
| Settings did not expose passkey management. | Settings shows passkey listing, add, and revoke actions on supported devices. |

## Commit History
- d20dd0a Enable passkey authentication: Turn on the passkey feature flag and expose the existing passkey sign-in and settings management flows on supported Android versions.

## Test Plan
- [x] Run `./gradlew :app:lintDebug`
- [x] On an Android 9+ device or emulator, confirm the username sign-in screen shows the passkey action.
- [x] On an Android 9+ device or emulator, confirm Settings shows passkey management and existing add/remove flows still work.
- [x] On an Android 8.1 or lower device or emulator, confirm the app still uses the email verification flow without passkey UI.

---
Assisted-By: Codex(gpt-5)