### PR TITLE
Support backward pagination refresh

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -122,8 +122,8 @@ fragment SharedPostFields on Post {
     }
 }
 
-query PublicTimeline($after: String) {
-    publicTimeline(first: 20, after: $after) {
+query PublicTimeline($first: Int, $after: String, $before: String, $last: Int) {
+    publicTimeline(first: $first, after: $after, before: $before, last: $last) {
         edges {
             cursor
             node {
@@ -135,13 +135,15 @@ query PublicTimeline($after: String) {
         }
         pageInfo {
             hasNextPage
+            hasPreviousPage
+            startCursor
             endCursor
         }
     }
 }
 
-query LocalTimeline($after: String) {
-    publicTimeline(local: true, first: 20, after: $after) {
+query LocalTimeline($first: Int, $after: String, $before: String, $last: Int) {
+    publicTimeline(local: true, first: $first, after: $after, before: $before, last: $last) {
         edges {
             cursor
             node {
@@ -153,13 +155,15 @@ query LocalTimeline($after: String) {
         }
         pageInfo {
             hasNextPage
+            hasPreviousPage
+            startCursor
             endCursor
         }
     }
 }
 
-query PersonalTimeline($after: String) {
-    personalTimeline(first: 20, after: $after) {
+query PersonalTimeline($first: Int, $after: String, $before: String, $last: Int) {
+    personalTimeline(first: $first, after: $after, before: $before, last: $last) {
         edges {
             cursor
             lastSharer {
@@ -179,6 +183,8 @@ query PersonalTimeline($after: String) {
         }
         pageInfo {
             hasNextPage
+            hasPreviousPage
+            startCursor
             endCursor
         }
     }
@@ -464,8 +470,8 @@ query PostReplies($id: ID!, $after: String) {
     }
 }
 
-query Bookmarks($after: String, $postType: PostType) {
-    bookmarks(first: 20, after: $after, postType: $postType) {
+query Bookmarks($first: Int, $after: String, $before: String, $last: Int, $postType: PostType) {
+    bookmarks(first: $first, after: $after, before: $before, last: $last, postType: $postType) {
         edges {
             cursor
             node {
@@ -477,6 +483,8 @@ query Bookmarks($after: String, $postType: PostType) {
         }
         pageInfo {
             hasNextPage
+            hasPreviousPage
+            startCursor
             endCursor
         }
     }

--- a/app/src/main/java/pub/hackers/android/data/paging/CursorPagingSource.kt
+++ b/app/src/main/java/pub/hackers/android/data/paging/CursorPagingSource.kt
@@ -14,6 +14,8 @@ data class CursorPage<T>(
     val items: List<T>,
     val endCursor: String?,
     val hasNextPage: Boolean,
+    val startCursor: String? = null,
+    val hasPreviousPage: Boolean = false,
 )
 
 /**
@@ -89,15 +91,15 @@ suspend fun HackersPubRepository.notificationsPage(after: String?) =
 
 suspend fun HackersPubRepository.personalTimelinePage(after: String?) =
     getPersonalTimeline(after = after, refresh = (after == null))
-        .map { CursorPage(it.posts, it.endCursor, it.hasNextPage) }
+        .map { CursorPage(it.posts, it.endCursor, it.hasNextPage, it.startCursor, it.hasPreviousPage) }
 
 suspend fun HackersPubRepository.publicTimelinePage(after: String?) =
     getPublicTimeline(after = after, refresh = (after == null))
-        .map { CursorPage(it.posts, it.endCursor, it.hasNextPage) }
+        .map { CursorPage(it.posts, it.endCursor, it.hasNextPage, it.startCursor, it.hasPreviousPage) }
 
 suspend fun HackersPubRepository.localTimelinePage(after: String?) =
     getLocalTimeline(after = after, refresh = (after == null))
-        .map { CursorPage(it.posts, it.endCursor, it.hasNextPage) }
+        .map { CursorPage(it.posts, it.endCursor, it.hasNextPage, it.startCursor, it.hasPreviousPage) }
 
 suspend fun HackersPubRepository.postRepliesPage(postId: String, after: String?) =
     getPostReplies(postId, after)
@@ -118,7 +120,7 @@ suspend fun HackersPubRepository.actorArticlesPage(handle: String, after: String
 suspend fun HackersPubRepository.bookmarksPage(
     after: String?,
     postType: pub.hackers.android.graphql.type.PostType?,
-) = getBookmarks(after, postType)
-    .map { CursorPage(it.posts, it.endCursor, it.hasNextPage) }
+) = getBookmarks(after = after, postType = postType)
+    .map { CursorPage(it.posts, it.endCursor, it.hasNextPage, it.startCursor, it.hasPreviousPage) }
 
 // endregion

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -72,10 +72,22 @@ import javax.inject.Singleton
 class HackersPubRepository @Inject constructor(
     private val apolloClient: ApolloClient
 ) {
-    suspend fun getPublicTimeline(after: String? = null, refresh: Boolean = false): Result<TimelineResult> {
+    suspend fun getPublicTimeline(
+        after: String? = null,
+        before: String? = null,
+        refresh: Boolean = false,
+    ): Result<TimelineResult> {
         return try {
-            val response = apolloClient.query(PublicTimelineQuery(Optional.presentIfNotNull(after)))
-                .apply { if (refresh) fetchPolicy(FetchPolicy.NetworkOnly) }
+            val backwards = before != null
+            val response = apolloClient.query(
+                PublicTimelineQuery(
+                    first = Optional.presentIfNotNull(if (backwards) null else 20),
+                    after = Optional.presentIfNotNull(if (backwards) null else after),
+                    before = Optional.presentIfNotNull(before),
+                    last = Optional.presentIfNotNull(if (backwards) 20 else null),
+                )
+            )
+                .apply { if (refresh || backwards) fetchPolicy(FetchPolicy.NetworkOnly) }
                 .execute()
 
             if (response.hasErrors()) {
@@ -89,7 +101,9 @@ class HackersPubRepository @Inject constructor(
                                 edge.node.postFields.toPost(edge.node.sharedPost?.sharedPostFields?.toPost())
                             }?.distinctBy { it.id } ?: emptyList(),
                             hasNextPage = data?.pageInfo?.hasNextPage ?: false,
-                            endCursor = data?.pageInfo?.endCursor
+                            endCursor = data?.pageInfo?.endCursor,
+                            hasPreviousPage = data?.pageInfo?.hasPreviousPage ?: false,
+                            startCursor = data?.pageInfo?.startCursor,
                         )
                     )
                 }
@@ -99,10 +113,22 @@ class HackersPubRepository @Inject constructor(
         }
     }
 
-    suspend fun getLocalTimeline(after: String? = null, refresh: Boolean = false): Result<TimelineResult> {
+    suspend fun getLocalTimeline(
+        after: String? = null,
+        before: String? = null,
+        refresh: Boolean = false,
+    ): Result<TimelineResult> {
         return try {
-            val response = apolloClient.query(LocalTimelineQuery(Optional.presentIfNotNull(after)))
-                .apply { if (refresh) fetchPolicy(FetchPolicy.NetworkOnly) }
+            val backwards = before != null
+            val response = apolloClient.query(
+                LocalTimelineQuery(
+                    first = Optional.presentIfNotNull(if (backwards) null else 20),
+                    after = Optional.presentIfNotNull(if (backwards) null else after),
+                    before = Optional.presentIfNotNull(before),
+                    last = Optional.presentIfNotNull(if (backwards) 20 else null),
+                )
+            )
+                .apply { if (refresh || backwards) fetchPolicy(FetchPolicy.NetworkOnly) }
                 .execute()
 
             if (response.hasErrors()) {
@@ -116,7 +142,9 @@ class HackersPubRepository @Inject constructor(
                                 edge.node.postFields.toPost(edge.node.sharedPost?.sharedPostFields?.toPost())
                             }?.distinctBy { it.id } ?: emptyList(),
                             hasNextPage = data?.pageInfo?.hasNextPage ?: false,
-                            endCursor = data?.pageInfo?.endCursor
+                            endCursor = data?.pageInfo?.endCursor,
+                            hasPreviousPage = data?.pageInfo?.hasPreviousPage ?: false,
+                            startCursor = data?.pageInfo?.startCursor,
                         )
                     )
                 }
@@ -126,10 +154,22 @@ class HackersPubRepository @Inject constructor(
         }
     }
 
-    suspend fun getPersonalTimeline(after: String? = null, refresh: Boolean = false): Result<TimelineResult> {
+    suspend fun getPersonalTimeline(
+        after: String? = null,
+        before: String? = null,
+        refresh: Boolean = false,
+    ): Result<TimelineResult> {
         return try {
-            val response = apolloClient.query(PersonalTimelineQuery(Optional.presentIfNotNull(after)))
-                .apply { if (refresh) fetchPolicy(FetchPolicy.NetworkOnly) }
+            val backwards = before != null
+            val response = apolloClient.query(
+                PersonalTimelineQuery(
+                    first = Optional.presentIfNotNull(if (backwards) null else 20),
+                    after = Optional.presentIfNotNull(if (backwards) null else after),
+                    before = Optional.presentIfNotNull(before),
+                    last = Optional.presentIfNotNull(if (backwards) 20 else null),
+                )
+            )
+                .apply { if (refresh || backwards) fetchPolicy(FetchPolicy.NetworkOnly) }
                 .execute()
 
             if (response.hasErrors()) {
@@ -149,7 +189,9 @@ class HackersPubRepository @Inject constructor(
                                 )
                             } ?: emptyList(),
                             hasNextPage = data?.pageInfo?.hasNextPage ?: false,
-                            endCursor = data?.pageInfo?.endCursor
+                            endCursor = data?.pageInfo?.endCursor,
+                            hasPreviousPage = data?.pageInfo?.hasPreviousPage ?: false,
+                            startCursor = data?.pageInfo?.startCursor,
                         )
                     )
                 }
@@ -256,12 +298,17 @@ class HackersPubRepository @Inject constructor(
 
     suspend fun getBookmarks(
         after: String? = null,
+        before: String? = null,
         postType: pub.hackers.android.graphql.type.PostType? = null,
     ): Result<TimelineResult> {
         return try {
+            val backwards = before != null
             val response = apolloClient.query(
                 BookmarksQuery(
-                    after = Optional.presentIfNotNull(after),
+                    first = Optional.presentIfNotNull(if (backwards) null else 20),
+                    after = Optional.presentIfNotNull(if (backwards) null else after),
+                    before = Optional.presentIfNotNull(before),
+                    last = Optional.presentIfNotNull(if (backwards) 20 else null),
                     postType = Optional.presentIfNotNull(postType)
                 )
             ).fetchPolicy(FetchPolicy.NetworkOnly).execute()
@@ -277,7 +324,9 @@ class HackersPubRepository @Inject constructor(
                                 edge.node.postFields.toPost(edge.node.sharedPost?.sharedPostFields?.toPost())
                             } ?: emptyList(),
                             hasNextPage = data?.pageInfo?.hasNextPage ?: false,
-                            endCursor = data?.pageInfo?.endCursor
+                            endCursor = data?.pageInfo?.endCursor,
+                            hasPreviousPage = data?.pageInfo?.hasPreviousPage ?: false,
+                            startCursor = data?.pageInfo?.startCursor,
                         )
                     )
                 }

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -229,7 +229,9 @@ data class PasskeyRegistrationResult(
 data class TimelineResult(
     val posts: List<Post>,
     val hasNextPage: Boolean,
-    val endCursor: String?
+    val endCursor: String?,
+    val hasPreviousPage: Boolean = false,
+    val startCursor: String? = null,
 )
 
 @Immutable

--- a/app/src/main/java/pub/hackers/android/ui/screens/bookmarks/BookmarksScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/bookmarks/BookmarksScreen.kt
@@ -64,6 +64,7 @@ fun BookmarksScreen(
     viewModel: BookmarksViewModel = hiltViewModel(),
 ) {
     val items = viewModel.posts.collectAsLazyPagingItems()
+    val newerPosts by viewModel.newerPosts.collectAsState()
     val selectedTab by viewModel.selectedTab.collectAsState()
     val uiState by viewModel.uiState.collectAsState()
     val listState = rememberLazyListState()
@@ -72,6 +73,7 @@ fun BookmarksScreen(
     val bookmarkRemovedMessage = stringResource(R.string.bookmark_removed)
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
+    val visiblePostCount = newerPosts.size + items.itemCount
 
     LaunchedEffect(selectedTab) {
         listState.scrollToItem(0)
@@ -79,7 +81,7 @@ fun BookmarksScreen(
 
     val pickerPostId = uiState.reactionPickerPostId
     if (pickerPostId != null) {
-        val pickerPost = items.itemSnapshotList.items.find {
+        val pickerPost = (newerPosts + items.itemSnapshotList.items).find {
             it.id == pickerPostId || it.sharedPost?.id == pickerPostId
         }
         val targetPost = pickerPost?.sharedPost ?: pickerPost
@@ -158,29 +160,98 @@ fun BookmarksScreen(
             Box(modifier = Modifier.fillMaxSize()) {
                 val refresh = items.loadState.refresh
                 when {
-                    refresh is LoadState.Error && items.itemCount == 0 -> {
+                    refresh is LoadState.Error && visiblePostCount == 0 -> {
                         ErrorMessage(
                             message = refresh.error.message ?: stringResource(R.string.error_generic),
                             onRetry = { items.refresh() }
                         )
                     }
 
-                    items.itemCount == 0 && refresh is LoadState.NotLoading -> {
+                    visiblePostCount == 0 && refresh is LoadState.NotLoading -> {
                         BookmarksEmptyState(
                             onRefresh = { items.refresh() }
                         )
                     }
 
-                    refresh is LoadState.Loading && items.itemCount == 0 -> {
+                    refresh is LoadState.Loading && visiblePostCount == 0 -> {
                         FullScreenLoading()
                     }
 
                     else -> {
                         PullToRefreshBox(
-                            isRefreshing = refresh is LoadState.Loading,
-                            onRefresh = { items.refresh() }
+                            isRefreshing = refresh is LoadState.Loading || uiState.isLoadingNewer,
+                            onRefresh = {
+                                if (visiblePostCount > 0) viewModel.loadNewerPosts()
+                                else items.refresh()
+                            }
                         ) {
                             LazyColumn(state = listState) {
+                                items(
+                                    count = newerPosts.size,
+                                    key = { index ->
+                                        val post = newerPosts[index]
+                                        "newer-${post.sharedPost?.id ?: post.id}"
+                                    }
+                                ) { index ->
+                                    val post = newerPosts[index]
+                                    PostCard(
+                                        post = post,
+                                        onClick = { onPostClick(post.sharedPost?.id ?: post.id) },
+                                        onProfileClick = onProfileClick,
+                                        onReplyClick = {
+                                            onReplyClick(post.sharedPost?.id ?: post.id)
+                                        },
+                                        onShareClick = {
+                                            val targetId = post.sharedPost?.id ?: post.id
+                                            if (post.viewerHasShared) {
+                                                viewModel.unsharePost(targetId)
+                                            } else {
+                                                viewModel.sharePost(targetId)
+                                            }
+                                        },
+                                        onQuoteClick = {
+                                            onQuoteClick(post.sharedPost?.id ?: post.id)
+                                        },
+                                        onReactionClick = {
+                                            viewModel.toggleFavourite(post)
+                                        },
+                                        onReactionLongPress = {
+                                            viewModel.showReactionPicker(post.sharedPost?.id ?: post.id)
+                                        },
+                                        onBookmarkClick = {
+                                            val displayPost = post.sharedPost ?: post
+                                            Toast.makeText(
+                                                context,
+                                                if (displayPost.viewerHasBookmarked) {
+                                                    bookmarkRemovedMessage
+                                                } else {
+                                                    bookmarkedMessage
+                                                },
+                                                Toast.LENGTH_SHORT
+                                            ).show()
+                                            viewModel.toggleBookmark(post)
+                                        },
+                                        onExternalShareClick = {
+                                            val displayPost = post.sharedPost ?: post
+                                            val shareUrl = displayPost.url ?: displayPost.iri
+                                            if (shareUrl != null) {
+                                                val sendIntent = Intent().apply {
+                                                    action = Intent.ACTION_SEND
+                                                    putExtra(Intent.EXTRA_TEXT, shareUrl)
+                                                    type = "text/plain"
+                                                }
+                                                context.startActivity(Intent.createChooser(sendIntent, null))
+                                            }
+                                        },
+                                        onQuotedPostClick = onPostClick
+                                    )
+                                    HorizontalDivider(
+                                        color = colors.divider,
+                                        thickness = 1.dp,
+                                        modifier = Modifier.padding(horizontal = 16.dp)
+                                    )
+                                }
+
                                 items(
                                     count = items.itemCount,
                                     key = items.itemKey { it.sharedPost?.id ?: it.id }

--- a/app/src/main/java/pub/hackers/android/ui/screens/bookmarks/BookmarksViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/bookmarks/BookmarksViewModel.kt
@@ -7,13 +7,16 @@ import androidx.paging.cachedIn
 import androidx.paging.filter
 import androidx.paging.map
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pub.hackers.android.data.paging.PostOverlayStore
@@ -34,6 +37,7 @@ enum class BookmarkTab {
 
 data class BookmarksUiState(
     val reactionPickerPostId: String? = null,
+    val isLoadingNewer: Boolean = false,
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -49,6 +53,17 @@ class BookmarksViewModel @Inject constructor(
     val uiState: StateFlow<BookmarksUiState> = _uiState.asStateFlow()
 
     private val overlayStore = PostOverlayStore()
+    private var topCursor: String? = null
+    private var loadNewerJob: Job? = null
+    private val _newerPosts = MutableStateFlow<List<Post>>(emptyList())
+    val newerPosts: StateFlow<List<Post>> = combine(
+        _newerPosts,
+        overlayStore.overlays,
+    ) { posts, overlays ->
+        posts.map { post -> post.applyOverlays(overlays) }
+            .filter { post -> (post.sharedPost ?: post).viewerHasBookmarked }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
     private val bookmarkCoordinator = BookmarkMutationCoordinator(
         scope = viewModelScope,
         requestMutation = { postId, shouldBookmark ->
@@ -71,6 +86,11 @@ class BookmarksViewModel @Inject constructor(
         .flatMapLatest { tab ->
             cursorPager { after ->
                 repository.bookmarksPage(after, tab.toGraphqlPostType())
+                    .onSuccess { page ->
+                        if (after == null && _newerPosts.value.isEmpty()) {
+                            topCursor = page.startCursor
+                        }
+                    }
             }.flow.distinctByEffectiveId().cachedIn(viewModelScope)
         }
         .combine(overlayStore.overlays) { paging, overlays ->
@@ -81,7 +101,44 @@ class BookmarksViewModel @Inject constructor(
         .cachedIn(viewModelScope)
 
     fun selectTab(tab: BookmarkTab) {
-        if (_selectedTab.value != tab) _selectedTab.value = tab
+        if (_selectedTab.value != tab) {
+            loadNewerJob?.cancel()
+            topCursor = null
+            _newerPosts.value = emptyList()
+            _uiState.update { it.copy(isLoadingNewer = false) }
+            _selectedTab.value = tab
+        }
+    }
+
+    fun loadNewerPosts() {
+        val before = topCursor ?: return
+        if (_uiState.value.isLoadingNewer) return
+        val tab = _selectedTab.value
+        val postType = tab.toGraphqlPostType()
+        _uiState.update { it.copy(isLoadingNewer = true) }
+        loadNewerJob = viewModelScope.launch {
+            repository.getBookmarks(before = before, postType = postType)
+                .onSuccess { page ->
+                    if (_selectedTab.value == tab) {
+                        prependNewerPosts(page.posts, page.startCursor)
+                    }
+                }
+                .onFailure {
+                    // Keep the currently loaded bookmarks visible; the next pull can retry.
+                }
+            if (_selectedTab.value == tab) {
+                _uiState.update { it.copy(isLoadingNewer = false) }
+            }
+        }
+    }
+
+    private fun prependNewerPosts(posts: List<Post>, startCursor: String?) {
+        if (posts.isEmpty()) return
+        topCursor = startCursor ?: topCursor
+        _newerPosts.update { current ->
+            val seen = current.mapTo(mutableSetOf()) { it.effectiveId }
+            posts.filter { seen.add(it.effectiveId) } + current
+        }
     }
 
     fun sharePost(postId: String) {
@@ -197,3 +254,6 @@ class BookmarksViewModel @Inject constructor(
         BookmarkTab.NOTES -> GqlPostType.NOTE
     }
 }
+
+private val Post.effectiveId: String
+    get() = sharedPost?.id ?: id

--- a/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreScreen.kt
@@ -1,5 +1,6 @@
 package pub.hackers.android.ui.screens.explore
 
+import android.content.Context
 import android.content.Intent
 import android.widget.Toast
 import androidx.compose.foundation.background
@@ -36,12 +37,14 @@ import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import pub.hackers.android.R
+import pub.hackers.android.domain.model.Post
 import pub.hackers.android.ui.components.ErrorMessage
 import pub.hackers.android.ui.components.FullScreenLoading
 import pub.hackers.android.ui.components.LargeTitleHeader
 import pub.hackers.android.ui.components.LoadingItem
 import pub.hackers.android.ui.components.PostCard
 import pub.hackers.android.ui.components.ReactionPicker
+import pub.hackers.android.ui.theme.AppColorScheme
 import pub.hackers.android.ui.theme.LocalAppColors
 import pub.hackers.android.ui.theme.LocalAppTypography
 
@@ -57,6 +60,7 @@ fun ExploreScreen(
     viewModel: ExploreViewModel = hiltViewModel()
 ) {
     val items = viewModel.posts.collectAsLazyPagingItems()
+    val newerPosts by viewModel.newerPosts.collectAsState()
     val selectedTab by viewModel.selectedTab.collectAsState()
     val uiState by viewModel.uiState.collectAsState()
     val listState = rememberLazyListState()
@@ -74,7 +78,7 @@ fun ExploreScreen(
     // Reaction picker bottom sheet — look up the currently-loaded post.
     val pickerPostId = uiState.reactionPickerPostId
     if (pickerPostId != null) {
-        val pickerPost = items.itemSnapshotList.items.find {
+        val pickerPost = (newerPosts + items.itemSnapshotList.items).find {
             it.id == pickerPostId || it.sharedPost?.id == pickerPostId
         }
         val targetPost = pickerPost?.sharedPost ?: pickerPost
@@ -180,79 +184,53 @@ fun ExploreScreen(
 
                     else -> {
                         PullToRefreshBox(
-                            isRefreshing = refresh is LoadState.Loading,
-                            onRefresh = { items.refresh() }
+                            isRefreshing = refresh is LoadState.Loading || uiState.isLoadingNewer,
+                            onRefresh = {
+                                if (items.itemCount > 0) viewModel.loadNewerPosts()
+                                else items.refresh()
+                            }
                         ) {
                             LazyColumn(state = listState) {
+                                items(
+                                    count = newerPosts.size,
+                                    key = { index ->
+                                        val post = newerPosts[index]
+                                        "newer-${post.sharedPost?.id ?: post.id}"
+                                    }
+                                ) { index ->
+                                    val post = newerPosts[index]
+                                    ExplorePostItem(
+                                        post = post,
+                                        isLoggedIn = isLoggedIn,
+                                        colors = colors,
+                                        context = context,
+                                        bookmarkedMessage = bookmarkedMessage,
+                                        bookmarkRemovedMessage = bookmarkRemovedMessage,
+                                        onPostClick = onPostClick,
+                                        onProfileClick = onProfileClick,
+                                        onReplyClick = onReplyClick,
+                                        onQuoteClick = onQuoteClick,
+                                        viewModel = viewModel,
+                                    )
+                                }
+
                                 items(
                                     count = items.itemCount,
                                     key = items.itemKey { it.id }
                                 ) { index ->
                                     val post = items[index] ?: return@items
-                                    PostCard(
+                                    ExplorePostItem(
                                         post = post,
-                                        onClick = { onPostClick(post.sharedPost?.id ?: post.id) },
+                                        isLoggedIn = isLoggedIn,
+                                        colors = colors,
+                                        context = context,
+                                        bookmarkedMessage = bookmarkedMessage,
+                                        bookmarkRemovedMessage = bookmarkRemovedMessage,
+                                        onPostClick = onPostClick,
                                         onProfileClick = onProfileClick,
-                                        onReplyClick = if (isLoggedIn) {
-                                            { onReplyClick(post.sharedPost?.id ?: post.id) }
-                                        } else null,
-                                        onShareClick = if (isLoggedIn) {
-                                            {
-                                                if (post.viewerHasShared) {
-                                                    viewModel.unsharePost(post.id)
-                                                } else {
-                                                    viewModel.sharePost(post.id)
-                                                }
-                                            }
-                                        } else null,
-                                        onQuoteClick = if (isLoggedIn) {
-                                            { onQuoteClick(post.sharedPost?.id ?: post.id) }
-                                        } else null,
-                                        onReactionClick = if (isLoggedIn) {
-                                            { viewModel.toggleFavourite(post) }
-                                        } else null,
-                                        onReactionLongPress = if (isLoggedIn) {
-                                            {
-                                                viewModel.showReactionPicker(
-                                                    post.sharedPost?.id ?: post.id
-                                                )
-                                            }
-                                        } else null,
-                                        onBookmarkClick = if (isLoggedIn) {
-                                            {
-                                                val displayPost = post.sharedPost ?: post
-                                                Toast.makeText(
-                                                    context,
-                                                    if (displayPost.viewerHasBookmarked) {
-                                                        bookmarkRemovedMessage
-                                                    } else {
-                                                        bookmarkedMessage
-                                                    },
-                                                    Toast.LENGTH_SHORT
-                                                ).show()
-                                                viewModel.toggleBookmark(post)
-                                            }
-                                        } else null,
-                                        onExternalShareClick = {
-                                            val displayPost = post.sharedPost ?: post
-                                            val shareUrl = displayPost.url ?: displayPost.iri
-                                            if (shareUrl != null) {
-                                                val sendIntent = Intent().apply {
-                                                    action = Intent.ACTION_SEND
-                                                    putExtra(Intent.EXTRA_TEXT, shareUrl)
-                                                    type = "text/plain"
-                                                }
-                                                context.startActivity(
-                                                    Intent.createChooser(sendIntent, null)
-                                                )
-                                            }
-                                        },
-                                        onQuotedPostClick = onPostClick
-                                    )
-                                    HorizontalDivider(
-                                        color = colors.divider,
-                                        thickness = 1.dp,
-                                        modifier = Modifier.padding(horizontal = 16.dp)
+                                        onReplyClick = onReplyClick,
+                                        onQuoteClick = onQuoteClick,
+                                        viewModel = viewModel,
                                     )
                                 }
 
@@ -266,4 +244,85 @@ fun ExploreScreen(
             }
         }
     }
+}
+
+@Composable
+private fun ExplorePostItem(
+    post: Post,
+    isLoggedIn: Boolean,
+    colors: AppColorScheme,
+    context: Context,
+    bookmarkedMessage: String,
+    bookmarkRemovedMessage: String,
+    onPostClick: (String) -> Unit,
+    onProfileClick: (String) -> Unit,
+    onReplyClick: (String) -> Unit,
+    onQuoteClick: (String) -> Unit,
+    viewModel: ExploreViewModel,
+) {
+    PostCard(
+        post = post,
+        onClick = { onPostClick(post.sharedPost?.id ?: post.id) },
+        onProfileClick = onProfileClick,
+        onReplyClick = if (isLoggedIn) {
+            { onReplyClick(post.sharedPost?.id ?: post.id) }
+        } else null,
+        onShareClick = if (isLoggedIn) {
+            {
+                if (post.viewerHasShared) {
+                    viewModel.unsharePost(post.id)
+                } else {
+                    viewModel.sharePost(post.id)
+                }
+            }
+        } else null,
+        onQuoteClick = if (isLoggedIn) {
+            { onQuoteClick(post.sharedPost?.id ?: post.id) }
+        } else null,
+        onReactionClick = if (isLoggedIn) {
+            { viewModel.toggleFavourite(post) }
+        } else null,
+        onReactionLongPress = if (isLoggedIn) {
+            {
+                viewModel.showReactionPicker(
+                    post.sharedPost?.id ?: post.id
+                )
+            }
+        } else null,
+        onBookmarkClick = if (isLoggedIn) {
+            {
+                val displayPost = post.sharedPost ?: post
+                Toast.makeText(
+                    context,
+                    if (displayPost.viewerHasBookmarked) {
+                        bookmarkRemovedMessage
+                    } else {
+                        bookmarkedMessage
+                    },
+                    Toast.LENGTH_SHORT
+                ).show()
+                viewModel.toggleBookmark(post)
+            }
+        } else null,
+        onExternalShareClick = {
+            val displayPost = post.sharedPost ?: post
+            val shareUrl = displayPost.url ?: displayPost.iri
+            if (shareUrl != null) {
+                val sendIntent = Intent().apply {
+                    action = Intent.ACTION_SEND
+                    putExtra(Intent.EXTRA_TEXT, shareUrl)
+                    type = "text/plain"
+                }
+                context.startActivity(
+                    Intent.createChooser(sendIntent, null)
+                )
+            }
+        },
+        onQuotedPostClick = onPostClick
+    )
+    HorizontalDivider(
+        color = colors.divider,
+        thickness = 1.dp,
+        modifier = Modifier.padding(horizontal = 16.dp)
+    )
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreViewModel.kt
@@ -6,13 +6,16 @@ import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pub.hackers.android.data.paging.PostOverlayStore
@@ -34,6 +37,7 @@ enum class ExploreTab {
 data class ExploreUiState(
     val reactionPickerPostId: String? = null,
     val error: String? = null,
+    val isLoadingNewer: Boolean = false,
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -49,6 +53,16 @@ class ExploreViewModel @Inject constructor(
     val uiState: StateFlow<ExploreUiState> = _uiState.asStateFlow()
 
     private val overlayStore = PostOverlayStore()
+    private var topCursor: String? = null
+    private var loadNewerJob: Job? = null
+    private val _newerPosts = MutableStateFlow<List<Post>>(emptyList())
+    val newerPosts: StateFlow<List<Post>> = combine(
+        _newerPosts,
+        overlayStore.overlays,
+    ) { posts, overlays ->
+        posts.map { post -> post.applyOverlays(overlays) }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
     private val bookmarkCoordinator = BookmarkMutationCoordinator(
         scope = viewModelScope,
         requestMutation = { postId, shouldBookmark ->
@@ -70,9 +84,14 @@ class ExploreViewModel @Inject constructor(
     val posts: Flow<PagingData<Post>> = _selectedTab
         .flatMapLatest { tab ->
             cursorPager { after ->
-                when (tab) {
+                val pageResult = when (tab) {
                     ExploreTab.LOCAL -> repository.localTimelinePage(after)
                     ExploreTab.GLOBAL -> repository.publicTimelinePage(after)
+                }
+                pageResult.onSuccess { page ->
+                    if (after == null && _newerPosts.value.isEmpty()) {
+                        topCursor = page.startCursor
+                    }
                 }
             }.flow.distinctByEffectiveId().cachedIn(viewModelScope)
         }
@@ -82,7 +101,44 @@ class ExploreViewModel @Inject constructor(
         .cachedIn(viewModelScope)
 
     fun selectTab(tab: ExploreTab) {
-        if (_selectedTab.value != tab) _selectedTab.value = tab
+        if (_selectedTab.value != tab) {
+            loadNewerJob?.cancel()
+            topCursor = null
+            _newerPosts.value = emptyList()
+            _uiState.update { it.copy(error = null, isLoadingNewer = false) }
+            _selectedTab.value = tab
+        }
+    }
+
+    fun loadNewerPosts() {
+        val before = topCursor ?: return
+        if (_uiState.value.isLoadingNewer) return
+        val tab = _selectedTab.value
+        _uiState.update { it.copy(isLoadingNewer = true, error = null) }
+        loadNewerJob = viewModelScope.launch {
+            val result = when (tab) {
+                ExploreTab.LOCAL -> repository.getLocalTimeline(before = before, refresh = true)
+                ExploreTab.GLOBAL -> repository.getPublicTimeline(before = before, refresh = true)
+            }
+            if (_selectedTab.value != tab) return@launch
+            result
+                .onSuccess { page -> prependNewerPosts(page.posts, page.startCursor) }
+                .onFailure { error ->
+                    _uiState.update { it.copy(error = error.message) }
+                }
+            if (_selectedTab.value == tab) {
+                _uiState.update { it.copy(isLoadingNewer = false) }
+            }
+        }
+    }
+
+    private fun prependNewerPosts(posts: List<Post>, startCursor: String?) {
+        if (posts.isEmpty()) return
+        topCursor = startCursor ?: topCursor
+        _newerPosts.update { current ->
+            val seen = current.mapTo(mutableSetOf()) { it.effectiveId }
+            posts.filter { seen.add(it.effectiveId) } + current
+        }
     }
 
     fun sharePost(postId: String) {
@@ -197,3 +253,6 @@ class ExploreViewModel @Inject constructor(
         }
     }
 }
+
+private val Post.effectiveId: String
+    get() = sharedPost?.id ?: id

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -71,6 +71,7 @@ fun TimelineScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val items = viewModel.posts.collectAsLazyPagingItems()
+    val newerPosts by viewModel.newerPosts.collectAsState()
     val listState = rememberLazyListState()
     val context = LocalContext.current
     val bookmarkedMessage = stringResource(R.string.bookmarked)
@@ -94,7 +95,8 @@ fun TimelineScreen(
     LaunchedEffect(tabRetapped) {
         if (tabRetapped > 0L) {
             if (listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0) {
-                items.refresh()
+                if (items.itemCount > 0) viewModel.loadNewerPosts()
+                else items.refresh()
             } else {
                 listState.animateScrollToItem(0)
             }
@@ -104,7 +106,7 @@ fun TimelineScreen(
     // Reaction picker bottom sheet — look up the currently-loaded post by id.
     val pickerPostId = uiState.reactionPickerPostId
     if (pickerPostId != null) {
-        val pickerPost = items.itemSnapshotList.items.find {
+        val pickerPost = (newerPosts + items.itemSnapshotList.items).find {
             it.id == pickerPostId || it.sharedPost?.id == pickerPostId
         }
         val targetPost = pickerPost?.sharedPost ?: pickerPost
@@ -239,10 +241,76 @@ fun TimelineScreen(
 
                 else -> {
                     PullToRefreshBox(
-                        isRefreshing = refresh is LoadState.Loading,
-                        onRefresh = { items.refresh() }
+                        isRefreshing = refresh is LoadState.Loading || uiState.isLoadingNewer,
+                        onRefresh = {
+                            if (items.itemCount > 0) viewModel.loadNewerPosts()
+                            else items.refresh()
+                        }
                     ) {
                         LazyColumn(state = listState) {
+                            items(
+                                count = newerPosts.size,
+                                key = { index ->
+                                    val post = newerPosts[index]
+                                    "newer-${post.sharedPost?.id ?: post.id}"
+                                }
+                            ) { index ->
+                                val post = newerPosts[index]
+                                PostCard(
+                                    post = post,
+                                    onClick = { onPostClick(post.sharedPost?.id ?: post.id) },
+                                    onProfileClick = onProfileClick,
+                                    onReplyClick = {
+                                        onComposeClick(post.sharedPost?.id ?: post.id)
+                                    },
+                                    onShareClick = {
+                                        if (post.viewerHasShared) {
+                                            viewModel.unsharePost(post.id)
+                                        } else {
+                                            viewModel.sharePost(post.id)
+                                        }
+                                    },
+                                    onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
+                                    onReactionClick = { viewModel.toggleFavourite(post) },
+                                    onReactionLongPress = {
+                                        viewModel.showReactionPicker(post.sharedPost?.id ?: post.id)
+                                    },
+                                    onBookmarkClick = {
+                                        val displayPost = post.sharedPost ?: post
+                                        Toast.makeText(
+                                            context,
+                                            if (displayPost.viewerHasBookmarked) {
+                                                bookmarkRemovedMessage
+                                            } else {
+                                                bookmarkedMessage
+                                            },
+                                            Toast.LENGTH_SHORT
+                                        ).show()
+                                        viewModel.toggleBookmark(post)
+                                    },
+                                    onExternalShareClick = {
+                                        val displayPost = post.sharedPost ?: post
+                                        val shareUrl = displayPost.url ?: displayPost.iri
+                                        if (shareUrl != null) {
+                                            val sendIntent = Intent().apply {
+                                                action = Intent.ACTION_SEND
+                                                putExtra(Intent.EXTRA_TEXT, shareUrl)
+                                                type = "text/plain"
+                                            }
+                                            context.startActivity(
+                                                Intent.createChooser(sendIntent, null)
+                                            )
+                                        }
+                                    },
+                                    onQuotedPostClick = onPostClick
+                                )
+                                HorizontalDivider(
+                                    color = colors.divider,
+                                    thickness = 1.dp,
+                                    modifier = Modifier.padding(horizontal = 16.dp)
+                                )
+                            }
+
                             items(
                                 count = items.itemCount,
                                 key = items.itemKey { it.id }

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
@@ -2,25 +2,24 @@ package pub.hackers.android.ui.screens.timeline
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.paging.PagingConfig
 import androidx.paging.PagingData
-import androidx.paging.PagingSource
-import androidx.paging.Pager
 import androidx.paging.cachedIn
 import androidx.paging.map
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pub.hackers.android.data.local.PreferencesManager
-import pub.hackers.android.data.paging.CursorPagingSource
 import pub.hackers.android.data.paging.PostOverlayStore
 import pub.hackers.android.data.paging.applyOverlays
+import pub.hackers.android.data.paging.cursorPager
 import pub.hackers.android.data.paging.distinctByEffectiveId
 import pub.hackers.android.data.paging.personalTimelinePage
 import pub.hackers.android.data.repository.HackersPubRepository
@@ -33,6 +32,7 @@ data class TimelineUiState(
     val error: String? = null,
     val reactionPickerPostId: String? = null,
     val draftCount: Int = 0,
+    val isLoadingNewer: Boolean = false,
 )
 
 @HiltViewModel
@@ -64,21 +64,23 @@ class TimelineViewModel @Inject constructor(
         },
     )
 
-    private var currentPagingSource: PagingSource<String, Post>? = null
+    private var topCursor: String? = null
+    private val _newerPosts = MutableStateFlow<List<Post>>(emptyList())
+    val newerPosts: StateFlow<List<Post>> = combine(
+        _newerPosts,
+        overlayStore.overlays,
+    ) { posts, overlays ->
+        posts.map { post -> post.applyOverlays(overlays) }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     val posts: Flow<PagingData<Post>> = combine(
-        Pager(
-            config = PagingConfig(
-                pageSize = 20,
-                prefetchDistance = 5,
-                enablePlaceholders = false,
-                initialLoadSize = 20,
-            ),
-            pagingSourceFactory = {
-                CursorPagingSource<Post> { after -> repository.personalTimelinePage(after) }
-                    .also { currentPagingSource = it }
-            },
-        ).flow
+        cursorPager { after ->
+            repository.personalTimelinePage(after).onSuccess { page ->
+                if (after == null && _newerPosts.value.isEmpty()) {
+                    topCursor = page.startCursor
+                }
+            }
+        }.flow
             .distinctByEffectiveId()
             .cachedIn(viewModelScope),
         overlayStore.overlays,
@@ -90,8 +92,31 @@ class TimelineViewModel @Inject constructor(
         loadDraftCount()
         viewModelScope.launch {
             refreshTrigger.refreshAt.drop(1).collect {
-                currentPagingSource?.invalidate()
+                loadNewerPosts()
             }
+        }
+    }
+
+    fun loadNewerPosts() {
+        val before = topCursor ?: return
+        if (_uiState.value.isLoadingNewer) return
+        _uiState.update { it.copy(isLoadingNewer = true, error = null) }
+        viewModelScope.launch {
+            repository.getPersonalTimeline(before = before, refresh = true)
+                .onSuccess { page -> prependNewerPosts(page.posts, page.startCursor) }
+                .onFailure { error ->
+                    _uiState.update { it.copy(error = error.message) }
+                }
+            _uiState.update { it.copy(isLoadingNewer = false) }
+        }
+    }
+
+    private fun prependNewerPosts(posts: List<Post>, startCursor: String?) {
+        if (posts.isEmpty()) return
+        topCursor = startCursor ?: topCursor
+        _newerPosts.update { current ->
+            val seen = current.mapTo(mutableSetOf()) { it.effectiveId }
+            posts.filter { seen.add(it.effectiveId) } + current
         }
     }
 
@@ -212,3 +237,6 @@ class TimelineViewModel @Inject constructor(
         }
     }
 }
+
+private val Post.effectiveId: String
+    get() = sharedPost?.id ?: id


### PR DESCRIPTION
This PR implements newer-item refresh handling for timelines, bookmarks, notifications, search, and profile lists. Which is related with https://github.com/hackers-pub/hackerspub/pull/296 .

And This PR was assisted by Codex / GPT-5.5.