### PR TITLE
Add image attachments to note composer

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -596,8 +596,8 @@ query ViewerPasskeys {
     }
 }
 
-mutation CreateNote($content: Markdown!, $language: Locale!, $visibility: PostVisibility!, $quotePolicy: QuotePolicy, $replyTargetId: ID, $quotedPostId: ID) {
-    createNote(input: { content: $content, language: $language, visibility: $visibility, quotePolicy: $quotePolicy, replyTargetId: $replyTargetId, quotedPostId: $quotedPostId }) {
+mutation CreateNote($content: Markdown!, $language: Locale!, $visibility: PostVisibility!, $quotePolicy: QuotePolicy, $replyTargetId: ID, $quotedPostId: ID, $media: [CreateNoteMediumInput!] = []) {
+    createNote(input: { content: $content, language: $language, visibility: $visibility, quotePolicy: $quotePolicy, replyTargetId: $replyTargetId, quotedPostId: $quotedPostId, media: $media }) {
         ... on CreateNotePayload {
             note {
                 ...PostFields
@@ -608,6 +608,56 @@ mutation CreateNote($content: Markdown!, $language: Locale!, $visibility: PostVi
         }
         ... on NotAuthenticatedError {
             notAuthenticated
+        }
+    }
+}
+
+mutation StartMediumUpload($contentLength: Int!, $contentType: MediaType!) {
+    startMediumUpload(input: { contentLength: $contentLength, contentType: $contentType }) {
+        __typename
+        ... on StartMediumUploadPayload {
+            uploadId
+            uploadUrl
+            method
+            headers {
+                name
+                value
+            }
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+    }
+}
+
+mutation FinishMediumUpload($uploadId: UUID!) {
+    finishMediumUpload(input: { uploadId: $uploadId }) {
+        __typename
+        ... on FinishMediumUploadPayload {
+            medium {
+                id
+                uuid
+                url
+                width
+                height
+            }
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+    }
+}
+
+query MediumGeneratedAltText($mediumId: ID!, $language: Locale!, $context: String) {
+    node(id: $mediumId) {
+        ... on Medium {
+            generatedAltText(language: $language, context: $context)
         }
     }
 }

--- a/app/src/main/graphql/pub/hackers/android/schema.graphqls
+++ b/app/src/main/graphql/pub/hackers/android/schema.graphqls
@@ -592,6 +592,8 @@ input CreateNoteInput {
 
   language: Locale!
 
+  media: [CreateNoteMediumInput!] = []
+
   quotePolicy: QuotePolicy
 
   quotedPostId: ID
@@ -599,6 +601,12 @@ input CreateNoteInput {
   replyTargetId: ID
 
   visibility: PostVisibility!
+}
+
+input CreateNoteMediumInput {
+  alt: String!
+
+  mediumId: UUID!
 }
 
 type CreateNotePayload {
@@ -666,6 +674,20 @@ type DeletePostPayload {
 }
 
 union DeletePostResult = DeletePostPayload|InvalidInputError|NotAuthenticatedError|SharedPostDeletionNotAllowedError
+
+input FinishMediumUploadInput {
+  clientMutationId: ID
+
+  uploadId: UUID!
+}
+
+type FinishMediumUploadPayload {
+  clientMutationId: ID
+
+  medium: Medium!
+}
+
+union FinishMediumUploadResult = FinishMediumUploadPayload|InvalidInputError|NotAuthenticatedError
 
 """
 A document in a specific language.
@@ -890,6 +912,34 @@ scalar Markdown
 
 scalar MediaType
 
+scalar Sha256
+
+type Medium implements Node {
+  contentHash: Sha256
+
+  created: DateTime!
+
+  generatedAltText(context: String, language: Locale!): String
+
+  height: Int
+
+  id: ID!
+
+  type: MediaType!
+
+  url: URL!
+
+  uuid: UUID!
+
+  width: Int
+}
+
+type MediumUploadHeader {
+  name: String!
+
+  value: String!
+}
+
 type MentionNotification implements Node & Notification {
   account: Account!
 
@@ -964,6 +1014,10 @@ type Mutation {
   saveArticleDraft(input: SaveArticleDraftInput!): SaveArticleDraftResult!
 
   sharePost(input: SharePostInput!): SharePostResult!
+
+  startMediumUpload(input: StartMediumUploadInput!): StartMediumUploadResult!
+
+  finishMediumUpload(input: FinishMediumUploadInput!): FinishMediumUploadResult!
 
   unblockActor(input: UnblockActorInput!): UnblockActorResult!
 
@@ -1974,6 +2028,30 @@ type SignupValidationErrors {
 type StandardEmoji {
   raw: String!
 }
+
+input StartMediumUploadInput {
+  clientMutationId: ID
+
+  contentLength: Int!
+
+  contentType: MediaType!
+}
+
+type StartMediumUploadPayload {
+  clientMutationId: ID
+
+  expires: DateTime!
+
+  headers: [MediumUploadHeader!]!
+
+  method: String!
+
+  uploadId: UUID!
+
+  uploadUrl: URL!
+}
+
+union StartMediumUploadResult = InvalidInputError|NotAuthenticatedError|StartMediumUploadPayload
 
 scalar URITemplate
 

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -1,11 +1,26 @@
 package pub.hackers.android.data.repository
 
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.provider.OpenableColumns
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.cache.normalized.FetchPolicy
 import com.apollographql.apollo.cache.normalized.fetchPolicy
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import dagger.hilt.android.qualifiers.ApplicationContext
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.Response
+import okio.BufferedSink
 import pub.hackers.android.domain.model.*
 import pub.hackers.android.graphql.ArticleDraftQuery
 import pub.hackers.android.graphql.ArticleDraftsQuery
@@ -22,6 +37,7 @@ import pub.hackers.android.graphql.CreateNoteMutation
 import pub.hackers.android.graphql.DeleteArticleDraftMutation
 import pub.hackers.android.graphql.DeletePostMutation
 import pub.hackers.android.graphql.EditAccountQuery
+import pub.hackers.android.graphql.FinishMediumUploadMutation
 import pub.hackers.android.graphql.GetPasskeyAuthenticationOptionsMutation
 import pub.hackers.android.graphql.GetPasskeyRegistrationOptionsMutation
 import pub.hackers.android.graphql.FollowActorMutation
@@ -29,6 +45,7 @@ import pub.hackers.android.graphql.LocalTimelineQuery
 import pub.hackers.android.graphql.LoginByPasskeyMutation
 import pub.hackers.android.graphql.LoginByUsernameMutation
 import pub.hackers.android.graphql.MarkNotificationsAsReadMutation
+import pub.hackers.android.graphql.MediumGeneratedAltTextQuery
 import pub.hackers.android.graphql.NotificationsQuery
 import pub.hackers.android.graphql.PersonalTimelineQuery
 import pub.hackers.android.graphql.PostQuotesQuery
@@ -50,6 +67,7 @@ import pub.hackers.android.graphql.SearchActorsByHandleQuery
 import pub.hackers.android.graphql.SearchObjectQuery
 import pub.hackers.android.graphql.SearchPostQuery
 import pub.hackers.android.graphql.SharePostMutation
+import pub.hackers.android.graphql.StartMediumUploadMutation
 import pub.hackers.android.graphql.UnblockActorMutation
 import pub.hackers.android.graphql.UnfollowActorMutation
 import pub.hackers.android.graphql.UnbookmarkPostMutation
@@ -57,6 +75,7 @@ import pub.hackers.android.graphql.UnsharePostMutation
 import pub.hackers.android.graphql.UpdateAccountMutation
 import pub.hackers.android.graphql.ViewerQuery
 import pub.hackers.android.graphql.type.AccountLinkInput
+import pub.hackers.android.graphql.type.CreateNoteMediumInput
 import pub.hackers.android.graphql.type.UpdateAccountInput
 import pub.hackers.android.graphql.fragment.ActorFields
 import pub.hackers.android.graphql.fragment.EngagementStatsFields
@@ -65,13 +84,18 @@ import pub.hackers.android.graphql.fragment.PostFields
 import pub.hackers.android.graphql.fragment.SharedPostFields
 import pub.hackers.android.graphql.type.PostVisibility as GqlPostVisibility
 import pub.hackers.android.graphql.type.QuotePolicy as GqlQuotePolicy
+import java.io.IOException
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 @Singleton
 class HackersPubRepository @Inject constructor(
-    private val apolloClient: ApolloClient
+    private val apolloClient: ApolloClient,
+    private val okHttpClient: OkHttpClient,
+    @param:ApplicationContext private val context: Context,
 ) {
     suspend fun getPublicTimeline(
         after: String? = null,
@@ -932,7 +956,8 @@ class HackersPubRepository @Inject constructor(
         visibility: PostVisibility = PostVisibility.PUBLIC,
         quotePolicy: QuotePolicy = QuotePolicy.EVERYONE,
         replyTargetId: String? = null,
-        quotedPostId: String? = null
+        quotedPostId: String? = null,
+        media: List<NoteMediumAttachment> = emptyList(),
     ): Result<Post> {
         return try {
             val gqlVisibility = when (visibility) {
@@ -955,7 +980,15 @@ class HackersPubRepository @Inject constructor(
                     visibility = gqlVisibility,
                     quotePolicy = Optional.present(gqlQuotePolicy),
                     replyTargetId = Optional.presentIfNotNull(replyTargetId),
-                    quotedPostId = Optional.presentIfNotNull(quotedPostId)
+                    quotedPostId = Optional.presentIfNotNull(quotedPostId),
+                    media = Optional.present(
+                        media.map { attachment ->
+                            CreateNoteMediumInput(
+                                alt = attachment.alt,
+                                mediumId = attachment.mediumId,
+                            )
+                        }
+                    ),
                 )
             ).execute()
 
@@ -974,6 +1007,124 @@ class HackersPubRepository @Inject constructor(
                         Result.failure(Exception("Not authenticated"))
                     }
                     else -> Result.failure(Exception("Unknown error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun uploadMedium(
+        uri: Uri,
+        onProgress: (Int) -> Unit = {},
+    ): Result<UploadedMedium> {
+        return try {
+            val contentType = context.contentResolver.getType(uri)
+                ?: return Result.failure(Exception("Selected file has no content type"))
+            if (!contentType.startsWith("image/")) {
+                return Result.failure(Exception("Only image files can be attached"))
+            }
+
+            val contentLength = contentLength(uri)
+            if (contentLength <= 0L) {
+                return Result.failure(Exception("Selected image size is unknown"))
+            }
+            if (contentLength > Int.MAX_VALUE) {
+                return Result.failure(Exception("Selected image is too large"))
+            }
+
+            val startResponse = apolloClient.mutation(
+                StartMediumUploadMutation(
+                    contentLength = contentLength.toInt(),
+                    contentType = contentType,
+                )
+            ).execute()
+
+            if (startResponse.hasErrors()) {
+                return Result.failure(Exception(startResponse.errors?.firstOrNull()?.message ?: "Upload failed"))
+            }
+
+            val session = startResponse.data?.startMediumUpload?.onStartMediumUploadPayload
+                ?: return Result.failure(Exception("Upload failed"))
+
+            val request = Request.Builder()
+                .url(session.uploadUrl.toString())
+                .method(
+                    session.method,
+                    ContentUriRequestBody(
+                        context = context,
+                        uri = uri,
+                        contentType = contentType,
+                        contentLength = contentLength,
+                        onProgress = onProgress,
+                    )
+                )
+                .apply {
+                    session.headers.forEach { header ->
+                        addHeader(header.name, header.value)
+                    }
+                }
+                .build()
+
+            executeUploadRequest(request).use { response ->
+                if (!response.isSuccessful) {
+                    val message = when (response.code) {
+                        413 -> "File is too large"
+                        415 -> "File type is not supported"
+                        else -> "Upload failed with status ${response.code}"
+                    }
+                    throw Exception(message)
+                }
+            }
+
+            val finishResponse = apolloClient.mutation(
+                FinishMediumUploadMutation(uploadId = session.uploadId.toString())
+            ).execute()
+
+            if (finishResponse.hasErrors()) {
+                Result.failure(Exception(finishResponse.errors?.firstOrNull()?.message ?: "Upload failed"))
+            } else {
+                val medium = finishResponse.data?.finishMediumUpload?.onFinishMediumUploadPayload?.medium
+                    ?: return Result.failure(Exception("Upload failed"))
+                Result.success(
+                    UploadedMedium(
+                        relayId = medium.id,
+                        uuid = medium.uuid.toString(),
+                        url = medium.url.toString(),
+                        width = medium.width ?: 0,
+                        height = medium.height ?: 0,
+                    )
+                )
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun generateMediumAltText(
+        mediumRelayId: String,
+        language: String,
+        context: String,
+    ): Result<String> {
+        return try {
+            val response = apolloClient.query(
+                MediumGeneratedAltTextQuery(
+                    mediumId = mediumRelayId,
+                    language = language,
+                    context = Optional.present(context),
+                )
+            ).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Alt text generation failed"))
+            } else {
+                val altText = response.data?.node?.onMedium?.generatedAltText
+                if (altText.isNullOrBlank()) {
+                    Result.failure(Exception("Alt text generation failed"))
+                } else {
+                    Result.success(altText)
                 }
             }
         } catch (e: Exception) {
@@ -1745,6 +1896,79 @@ class HackersPubRepository @Inject constructor(
                 jsonArr
             }
             else -> value
+        }
+    }
+
+    private fun contentLength(uri: Uri): Long {
+        queryOpenableSize(uri)?.let { return it }
+
+        return context.contentResolver.openAssetFileDescriptor(uri, "r")?.use { descriptor ->
+            descriptor.length
+        } ?: -1L
+    }
+
+    private fun queryOpenableSize(uri: Uri): Long? {
+        val projection = arrayOf(OpenableColumns.SIZE)
+        val cursor: Cursor = context.contentResolver.query(uri, projection, null, null, null)
+            ?: return null
+
+        return cursor.use {
+            val sizeColumn = it.getColumnIndex(OpenableColumns.SIZE)
+            if (sizeColumn >= 0 && it.moveToFirst() && !it.isNull(sizeColumn)) {
+                it.getLong(sizeColumn).takeIf { size -> size > 0L }
+            } else {
+                null
+            }
+        }
+    }
+
+    private suspend fun executeUploadRequest(request: Request): Response {
+        return suspendCancellableCoroutine { continuation ->
+            val call = okHttpClient.newCall(request)
+            continuation.invokeOnCancellation { call.cancel() }
+            call.enqueue(
+                object : Callback {
+                    override fun onFailure(call: Call, e: IOException) {
+                        if (continuation.isCancelled) return
+                        continuation.resumeWithException(e)
+                    }
+
+                    override fun onResponse(call: Call, response: Response) {
+                        continuation.resume(response)
+                    }
+                }
+            )
+        }
+    }
+
+    private class ContentUriRequestBody(
+        private val context: Context,
+        private val uri: Uri,
+        private val contentType: String,
+        private val contentLength: Long,
+        private val onProgress: (Int) -> Unit,
+    ) : RequestBody() {
+        override fun contentType() = contentType.toMediaTypeOrNull()
+
+        override fun contentLength() = contentLength
+
+        override fun writeTo(sink: BufferedSink) {
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                var uploaded = 0L
+                while (true) {
+                    val read = input.read(buffer)
+                    if (read == -1) break
+                    sink.write(buffer, 0, read)
+                    uploaded += read
+                    val progress = if (contentLength > 0L) {
+                        ((uploaded * 100L) / contentLength).toInt().coerceIn(0, 100)
+                    } else {
+                        0
+                    }
+                    onProgress(progress)
+                }
+            } ?: throw IllegalStateException("Unable to open selected image")
         }
     }
 

--- a/app/src/main/java/pub/hackers/android/di/AppModule.kt
+++ b/app/src/main/java/pub/hackers/android/di/AppModule.kt
@@ -39,6 +39,12 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideOkHttpClient(): OkHttpClient {
+        return OkHttpClient.Builder().build()
+    }
+
+    @Provides
+    @Singleton
     fun provideApolloClient(
         @ApplicationContext context: Context,
         sessionManager: SessionManager
@@ -57,15 +63,16 @@ object AppModule {
             chain.proceed(request)
         }
 
-        val okHttpClient = OkHttpClient.Builder()
+        return OkHttpClient.Builder()
             .addInterceptor(authInterceptor)
             .build()
-
-        return ApolloClient.Builder()
-            .serverUrl("https://hackers.pub/graphql")
-            .okHttpClient(okHttpClient)
-            .normalizedCache(sqlNormalizedCacheFactory)
-            .build()
+            .let { okHttpClient ->
+                ApolloClient.Builder()
+                    .serverUrl("https://hackers.pub/graphql")
+                    .okHttpClient(okHttpClient)
+                    .normalizedCache(sqlNormalizedCacheFactory)
+                    .build()
+            }
     }
 
     @Provides

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -40,6 +40,21 @@ data class Media(
 }
 
 @Immutable
+data class UploadedMedium(
+    val relayId: String,
+    val uuid: String,
+    val url: String,
+    val width: Int,
+    val height: Int
+)
+
+@Immutable
+data class NoteMediumAttachment(
+    val mediumId: String,
+    val alt: String
+)
+
+@Immutable
 data class EngagementStats(
     val replies: Int,
     val reactions: Int,

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -1,11 +1,16 @@
 package pub.hackers.android.ui.screens.compose
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -16,6 +21,8 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -24,9 +31,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.outlined.AutoFixHigh
 import androidx.compose.material.icons.outlined.FormatQuote
 import androidx.compose.material.icons.outlined.Group
 import androidx.compose.material.icons.outlined.Lock
@@ -35,9 +45,14 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -100,9 +115,11 @@ private fun calculateMentionPopupOffset(
 ): IntOffset {
     val cursorYInBox = inputs.cursorRect.bottom - inputs.scrollY + paddingPx
     val cursorXInBox = inputs.cursorRect.left + paddingPx
+    val cursorMinY = paddingPx
+    val cursorMaxY = (inputs.textFieldBounds.height - paddingPx).coerceAtLeast(cursorMinY)
     val visibleCursorY = cursorYInBox.coerceIn(
-        paddingPx,
-        inputs.textFieldBounds.height - paddingPx
+        cursorMinY,
+        cursorMaxY
     )
 
     return IntOffset(
@@ -114,6 +131,7 @@ private fun calculateMentionPopupOffset(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ComposeScreen(
     replyToId: String?,
@@ -132,6 +150,12 @@ fun ComposeScreen(
 
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickMultipleVisualMedia(maxItems = 20),
+        onResult = { uris -> viewModel.addMediaUris(uris) }
+    )
+    var selectedAttachmentId by remember { mutableStateOf<String?>(null) }
+    val selectedAttachment = uiState.mediaAttachments.firstOrNull { it.localId == selectedAttachmentId }
 
     // Track TextFieldValue for cursor position
     var textFieldValue by remember {
@@ -223,7 +247,13 @@ fun ComposeScreen(
         focusRequester.requestFocus()
     }
 
-    val postEnabled = uiState.content.isNotBlank() && !uiState.isPosting
+    val mediaReady = uiState.mediaAttachments.all { attachment ->
+        !attachment.isUploading &&
+            attachment.uploadedMediumId != null &&
+            attachment.altText.isNotBlank() &&
+            attachment.error == null
+    }
+    val postEnabled = uiState.content.isNotBlank() && !uiState.isPosting && mediaReady
 
     Scaffold(
         contentWindowInsets = WindowInsets(0),
@@ -364,6 +394,12 @@ fun ComposeScreen(
                     }
                 }
 
+                MediaAttachmentSection(
+                    attachments = uiState.mediaAttachments,
+                    onRemove = viewModel::removeMediaAttachment,
+                    onAttachmentClick = { selectedAttachmentId = it },
+                )
+
                 // Quoted post preview
                 QuotedPostSection(
                     isLoading = uiState.isLoadingQuotedPost,
@@ -372,158 +408,468 @@ fun ComposeScreen(
             }
             // Close inner content Column
 
-            // Visibility toolbar pinned above keyboard
+            // Composer controls pinned above keyboard
             HorizontalDivider(color = colors.divider)
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 4.dp, vertical = 4.dp)
+                    .padding(start = 4.dp, top = 10.dp, end = 4.dp, bottom = 4.dp),
             ) {
-                Spacer(modifier = Modifier.weight(1f))
-
-                TextButton(
-                    onClick = { showVisibilityMenu = true },
-                    contentPadding = androidx.compose.foundation.layout.PaddingValues(
-                        horizontal = 8.dp,
-                        vertical = 4.dp
-                    )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Icon(
-                        imageVector = visibilityIcon(uiState.visibility),
-                        contentDescription = visibilityLabel(uiState.visibility),
-                        tint = colors.textSecondary
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = visibilityLabel(uiState.visibility),
-                        color = colors.textSecondary,
-                        style = typography.labelMedium
-                    )
-                    Icon(
-                        imageVector = Icons.Default.KeyboardArrowDown,
-                        contentDescription = null,
-                        tint = colors.textSecondary,
-                        modifier = Modifier.size(18.dp)
-                    )
-
-                    DropdownMenu(
-                        expanded = showVisibilityMenu,
-                        onDismissRequest = { showVisibilityMenu = false }
+                    IconButton(
+                        onClick = {
+                            imagePickerLauncher.launch(
+                                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                            )
+                        },
+                        enabled = !uiState.isPosting && uiState.mediaAttachments.size < 20,
                     ) {
-                        visibilityMenuItem(
-                            visibility = PostVisibility.PUBLIC,
-                            selectedVisibility = uiState.visibility,
-                            onClick = {
-                                viewModel.updateVisibility(PostVisibility.PUBLIC)
-                                showVisibilityMenu = false
-                            }
+                        Icon(
+                            imageVector = Icons.Filled.Image,
+                            contentDescription = stringResource(R.string.attach_images),
+                            tint = colors.textSecondary,
                         )
-                        visibilityMenuItem(
-                            visibility = PostVisibility.UNLISTED,
-                            selectedVisibility = uiState.visibility,
-                            onClick = {
-                                viewModel.updateVisibility(PostVisibility.UNLISTED)
-                                showVisibilityMenu = false
-                            }
+                    }
+
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    TextButton(
+                        onClick = { showVisibilityMenu = true },
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                            horizontal = 8.dp,
+                            vertical = 4.dp
                         )
-                        visibilityMenuItem(
-                            visibility = PostVisibility.FOLLOWERS,
-                            selectedVisibility = uiState.visibility,
-                            onClick = {
-                                viewModel.updateVisibility(PostVisibility.FOLLOWERS)
-                                showVisibilityMenu = false
-                            }
+                    ) {
+                        Icon(
+                            imageVector = visibilityIcon(uiState.visibility),
+                            contentDescription = visibilityLabel(uiState.visibility),
+                            tint = colors.textSecondary
                         )
-                        visibilityMenuItem(
-                            visibility = PostVisibility.DIRECT,
-                            selectedVisibility = uiState.visibility,
-                            onClick = {
-                                viewModel.updateVisibility(PostVisibility.DIRECT)
-                                showVisibilityMenu = false
-                            }
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = visibilityLabel(uiState.visibility),
+                            color = colors.textSecondary,
+                            style = typography.labelMedium
                         )
+                        Icon(
+                            imageVector = Icons.Default.KeyboardArrowDown,
+                            contentDescription = null,
+                            tint = colors.textSecondary,
+                            modifier = Modifier.size(18.dp)
+                        )
+
+                        DropdownMenu(
+                            expanded = showVisibilityMenu,
+                            onDismissRequest = { showVisibilityMenu = false }
+                        ) {
+                            visibilityMenuItem(
+                                visibility = PostVisibility.PUBLIC,
+                                selectedVisibility = uiState.visibility,
+                                onClick = {
+                                    viewModel.updateVisibility(PostVisibility.PUBLIC)
+                                    showVisibilityMenu = false
+                                }
+                            )
+                            visibilityMenuItem(
+                                visibility = PostVisibility.UNLISTED,
+                                selectedVisibility = uiState.visibility,
+                                onClick = {
+                                    viewModel.updateVisibility(PostVisibility.UNLISTED)
+                                    showVisibilityMenu = false
+                                }
+                            )
+                            visibilityMenuItem(
+                                visibility = PostVisibility.FOLLOWERS,
+                                selectedVisibility = uiState.visibility,
+                                onClick = {
+                                    viewModel.updateVisibility(PostVisibility.FOLLOWERS)
+                                    showVisibilityMenu = false
+                                }
+                            )
+                            visibilityMenuItem(
+                                visibility = PostVisibility.DIRECT,
+                                selectedVisibility = uiState.visibility,
+                                onClick = {
+                                    viewModel.updateVisibility(PostVisibility.DIRECT)
+                                    showVisibilityMenu = false
+                                }
+                            )
+                        }
+                    }
+
+                    TextButton(
+                        onClick = { showQuotePolicyMenu = true },
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                            horizontal = 8.dp,
+                            vertical = 4.dp
+                        )
+                    ) {
+                        Icon(
+                            imageVector = quotePolicyIcon(effectiveQuotePolicy),
+                            contentDescription = quotePolicyLabel(effectiveQuotePolicy),
+                            tint = colors.textSecondary
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = quotePolicyShortLabel(effectiveQuotePolicy),
+                            color = colors.textSecondary,
+                            style = typography.labelMedium
+                        )
+                        Icon(
+                            imageVector = Icons.Default.KeyboardArrowDown,
+                            contentDescription = null,
+                            tint = colors.textSecondary,
+                            modifier = Modifier.size(18.dp)
+                        )
+
+                        DropdownMenu(
+                            expanded = showQuotePolicyMenu,
+                            onDismissRequest = { showQuotePolicyMenu = false }
+                        ) {
+                            quotePolicyMenuItem(
+                                policy = QuotePolicy.EVERYONE,
+                                selectedPolicy = effectiveQuotePolicy,
+                                enabled = !quotePolicyLocked,
+                                onClick = {
+                                    viewModel.updateQuotePolicy(QuotePolicy.EVERYONE)
+                                    showQuotePolicyMenu = false
+                                }
+                            )
+                            quotePolicyMenuItem(
+                                policy = QuotePolicy.FOLLOWERS,
+                                selectedPolicy = effectiveQuotePolicy,
+                                enabled = !quotePolicyLocked,
+                                onClick = {
+                                    viewModel.updateQuotePolicy(QuotePolicy.FOLLOWERS)
+                                    showQuotePolicyMenu = false
+                                }
+                            )
+                            quotePolicyMenuItem(
+                                policy = QuotePolicy.SELF,
+                                selectedPolicy = effectiveQuotePolicy,
+                                enabled = true,
+                                onClick = {
+                                    viewModel.updateQuotePolicy(QuotePolicy.SELF)
+                                    showQuotePolicyMenu = false
+                                }
+                            )
+                        }
                     }
                 }
 
-                TextButton(
-                    onClick = { showQuotePolicyMenu = true },
-                    contentPadding = androidx.compose.foundation.layout.PaddingValues(
-                        horizontal = 8.dp,
-                        vertical = 4.dp
-                    )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Icon(
-                        imageVector = quotePolicyIcon(effectiveQuotePolicy),
-                        contentDescription = quotePolicyLabel(effectiveQuotePolicy),
-                        tint = colors.textSecondary
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = quotePolicyShortLabel(effectiveQuotePolicy),
-                        color = colors.textSecondary,
-                        style = typography.labelMedium
-                    )
-                    Icon(
-                        imageVector = Icons.Default.KeyboardArrowDown,
-                        contentDescription = null,
-                        tint = colors.textSecondary,
-                        modifier = Modifier.size(18.dp)
-                    )
-
-                    DropdownMenu(
-                        expanded = showQuotePolicyMenu,
-                        onDismissRequest = { showQuotePolicyMenu = false }
+                    Button(
+                        onClick = { viewModel.post() },
+                        enabled = postEnabled,
+                        shape = RoundedCornerShape(AppShapes.pillRadius),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = colors.composeAccent,
+                            contentColor = colors.composeOnAccent,
+                            disabledContainerColor = colors.composeAccent,
+                            disabledContentColor = colors.composeOnAccent,
+                        ),
+                        modifier = Modifier.alpha(if (postEnabled) 1f else 0.4f)
                     ) {
-                        quotePolicyMenuItem(
-                            policy = QuotePolicy.EVERYONE,
-                            selectedPolicy = effectiveQuotePolicy,
-                            enabled = !quotePolicyLocked,
-                            onClick = {
-                                viewModel.updateQuotePolicy(QuotePolicy.EVERYONE)
-                                showQuotePolicyMenu = false
-                            }
-                        )
-                        quotePolicyMenuItem(
-                            policy = QuotePolicy.FOLLOWERS,
-                            selectedPolicy = effectiveQuotePolicy,
-                            enabled = !quotePolicyLocked,
-                            onClick = {
-                                viewModel.updateQuotePolicy(QuotePolicy.FOLLOWERS)
-                                showQuotePolicyMenu = false
-                            }
-                        )
-                        quotePolicyMenuItem(
-                            policy = QuotePolicy.SELF,
-                            selectedPolicy = effectiveQuotePolicy,
-                            enabled = true,
-                            onClick = {
-                                viewModel.updateQuotePolicy(QuotePolicy.SELF)
-                                showQuotePolicyMenu = false
-                            }
+                        Text(
+                            text = stringResource(R.string.post),
+                            color = colors.composeOnAccent
                         )
                     }
                 }
+            }
+        }
+    }
 
-                Button(
-                    onClick = { viewModel.post() },
-                    enabled = postEnabled,
-                    shape = RoundedCornerShape(AppShapes.pillRadius),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = colors.composeAccent,
-                        contentColor = colors.composeOnAccent,
-                        disabledContainerColor = colors.composeAccent,
-                        disabledContentColor = colors.composeOnAccent,
-                    ),
-                    modifier = Modifier.alpha(if (postEnabled) 1f else 0.4f)
+    selectedAttachment?.let { attachment ->
+        ModalBottomSheet(
+            onDismissRequest = { selectedAttachmentId = null },
+        ) {
+            MediaAttachmentEditorSheet(
+                attachment = attachment,
+                onAltTextChange = viewModel::updateMediaAltText,
+                onGenerateAltText = viewModel::generateAltText,
+                onRemove = {
+                    viewModel.removeMediaAttachment(attachment.localId)
+                    selectedAttachmentId = null
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun MediaAttachmentSection(
+    attachments: List<ComposeMediaAttachment>,
+    onRemove: (String) -> Unit,
+    onAttachmentClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (attachments.isEmpty()) return
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 12.dp, bottom = 12.dp),
+    ) {
+        HorizontalDivider(color = LocalAppColors.current.divider)
+        Spacer(modifier = Modifier.height(12.dp))
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(horizontal = 2.dp),
+        ) {
+            itemsIndexed(
+                items = attachments,
+                key = { _, attachment -> attachment.localId },
+            ) { index, attachment ->
+                MediaAttachmentThumbnailCard(
+                    attachment = attachment,
+                    index = index,
+                    onRemove = onRemove,
+                    onClick = { onAttachmentClick(attachment.localId) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MediaAttachmentThumbnailCard(
+    attachment: ComposeMediaAttachment,
+    index: Int,
+    onRemove: (String) -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+    val requiresAltText = !attachment.isUploading &&
+        attachment.uploadedMediumId != null &&
+        attachment.altText.isBlank() &&
+        attachment.error == null
+    val hasWarning = requiresAltText || attachment.error != null
+    val warningColor = MaterialTheme.colorScheme.error
+
+    Surface(
+        modifier = modifier
+            .width(104.dp)
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(8.dp),
+        color = colors.surface,
+        border = BorderStroke(1.dp, if (hasWarning) warningColor else colors.divider),
+    ) {
+        Column(modifier = Modifier.padding(8.dp)) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(88.dp)
+                    .clip(RoundedCornerShape(AppShapes.mediaRadius))
+            ) {
+                AsyncImage(
+                    model = attachment.uri,
+                    contentDescription = attachment.altText.ifBlank { null },
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
+                )
+                if (attachment.isUploading) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .alpha(0.65f),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator(
+                            progress = { attachment.uploadProgress / 100f },
+                            modifier = Modifier.size(32.dp),
+                            color = colors.composeAccent,
+                        )
+                    }
+                }
+                if (requiresAltText) {
+                    Surface(
+                        modifier = Modifier
+                            .align(Alignment.TopStart)
+                            .padding(4.dp)
+                            .size(24.dp),
+                        shape = CircleShape,
+                        color = warningColor,
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Text(
+                                text = "!",
+                                style = typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onError,
+                            )
+                        }
+                    }
+                }
+                IconButton(
+                    onClick = { onRemove(attachment.localId) },
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .size(32.dp),
                 ) {
-                    Text(
-                        text = stringResource(R.string.post),
-                        color = colors.composeOnAccent
+                    Icon(
+                        imageVector = Icons.Filled.Delete,
+                        contentDescription = stringResource(R.string.remove_image),
+                        tint = colors.composeOnAccent,
+                    )
+                }
+            }
+
+            if (attachment.isUploading) {
+                Spacer(modifier = Modifier.height(6.dp))
+                LinearProgressIndicator(
+                    progress = { attachment.uploadProgress / 100f },
+                    modifier = Modifier.fillMaxWidth(),
+                    color = colors.composeAccent,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = if (requiresAltText) {
+                    "! ${stringResource(R.string.attached_image_number, index + 1)}"
+                } else {
+                    stringResource(R.string.attached_image_number, index + 1)
+                },
+                style = typography.labelSmall,
+                color = if (hasWarning) warningColor else colors.textSecondary,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MediaAttachmentEditorSheet(
+    attachment: ComposeMediaAttachment,
+    onAltTextChange: (String, String) -> Unit,
+    onGenerateAltText: (String) -> Unit,
+    onRemove: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(R.string.alt_text_required),
+                style = typography.titleMedium,
+                color = colors.textPrimary,
+                modifier = Modifier.weight(1f),
+            )
+            IconButton(onClick = onRemove) {
+                Icon(
+                    imageVector = Icons.Filled.Delete,
+                    contentDescription = stringResource(R.string.remove_image),
+                    tint = colors.textSecondary,
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(220.dp)
+                .clip(RoundedCornerShape(AppShapes.mediaRadius))
+        ) {
+            AsyncImage(
+                model = attachment.uri,
+                contentDescription = attachment.altText.ifBlank { null },
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+            )
+            if (attachment.isUploading) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .alpha(0.65f),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator(
+                        progress = { attachment.uploadProgress / 100f },
+                        modifier = Modifier.size(40.dp),
+                        color = colors.composeAccent,
                     )
                 }
             }
         }
+
+        if (attachment.isUploading) {
+            Spacer(modifier = Modifier.height(8.dp))
+            LinearProgressIndicator(
+                progress = { attachment.uploadProgress / 100f },
+                modifier = Modifier.fillMaxWidth(),
+                color = colors.composeAccent,
+            )
+        }
+
+        attachment.error?.let { error ->
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = error,
+                style = typography.labelSmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = attachment.altText,
+            onValueChange = { onAltTextChange(attachment.localId, it) },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !attachment.isUploading,
+            textStyle = typography.bodyMedium,
+            label = { Text(stringResource(R.string.alt_text_required)) },
+            singleLine = false,
+            minLines = 3,
+            supportingText = {
+                Text(
+                    text = stringResource(R.string.alt_text_required_supporting),
+                    style = typography.labelSmall,
+                )
+            },
+        )
+
+        TextButton(
+            onClick = { onGenerateAltText(attachment.localId) },
+            enabled = !attachment.isUploading &&
+                attachment.uploadedMediumRelayId != null &&
+                !attachment.isGeneratingAltText,
+            modifier = Modifier.align(Alignment.End),
+        ) {
+            if (attachment.isGeneratingAltText) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+            } else {
+                Icon(
+                    imageVector = Icons.Outlined.AutoFixHigh,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+            }
+            Text(stringResource(R.string.auto_fill_alt_text))
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
     }
 }
 

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,18 +13,36 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import android.icu.util.ULocale
+import android.net.Uri
 import android.os.Build
 import android.view.textclassifier.TextClassificationManager
 import android.view.textclassifier.TextLanguage
+import androidx.compose.runtime.Immutable
 import pub.hackers.android.data.repository.HackersPubRepository
 import pub.hackers.android.domain.model.Actor
+import pub.hackers.android.domain.model.NoteMediumAttachment
 import pub.hackers.android.domain.model.Post
 import pub.hackers.android.domain.model.PostVisibility
 import pub.hackers.android.domain.model.QuotePolicy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import android.content.Context
+import java.util.UUID
 import javax.inject.Inject
+
+private const val MAX_NOTE_MEDIA = 20
+
+@Immutable
+data class ComposeMediaAttachment(
+    val localId: String,
+    val uri: Uri,
+    val altText: String = "",
+    val uploadProgress: Int = 0,
+    val uploadedMediumId: String? = null,
+    val uploadedMediumRelayId: String? = null,
+    val isUploading: Boolean = true,
+    val isGeneratingAltText: Boolean = false,
+    val error: String? = null,
+)
 
 data class ComposeUiState(
     val content: String = "",
@@ -38,6 +57,7 @@ data class ComposeUiState(
     val quotedPost: Post? = null,
     val isLoadingQuotedPost: Boolean = false,
     val quotedPostLoadFailed: Boolean = false,
+    val mediaAttachments: List<ComposeMediaAttachment> = emptyList(),
     val isPosting: Boolean = false,
     val isPosted: Boolean = false,
     val error: String? = null,
@@ -52,7 +72,7 @@ data class ComposeUiState(
 @HiltViewModel
 class ComposeViewModel @Inject constructor(
     private val repository: HackersPubRepository,
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val replyPostedSignal: ReplyPostedSignal,
 ) : ViewModel() {
 
@@ -60,6 +80,7 @@ class ComposeViewModel @Inject constructor(
     val uiState: StateFlow<ComposeUiState> = _uiState.asStateFlow()
 
     private var viewerHandle: String? = null
+    private val uploadJobs = mutableMapOf<String, Job>()
 
     // Regex to detect @mention at cursor position
     // Matches: @handle or @user@domain patterns that are incomplete
@@ -304,9 +325,149 @@ class ComposeViewModel @Inject constructor(
         _uiState.update { it.copy(quotePolicy = quotePolicy) }
     }
 
+    fun addMediaUris(uris: List<Uri>) {
+        if (uris.isEmpty()) return
+
+        val currentCount = _uiState.value.mediaAttachments.size
+        val remainingSlots = MAX_NOTE_MEDIA - currentCount
+        if (remainingSlots <= 0) {
+            _uiState.update { it.copy(error = "You can attach up to $MAX_NOTE_MEDIA images") }
+            return
+        }
+
+        val acceptedUris = uris.take(remainingSlots)
+        if (acceptedUris.size < uris.size) {
+            _uiState.update { it.copy(error = "Some images were skipped because the limit is $MAX_NOTE_MEDIA") }
+        }
+
+        val attachments = acceptedUris.map { uri ->
+            ComposeMediaAttachment(
+                localId = UUID.randomUUID().toString(),
+                uri = uri,
+            )
+        }
+
+        _uiState.update { state ->
+            state.copy(mediaAttachments = state.mediaAttachments + attachments)
+        }
+
+        attachments.forEach { attachment ->
+            uploadMediaAttachment(attachment.localId, attachment.uri)
+        }
+    }
+
+    fun removeMediaAttachment(localId: String) {
+        uploadJobs.remove(localId)?.cancel()
+        _uiState.update { state ->
+            state.copy(mediaAttachments = state.mediaAttachments.filterNot { it.localId == localId })
+        }
+    }
+
+    fun updateMediaAltText(localId: String, altText: String) {
+        updateMediaAttachment(localId) { it.copy(altText = altText) }
+    }
+
+    fun generateAltText(localId: String) {
+        val attachment = _uiState.value.mediaAttachments.firstOrNull { it.localId == localId }
+        val mediumRelayId = attachment?.uploadedMediumRelayId ?: return
+        if (attachment.isGeneratingAltText) return
+
+        updateMediaAttachment(localId) { it.copy(isGeneratingAltText = true, error = null) }
+        viewModelScope.launch {
+            repository.generateMediumAltText(
+                mediumRelayId = mediumRelayId,
+                language = _uiState.value.language,
+                context = _uiState.value.content,
+            )
+                .onSuccess { altText ->
+                    updateMediaAttachment(localId) {
+                        it.copy(
+                            altText = altText,
+                            isGeneratingAltText = false,
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    updateMediaAttachment(localId) {
+                        it.copy(
+                            isGeneratingAltText = false,
+                            error = error.message,
+                        )
+                    }
+                    _uiState.update { it.copy(error = error.message ?: "Alt text generation failed") }
+                }
+        }
+    }
+
+    private fun uploadMediaAttachment(localId: String, uri: Uri) {
+        uploadJobs[localId]?.cancel()
+        uploadJobs[localId] = viewModelScope.launch {
+            try {
+                repository.uploadMedium(uri) { progress ->
+                    updateMediaAttachment(localId) { it.copy(uploadProgress = progress) }
+                }
+                    .onSuccess { medium ->
+                        updateMediaAttachment(localId) {
+                            it.copy(
+                                uploadProgress = 100,
+                                uploadedMediumId = medium.uuid,
+                                uploadedMediumRelayId = medium.relayId,
+                                isUploading = false,
+                            )
+                        }
+                    }
+                    .onFailure { error ->
+                        updateMediaAttachment(localId) {
+                            it.copy(
+                                isUploading = false,
+                                error = error.message,
+                            )
+                        }
+                        _uiState.update { it.copy(error = error.message ?: "Image upload failed") }
+                    }
+            } finally {
+                uploadJobs.remove(localId)
+            }
+        }
+    }
+
+    private fun updateMediaAttachment(
+        localId: String,
+        transform: (ComposeMediaAttachment) -> ComposeMediaAttachment,
+    ) {
+        _uiState.update { state ->
+            state.copy(
+                mediaAttachments = state.mediaAttachments.map { attachment ->
+                    if (attachment.localId == localId) transform(attachment) else attachment
+                }
+            )
+        }
+    }
+
     fun post() {
         val state = _uiState.value
         if (state.content.isBlank() || state.isPosting) return
+        val media = state.mediaAttachments.map { attachment ->
+            val mediumId = attachment.uploadedMediumId
+            when {
+                attachment.isUploading || mediumId == null -> {
+                    _uiState.update { it.copy(error = "Wait for image uploads to finish") }
+                    return
+                }
+                attachment.altText.isBlank() -> {
+                    _uiState.update { it.copy(error = "Alt text is required for every image") }
+                    return
+                }
+                attachment.error != null -> {
+                    _uiState.update { it.copy(error = attachment.error) }
+                    return
+                }
+                else -> NoteMediumAttachment(
+                    mediumId = mediumId,
+                    alt = attachment.altText.trim(),
+                )
+            }
+        }
 
         viewModelScope.launch {
             _uiState.update { it.copy(isPosting = true, error = null) }
@@ -317,7 +478,8 @@ class ComposeViewModel @Inject constructor(
                 visibility = state.visibility,
                 quotePolicy = state.effectiveQuotePolicy(),
                 replyTargetId = state.replyToId,
-                quotedPostId = state.quotedPostId
+                quotedPostId = state.quotedPostId,
+                media = media,
             )
                 .onSuccess { newPost ->
                     state.replyToId?.let { replyTargetId ->
@@ -346,5 +508,11 @@ class ComposeViewModel @Inject constructor(
         } else {
             QuotePolicy.SELF
         }
+    }
+
+    override fun onCleared() {
+        uploadJobs.values.forEach { it.cancel() }
+        uploadJobs.clear()
+        super.onCleared()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,12 @@
     <string name="quote_policy_short_everyone">Quote: Anyone</string>
     <string name="quote_policy_short_followers">Quote: Followers</string>
     <string name="quote_policy_short_self">Quote: Only you</string>
+    <string name="attach_images">Attach images</string>
+    <string name="attached_image_number">Image %1$d</string>
+    <string name="remove_image">Remove image</string>
+    <string name="alt_text_required">Alt text</string>
+    <string name="alt_text_required_supporting">Required before posting</string>
+    <string name="auto_fill_alt_text">Auto-fill</string>
 
     <!-- Article Compose -->
     <string name="new_article">New Article</string>

--- a/app/src/test/java/pub/hackers/android/ui/screens/compose/ComposeViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/compose/ComposeViewModelTest.kt
@@ -1,6 +1,7 @@
 package pub.hackers.android.ui.screens.compose
 
 import android.content.Context
+import android.net.Uri
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -17,10 +18,12 @@ import org.robolectric.annotation.Config
 import pub.hackers.android.data.repository.HackersPubRepository
 import pub.hackers.android.domain.model.Actor
 import pub.hackers.android.domain.model.EngagementStats
+import pub.hackers.android.domain.model.NoteMediumAttachment
 import pub.hackers.android.domain.model.Post
 import pub.hackers.android.domain.model.PostDetailResult
 import pub.hackers.android.domain.model.PostVisibility
 import pub.hackers.android.domain.model.QuotePolicy
+import pub.hackers.android.domain.model.UploadedMedium
 import pub.hackers.android.testutil.MainDispatcherRule
 import java.time.Instant
 
@@ -185,6 +188,92 @@ class ComposeViewModelTest {
                 quotePolicy = QuotePolicy.SELF,
                 replyTargetId = null,
                 quotedPostId = null,
+            )
+        }
+    }
+
+    @Test
+    fun `post sends uploaded media with required alt text`() = runTest {
+        val createdPost = samplePost(id = "created")
+        coEvery { repository.uploadMedium(any(), any()) } coAnswers {
+            secondArg<(Int) -> Unit>().invoke(100)
+            Result.success(
+                UploadedMedium(
+                    relayId = "relay-medium-1",
+                    uuid = "medium-uuid-1",
+                    url = "https://example.com/image.webp",
+                    width = 100,
+                    height = 80,
+                )
+            )
+        }
+        coEvery {
+            repository.createNote(
+                content = "hello with image",
+                language = any(),
+                visibility = PostVisibility.PUBLIC,
+                quotePolicy = QuotePolicy.EVERYONE,
+                replyTargetId = null,
+                quotedPostId = null,
+                media = listOf(NoteMediumAttachment(mediumId = "medium-uuid-1", alt = "diagram")),
+            )
+        } returns Result.success(createdPost)
+
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.updateContent("hello with image")
+        vm.addMediaUris(listOf(Uri.parse("content://images/1")))
+        advanceUntilIdle()
+        val attachmentId = vm.uiState.value.mediaAttachments.single().localId
+        vm.updateMediaAltText(attachmentId, "diagram")
+        vm.post()
+        advanceUntilIdle()
+
+        coVerify {
+            repository.createNote(
+                content = "hello with image",
+                language = any(),
+                visibility = PostVisibility.PUBLIC,
+                quotePolicy = QuotePolicy.EVERYONE,
+                replyTargetId = null,
+                quotedPostId = null,
+                media = listOf(NoteMediumAttachment(mediumId = "medium-uuid-1", alt = "diagram")),
+            )
+        }
+    }
+
+    @Test
+    fun `post blocks media without alt text`() = runTest {
+        coEvery { repository.uploadMedium(any(), any()) } returns Result.success(
+            UploadedMedium(
+                relayId = "relay-medium-1",
+                uuid = "medium-uuid-1",
+                url = "https://example.com/image.webp",
+                width = 100,
+                height = 80,
+            )
+        )
+
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.updateContent("hello with image")
+        vm.addMediaUris(listOf(Uri.parse("content://images/1")))
+        advanceUntilIdle()
+        vm.post()
+        advanceUntilIdle()
+
+        assertEquals("Alt text is required for every image", vm.uiState.value.error)
+        coVerify(exactly = 0) {
+            repository.createNote(
+                content = any(),
+                language = any(),
+                visibility = any(),
+                quotePolicy = any(),
+                replyTargetId = any(),
+                quotedPostId = any(),
+                media = any(),
             )
         }
     }


### PR DESCRIPTION
## Summary
- add GraphQL operations and repository plumbing for note media uploads and generated alt text
- add composer image picker, upload progress, thumbnail rail, and bottom-sheet alt editor
- require uploaded images to have alt text before posting, with `!` highlighting for missing annotations
- fix mention popup positioning when the active input area is constrained

## Tests
- `./gradlew :app:testDebugUnitTest --tests pub.hackers.android.ui.screens.compose.ComposeViewModelTest :app:lintDebug`