### PR TITLE
Support post updated notifications

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -244,6 +244,12 @@ query Notifications($after: String) {
                             content
                         }
                     }
+                    ... on QuotedPostUpdatedNotification {
+                        post {
+                            id
+                            content
+                        }
+                    }
                     ... on ReactNotification {
                         emoji
                         customEmoji {
@@ -257,6 +263,12 @@ query Notifications($after: String) {
                         }
                     }
                     ... on ShareNotification {
+                        post {
+                            id
+                            content
+                        }
+                    }
+                    ... on SharedPostUpdatedNotification {
                         post {
                             id
                             content

--- a/app/src/main/graphql/pub/hackers/android/schema.graphqls
+++ b/app/src/main/graphql/pub/hackers/android/schema.graphqls
@@ -1141,11 +1141,15 @@ enum NotificationType {
 
   QUOTE
 
+  QUOTED_POST_UPDATED
+
   REACT
 
   REPLY
 
   SHARE
+
+  SHARED_POST_UPDATED
 }
 
 type PageInfo {
@@ -1683,6 +1687,20 @@ type QuoteNotification implements Node & Notification {
   uuid: UUID!
 }
 
+type QuotedPostUpdatedNotification implements Node & Notification {
+  account: Account!
+
+  actors(after: String, before: String, first: Int, last: Int): NotificationActorsConnection!
+
+  created: DateTime!
+
+  id: ID!
+
+  post: Post
+
+  uuid: UUID!
+}
+
 type ReactNotification implements Node & Notification {
   account: Account!
 
@@ -1939,6 +1957,20 @@ type Session {
 }
 
 type ShareNotification implements Node & Notification {
+  account: Account!
+
+  actors(after: String, before: String, first: Int, last: Int): NotificationActorsConnection!
+
+  created: DateTime!
+
+  id: ID!
+
+  post: Post
+
+  uuid: UUID!
+}
+
+type SharedPostUpdatedNotification implements Node & Notification {
   account: Account!
 
   actors(after: String, before: String, first: Int, last: Int): NotificationActorsConnection!

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -1829,12 +1829,30 @@ class HackersPubRepository @Inject constructor(
                 actors = actors,
                 post = onQuoteNotification.post?.let { NotificationPost(id = it.id, content = it.content.toString()) }
             )
+            onQuotedPostUpdatedNotification != null -> Notification.QuotedPostUpdated(
+                id = id,
+                uuid = uuid.toString(),
+                created = created,
+                actors = actors,
+                post = onQuotedPostUpdatedNotification.post?.let {
+                    NotificationPost(id = it.id, content = it.content.toString())
+                }
+            )
             onShareNotification != null -> Notification.Share(
                 id = id,
                 uuid = uuid.toString(),
                 created = created,
                 actors = actors,
                 post = onShareNotification.post?.let { NotificationPost(id = it.id, content = it.content.toString()) }
+            )
+            onSharedPostUpdatedNotification != null -> Notification.SharedPostUpdated(
+                id = id,
+                uuid = uuid.toString(),
+                created = created,
+                actors = actors,
+                post = onSharedPostUpdatedNotification.post?.let {
+                    NotificationPost(id = it.id, content = it.content.toString())
+                }
             )
             onReactNotification != null -> Notification.React(
                 id = id,

--- a/app/src/main/java/pub/hackers/android/data/worker/NotificationWorker.kt
+++ b/app/src/main/java/pub/hackers/android/data/worker/NotificationWorker.kt
@@ -135,7 +135,9 @@ class NotificationWorker @AssistedInject constructor(
             is Notification.Mention -> "$actorName mentioned you"
             is Notification.Reply -> "$actorName replied to your post"
             is Notification.Quote -> "$actorName quoted your post"
+            is Notification.QuotedPostUpdated -> "$actorName updated a post you quoted"
             is Notification.Share -> "$actorName shared your post"
+            is Notification.SharedPostUpdated -> "$actorName updated a post you shared"
             is Notification.React -> {
                 val othersCount = notification.actors.size - 1
                 val othersText = if (othersCount > 0) {

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -166,7 +166,25 @@ sealed class Notification {
     ) : Notification()
 
     @Immutable
+    data class QuotedPostUpdated(
+        override val id: String,
+        override val uuid: String,
+        override val created: Instant,
+        override val actors: List<Actor>,
+        val post: NotificationPost?
+    ) : Notification()
+
+    @Immutable
     data class Share(
+        override val id: String,
+        override val uuid: String,
+        override val created: Instant,
+        override val actors: List<Actor>,
+        val post: NotificationPost?
+    ) : Notification()
+
+    @Immutable
+    data class SharedPostUpdated(
         override val id: String,
         override val uuid: String,
         override val created: Instant,

--- a/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsScreen.kt
@@ -168,24 +168,38 @@ private fun NotificationItem(
             stringResource(R.string.notification_quote)
         )
 
+        is Notification.QuotedPostUpdated -> Pair(
+            Icons.Default.FormatQuote,
+            buildMultiActorActionText(
+                notification = notification,
+                actionText = stringResource(R.string.notification_quoted_post_updated)
+            )
+        )
+
         is Notification.Share -> Pair(
             Icons.Default.Repeat,
             stringResource(R.string.notification_share)
         )
 
+        is Notification.SharedPostUpdated -> Pair(
+            Icons.Default.Repeat,
+            buildMultiActorActionText(
+                notification = notification,
+                actionText = stringResource(R.string.notification_shared_post_updated)
+            )
+        )
+
         is Notification.React -> {
-            val othersCount = notification.actors.size - 1
-            val prefix = if (othersCount > 0) {
-                pluralStringResource(
-                    R.plurals.notification_and_others,
-                    othersCount,
-                    othersCount
-                ) + " "
-            } else ""
             val actionStr = if (notification.emoji != null) {
-                prefix + stringResource(R.string.notification_react_with_emoji, notification.emoji)
+                buildMultiActorActionText(
+                    notification = notification,
+                    actionText = stringResource(R.string.notification_react_with_emoji, notification.emoji)
+                )
             } else {
-                prefix + stringResource(R.string.notification_react)
+                buildMultiActorActionText(
+                    notification = notification,
+                    actionText = stringResource(R.string.notification_react)
+                )
             }
             Pair(Icons.Default.Favorite, actionStr)
         }
@@ -195,7 +209,9 @@ private fun NotificationItem(
         is Notification.Mention -> notification.post
         is Notification.Reply -> notification.post
         is Notification.Quote -> notification.post
+        is Notification.QuotedPostUpdated -> notification.post
         is Notification.Share -> notification.post
+        is Notification.SharedPostUpdated -> notification.post
         is Notification.React -> notification.post
         else -> null
     }
@@ -276,6 +292,24 @@ private fun NotificationItem(
             }
         }
     }
+}
+
+@Composable
+private fun buildMultiActorActionText(
+    notification: Notification,
+    actionText: String
+): String {
+    val othersCount = notification.actors.size - 1
+    val prefix = if (othersCount > 0) {
+        pluralStringResource(
+            R.plurals.notification_and_others,
+            othersCount,
+            othersCount
+        ) + " "
+    } else {
+        ""
+    }
+    return prefix + actionText
 }
 
 private fun formatRelativeTime(instant: Instant): String {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,7 +97,9 @@
     <string name="notification_mention">mentioned you</string>
     <string name="notification_reply">replied to your post</string>
     <string name="notification_quote">quoted your post</string>
+    <string name="notification_quoted_post_updated">updated a post you quoted</string>
     <string name="notification_share">shared your post</string>
+    <string name="notification_shared_post_updated">updated a post you shared</string>
     <string name="notification_react">reacted to your post</string>
     <string name="notification_react_with_emoji">reacted to your post with %1$s</string>
     <plurals name="notification_and_others">


### PR DESCRIPTION
## Summary
- add GraphQL/schema and domain mapping for `SharedPostUpdatedNotification` and `QuotedPostUpdatedNotification`
- render the new notification types in the in-app notification list with the reference wording
- include matching text for background notification polling

## Reference
- `hackers-pub/hackerspub` `SharedPostUpdatedNotificationCard` / `QuotedPostUpdatedNotificationCard`

## Tests
- `./gradlew :app:testDebugUnitTest --tests pub.hackers.android.ui.screens.notifications.NotificationsViewModelTest :app:lintDebug`