### PR TITLE
Add language filters to timelines

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -126,8 +126,8 @@ fragment SharedPostFields on Post {
     }
 }
 
-query PublicTimeline($first: Int, $after: String, $before: String, $last: Int) {
-    publicTimeline(first: $first, after: $after, before: $before, last: $last) {
+query PublicTimeline($first: Int, $after: String, $before: String, $last: Int, $languages: [Locale!]) {
+    publicTimeline(first: $first, after: $after, before: $before, last: $last, languages: $languages) {
         edges {
             cursor
             node {
@@ -146,8 +146,8 @@ query PublicTimeline($first: Int, $after: String, $before: String, $last: Int) {
     }
 }
 
-query LocalTimeline($first: Int, $after: String, $before: String, $last: Int) {
-    publicTimeline(local: true, first: $first, after: $after, before: $before, last: $last) {
+query LocalTimeline($first: Int, $after: String, $before: String, $last: Int, $languages: [Locale!]) {
+    publicTimeline(local: true, first: $first, after: $after, before: $before, last: $last, languages: $languages) {
         edges {
             cursor
             node {
@@ -166,8 +166,8 @@ query LocalTimeline($first: Int, $after: String, $before: String, $last: Int) {
     }
 }
 
-query PersonalTimeline($first: Int, $after: String, $before: String, $last: Int) {
-    personalTimeline(first: $first, after: $after, before: $before, last: $last) {
+query PersonalTimeline($first: Int, $after: String, $before: String, $last: Int, $languages: [Locale!]) {
+    personalTimeline(first: $first, after: $after, before: $before, last: $last, languages: $languages) {
         edges {
             cursor
             lastSharer {
@@ -203,6 +203,10 @@ query Viewer {
         avatarUrl
         handle
     }
+}
+
+query SuggestedFilterLanguages {
+    suggestedFilterLanguages
 }
 
 query Notifications($after: String) {

--- a/app/src/main/graphql/pub/hackers/android/schema.graphqls
+++ b/app/src/main/graphql/pub/hackers/android/schema.graphqls
@@ -1521,7 +1521,7 @@ type Query {
 
   nodes(ids: [ID!]!): [Node]!
 
-  personalTimeline(after: String, before: String, first: Int, last: Int, local: Boolean = false, postType: PostType, withoutShares: Boolean = false): QueryPersonalTimelineConnection!
+  personalTimeline(after: String, before: String, first: Int, languages: [Locale!] = [], last: Int, local: Boolean = false, postType: PostType, withoutShares: Boolean = false): QueryPersonalTimelineConnection!
 
   postByUrl(url: String!): Post
 
@@ -1538,6 +1538,8 @@ type Query {
   searchObject(query: String!): SearchObjectResult
 
   searchPost(after: String, before: String, first: Int, languages: [Locale!] = [], last: Int, query: String!): QuerySearchPostConnection!
+
+  suggestedFilterLanguages: [Locale!]!
 
   """
   Verify a signup token and return the signup info if valid.

--- a/app/src/main/java/pub/hackers/android/data/paging/CursorPagingSource.kt
+++ b/app/src/main/java/pub/hackers/android/data/paging/CursorPagingSource.kt
@@ -89,16 +89,22 @@ suspend fun HackersPubRepository.notificationsPage(after: String?) =
     getNotifications(after = after, refresh = (after == null))
         .map { CursorPage(it.notifications, it.endCursor, it.hasNextPage) }
 
-suspend fun HackersPubRepository.personalTimelinePage(after: String?) =
-    getPersonalTimeline(after = after, refresh = (after == null))
+suspend fun HackersPubRepository.personalTimelinePage(
+    after: String?,
+    languages: List<String> = emptyList(),
+) = getPersonalTimeline(after = after, refresh = (after == null), languages = languages)
         .map { CursorPage(it.posts, it.endCursor, it.hasNextPage, it.startCursor, it.hasPreviousPage) }
 
-suspend fun HackersPubRepository.publicTimelinePage(after: String?) =
-    getPublicTimeline(after = after, refresh = (after == null))
+suspend fun HackersPubRepository.publicTimelinePage(
+    after: String?,
+    languages: List<String> = emptyList(),
+) = getPublicTimeline(after = after, refresh = (after == null), languages = languages)
         .map { CursorPage(it.posts, it.endCursor, it.hasNextPage, it.startCursor, it.hasPreviousPage) }
 
-suspend fun HackersPubRepository.localTimelinePage(after: String?) =
-    getLocalTimeline(after = after, refresh = (after == null))
+suspend fun HackersPubRepository.localTimelinePage(
+    after: String?,
+    languages: List<String> = emptyList(),
+) = getLocalTimeline(after = after, refresh = (after == null), languages = languages)
         .map { CursorPage(it.posts, it.endCursor, it.hasNextPage, it.startCursor, it.hasPreviousPage) }
 
 suspend fun HackersPubRepository.postRepliesPage(postId: String, after: String?) =

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -68,6 +68,7 @@ import pub.hackers.android.graphql.SearchObjectQuery
 import pub.hackers.android.graphql.SearchPostQuery
 import pub.hackers.android.graphql.SharePostMutation
 import pub.hackers.android.graphql.StartMediumUploadMutation
+import pub.hackers.android.graphql.SuggestedFilterLanguagesQuery
 import pub.hackers.android.graphql.UnblockActorMutation
 import pub.hackers.android.graphql.UnfollowActorMutation
 import pub.hackers.android.graphql.UnbookmarkPostMutation
@@ -101,6 +102,7 @@ class HackersPubRepository @Inject constructor(
         after: String? = null,
         before: String? = null,
         refresh: Boolean = false,
+        languages: List<String> = emptyList(),
     ): Result<TimelineResult> {
         return try {
             val backwards = before != null
@@ -110,6 +112,7 @@ class HackersPubRepository @Inject constructor(
                     after = Optional.presentIfNotNull(if (backwards) null else after),
                     before = Optional.presentIfNotNull(before),
                     last = Optional.presentIfNotNull(if (backwards) 20 else null),
+                    languages = Optional.present(languages),
                 )
             )
                 .apply { if (refresh || backwards) fetchPolicy(FetchPolicy.NetworkOnly) }
@@ -142,6 +145,7 @@ class HackersPubRepository @Inject constructor(
         after: String? = null,
         before: String? = null,
         refresh: Boolean = false,
+        languages: List<String> = emptyList(),
     ): Result<TimelineResult> {
         return try {
             val backwards = before != null
@@ -151,6 +155,7 @@ class HackersPubRepository @Inject constructor(
                     after = Optional.presentIfNotNull(if (backwards) null else after),
                     before = Optional.presentIfNotNull(before),
                     last = Optional.presentIfNotNull(if (backwards) 20 else null),
+                    languages = Optional.present(languages),
                 )
             )
                 .apply { if (refresh || backwards) fetchPolicy(FetchPolicy.NetworkOnly) }
@@ -183,6 +188,7 @@ class HackersPubRepository @Inject constructor(
         after: String? = null,
         before: String? = null,
         refresh: Boolean = false,
+        languages: List<String> = emptyList(),
     ): Result<TimelineResult> {
         return try {
             val backwards = before != null
@@ -192,6 +198,7 @@ class HackersPubRepository @Inject constructor(
                     after = Optional.presentIfNotNull(if (backwards) null else after),
                     before = Optional.presentIfNotNull(before),
                     last = Optional.presentIfNotNull(if (backwards) 20 else null),
+                    languages = Optional.present(languages),
                 )
             )
                 .apply { if (refresh || backwards) fetchPolicy(FetchPolicy.NetworkOnly) }
@@ -220,6 +227,19 @@ class HackersPubRepository @Inject constructor(
                         )
                     )
                 }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getSuggestedFilterLanguages(): Result<List<String>> {
+        return try {
+            val response = apolloClient.query(SuggestedFilterLanguagesQuery()).execute()
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                Result.success(response.data?.suggestedFilterLanguages.orEmpty().map { it.toString() })
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/pub/hackers/android/ui/components/LanguageFilterRow.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/LanguageFilterRow.kt
@@ -1,0 +1,107 @@
+package pub.hackers.android.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import pub.hackers.android.R
+import pub.hackers.android.ui.theme.LocalAppColors
+import java.util.Locale
+
+@Composable
+fun LanguageFilterRow(
+    languages: List<String>,
+    selectedLanguage: String?,
+    onLanguageSelected: (String?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val configuration = LocalConfiguration.current
+    val uiLocale = remember(configuration) {
+        if (configuration.locales.size() > 0) {
+            configuration.locales[0]
+        } else {
+            Locale.getDefault()
+        }
+    }
+    val displayLanguages = remember(languages, selectedLanguage) {
+        if (selectedLanguage != null && selectedLanguage !in languages) {
+            listOf(selectedLanguage) + languages
+        } else {
+            languages
+        }
+    }
+
+    LazyRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp),
+    ) {
+        item(key = "all") {
+            LanguageFilterChip(
+                label = stringResource(R.string.all_languages),
+                selected = selectedLanguage == null,
+                onClick = { onLanguageSelected(null) },
+            )
+        }
+        items(
+            items = displayLanguages,
+            key = { it },
+        ) { language ->
+            LanguageFilterChip(
+                label = languageFilterLabel(language, uiLocale),
+                selected = selectedLanguage == language,
+                onClick = { onLanguageSelected(language) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun LanguageFilterChip(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val colors = LocalAppColors.current
+    FilterChip(
+        selected = selected,
+        onClick = onClick,
+        label = { Text(label) },
+        colors = FilterChipDefaults.filterChipColors(
+            containerColor = colors.background,
+            labelColor = colors.textBody,
+            selectedContainerColor = colors.accent,
+            selectedLabelColor = colors.background,
+        ),
+        border = FilterChipDefaults.filterChipBorder(
+            enabled = true,
+            selected = selected,
+            borderColor = colors.buttonOutline,
+            selectedBorderColor = colors.accent,
+        ),
+    )
+}
+
+@Composable
+private fun languageFilterLabel(language: String, uiLocale: Locale): String {
+    return remember(language, uiLocale) {
+        val locale = Locale.forLanguageTag(language)
+        val nativeName = locale.getDisplayLanguage(locale).ifBlank { language }
+        val uiName = locale.getDisplayLanguage(uiLocale).ifBlank { language }
+        if (nativeName.equals(uiName, ignoreCase = true)) {
+            nativeName
+        } else {
+            "$nativeName ($uiName)"
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.outlined.AutoFixHigh
 import androidx.compose.material.icons.outlined.FormatQuote
 import androidx.compose.material.icons.outlined.Group
+import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -79,6 +80,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -101,6 +103,7 @@ import pub.hackers.android.ui.theme.AppShapes
 import pub.hackers.android.ui.theme.LocalAppColors
 import pub.hackers.android.ui.theme.LocalAppTypography
 import kotlin.math.roundToInt
+import java.util.Locale
 
 private data class MentionPopupPositionInputs(
     val scrollY: Int,
@@ -145,6 +148,7 @@ fun ComposeScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     var showVisibilityMenu by remember { mutableStateOf(false) }
     var showQuotePolicyMenu by remember { mutableStateOf(false) }
+    var showLanguageMenu by remember { mutableStateOf(false) }
     val quotePolicyLocked = uiState.visibility != PostVisibility.PUBLIC &&
         uiState.visibility != PostVisibility.UNLISTED
     val effectiveQuotePolicy = if (quotePolicyLocked) QuotePolicy.SELF else uiState.quotePolicy
@@ -254,7 +258,10 @@ fun ComposeScreen(
             attachment.altText.isNotBlank() &&
             attachment.error == null
     }
-    val postEnabled = uiState.content.isNotBlank() && !uiState.isPosting && mediaReady
+    val postEnabled = uiState.content.isNotBlank() &&
+        uiState.language.isNotBlank() &&
+        !uiState.isPosting &&
+        mediaReady
 
     Scaffold(
         contentWindowInsets = WindowInsets(0),
@@ -572,6 +579,64 @@ fun ComposeScreen(
                     horizontalArrangement = Arrangement.End,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
+                    val languageOptions = remember(uiState.language, uiState.suggestedLanguages) {
+                        (listOf(uiState.language) + uiState.suggestedLanguages)
+                            .map { it.trim() }
+                            .filter { it.isNotEmpty() }
+                            .distinct()
+                    }
+                    TextButton(
+                        onClick = { showLanguageMenu = true },
+                        enabled = !uiState.isPosting && languageOptions.isNotEmpty(),
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Language,
+                            contentDescription = stringResource(R.string.compose_language_label),
+                            tint = colors.textSecondary,
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = uiState.language.ifBlank {
+                                stringResource(R.string.compose_language_label)
+                            },
+                            color = colors.textSecondary,
+                            style = typography.labelMedium,
+                            maxLines = 1,
+                        )
+                        Icon(
+                            imageVector = Icons.Default.KeyboardArrowDown,
+                            contentDescription = null,
+                            tint = colors.textSecondary,
+                            modifier = Modifier.size(18.dp),
+                        )
+
+                        DropdownMenu(
+                            expanded = showLanguageMenu,
+                            onDismissRequest = { showLanguageMenu = false },
+                        ) {
+                            languageOptions.forEach { language ->
+                                DropdownMenuItem(
+                                    text = { Text(languageOptionLabel(language)) },
+                                    leadingIcon = {
+                                        if (language == uiState.language) {
+                                            Icon(
+                                                imageVector = Icons.Default.Check,
+                                                contentDescription = null,
+                                            )
+                                        }
+                                    },
+                                    onClick = {
+                                        viewModel.updateLanguage(language)
+                                        showLanguageMenu = false
+                                    },
+                                )
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
                     Button(
                         onClick = { viewModel.post() },
                         enabled = postEnabled,
@@ -607,6 +672,29 @@ fun ComposeScreen(
                     selectedAttachmentId = null
                 },
             )
+        }
+    }
+
+}
+
+@Composable
+private fun languageOptionLabel(language: String): String {
+    val configuration = LocalConfiguration.current
+    val uiLocale = remember(configuration) {
+        if (configuration.locales.size() > 0) {
+            configuration.locales[0]
+        } else {
+            Locale.getDefault()
+        }
+    }
+    return remember(language, uiLocale) {
+        val locale = Locale.forLanguageTag(language)
+        val nativeName = locale.getDisplayLanguage(locale).ifBlank { language }
+        val uiName = locale.getDisplayLanguage(uiLocale).ifBlank { language }
+        if (nativeName.equals(uiName, ignoreCase = true)) {
+            "$nativeName ($language)"
+        } else {
+            "$nativeName ($uiName, $language)"
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
@@ -48,6 +48,8 @@ data class ComposeUiState(
     val content: String = "",
     val cursorPosition: Int = 0,
     val language: String = java.util.Locale.getDefault().language,
+    val isLanguageManuallySet: Boolean = false,
+    val suggestedLanguages: List<String> = emptyList(),
     val visibility: PostVisibility = PostVisibility.PUBLIC,
     val quotePolicy: QuotePolicy = QuotePolicy.EVERYONE,
     val replyToId: String? = null,
@@ -95,6 +97,8 @@ class ComposeViewModel @Inject constructor(
             }
         }
 
+        loadSuggestedLanguages()
+
         // Setup debounced mention search
         viewModelScope.launch {
             mentionQueryFlow
@@ -127,6 +131,16 @@ class ComposeViewModel @Inject constructor(
                     )
                 }
             }
+    }
+
+    private fun loadSuggestedLanguages() {
+        viewModelScope.launch {
+            runCatching {
+                repository.getSuggestedFilterLanguages().onSuccess { languages ->
+                    _uiState.update { it.copy(suggestedLanguages = languages) }
+                }
+            }
+        }
     }
 
     private fun detectMentionTrigger(content: String, cursorPosition: Int) {
@@ -295,7 +309,17 @@ class ComposeViewModel @Inject constructor(
         detectLanguage(content)
     }
 
+    fun updateLanguage(language: String) {
+        _uiState.update {
+            it.copy(
+                language = language.trim().replace('_', '-'),
+                isLanguageManuallySet = true,
+            )
+        }
+    }
+
     private fun detectLanguage(text: String) {
+        if (_uiState.value.isLanguageManuallySet) return
         if (text.isBlank() || text.length < 20) return
 
         try {

--- a/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreScreen.kt
@@ -41,6 +41,7 @@ import pub.hackers.android.domain.model.Post
 import pub.hackers.android.ui.components.ErrorMessage
 import pub.hackers.android.ui.components.FullScreenLoading
 import pub.hackers.android.ui.components.LargeTitleHeader
+import pub.hackers.android.ui.components.LanguageFilterRow
 import pub.hackers.android.ui.components.LoadingItem
 import pub.hackers.android.ui.components.PostCard
 import pub.hackers.android.ui.components.ReactionPicker
@@ -159,6 +160,14 @@ fun ExploreScreen(
                 thickness = 1.dp,
                 modifier = Modifier.padding(horizontal = 16.dp)
             )
+
+            LanguageFilterRow(
+                languages = uiState.suggestedFilterLanguages,
+                selectedLanguage = uiState.selectedLanguage,
+                onLanguageSelected = viewModel::selectLanguage,
+            )
+
+            HorizontalDivider(color = colors.divider)
 
             Box(modifier = Modifier.fillMaxSize()) {
                 val refresh = items.loadState.refresh

--- a/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreViewModel.kt
@@ -38,6 +38,8 @@ data class ExploreUiState(
     val reactionPickerPostId: String? = null,
     val error: String? = null,
     val isLoadingNewer: Boolean = false,
+    val suggestedFilterLanguages: List<String> = emptyList(),
+    val selectedLanguage: String? = null,
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -48,6 +50,7 @@ class ExploreViewModel @Inject constructor(
 
     private val _selectedTab = MutableStateFlow(ExploreTab.LOCAL)
     val selectedTab: StateFlow<ExploreTab> = _selectedTab.asStateFlow()
+    private val selectedLanguage = MutableStateFlow<String?>(null)
 
     private val _uiState = MutableStateFlow(ExploreUiState())
     val uiState: StateFlow<ExploreUiState> = _uiState.asStateFlow()
@@ -81,12 +84,15 @@ class ExploreViewModel @Inject constructor(
         },
     )
 
-    val posts: Flow<PagingData<Post>> = _selectedTab
-        .flatMapLatest { tab ->
+    val posts: Flow<PagingData<Post>> = combine(_selectedTab, selectedLanguage) { tab, language ->
+        tab to language
+    }
+        .flatMapLatest { (tab, language) ->
+            val languages = listOfNotNull(language)
             cursorPager { after ->
                 val pageResult = when (tab) {
-                    ExploreTab.LOCAL -> repository.localTimelinePage(after)
-                    ExploreTab.GLOBAL -> repository.publicTimelinePage(after)
+                    ExploreTab.LOCAL -> repository.localTimelinePage(after, languages)
+                    ExploreTab.GLOBAL -> repository.publicTimelinePage(after, languages)
                 }
                 pageResult.onSuccess { page ->
                     if (after == null && _newerPosts.value.isEmpty()) {
@@ -100,34 +106,75 @@ class ExploreViewModel @Inject constructor(
         }
         .cachedIn(viewModelScope)
 
+    init {
+        loadSuggestedFilterLanguages()
+    }
+
     fun selectTab(tab: ExploreTab) {
         if (_selectedTab.value != tab) {
-            loadNewerJob?.cancel()
-            topCursor = null
-            _newerPosts.value = emptyList()
-            _uiState.update { it.copy(error = null, isLoadingNewer = false) }
+            clearTimelineWindow()
             _selectedTab.value = tab
         }
+    }
+
+    fun selectLanguage(language: String?) {
+        if (selectedLanguage.value == language) return
+        clearTimelineWindow()
+        _uiState.update {
+            it.copy(
+                selectedLanguage = language,
+                error = null,
+                isLoadingNewer = false,
+            )
+        }
+        selectedLanguage.value = language
     }
 
     fun loadNewerPosts() {
         val before = topCursor ?: return
         if (_uiState.value.isLoadingNewer) return
         val tab = _selectedTab.value
+        val language = selectedLanguage.value
+        val languages = listOfNotNull(language)
         _uiState.update { it.copy(isLoadingNewer = true, error = null) }
         loadNewerJob = viewModelScope.launch {
             val result = when (tab) {
-                ExploreTab.LOCAL -> repository.getLocalTimeline(before = before, refresh = true)
-                ExploreTab.GLOBAL -> repository.getPublicTimeline(before = before, refresh = true)
+                ExploreTab.LOCAL -> repository.getLocalTimeline(
+                    before = before,
+                    refresh = true,
+                    languages = languages,
+                )
+                ExploreTab.GLOBAL -> repository.getPublicTimeline(
+                    before = before,
+                    refresh = true,
+                    languages = languages,
+                )
             }
-            if (_selectedTab.value != tab) return@launch
+            if (_selectedTab.value != tab || selectedLanguage.value != language) return@launch
             result
                 .onSuccess { page -> prependNewerPosts(page.posts, page.startCursor) }
                 .onFailure { error ->
                     _uiState.update { it.copy(error = error.message) }
                 }
-            if (_selectedTab.value == tab) {
+            if (_selectedTab.value == tab && selectedLanguage.value == language) {
                 _uiState.update { it.copy(isLoadingNewer = false) }
+            }
+        }
+    }
+
+    private fun clearTimelineWindow() {
+        loadNewerJob?.cancel()
+        topCursor = null
+        _newerPosts.value = emptyList()
+        _uiState.update { it.copy(error = null, isLoadingNewer = false) }
+    }
+
+    private fun loadSuggestedFilterLanguages() {
+        viewModelScope.launch {
+            runCatching {
+                repository.getSuggestedFilterLanguages().onSuccess { languages ->
+                    _uiState.update { it.copy(suggestedFilterLanguages = languages) }
+                }
             }
         }
     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -49,6 +50,7 @@ import pub.hackers.android.R
 import pub.hackers.android.ui.components.ErrorMessage
 import pub.hackers.android.ui.components.FullScreenLoading
 import pub.hackers.android.ui.components.LargeTitleHeader
+import pub.hackers.android.ui.components.LanguageFilterRow
 import pub.hackers.android.ui.components.LoadingItem
 import pub.hackers.android.ui.components.PostCard
 import pub.hackers.android.ui.components.ReactionPicker
@@ -213,166 +215,175 @@ fun TimelineScreen(
             }
         }
     ) { paddingValues ->
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
-            val refresh = items.loadState.refresh
-            when {
-                refresh is LoadState.Error && items.itemCount == 0 -> {
-                    ErrorMessage(
-                        message = refresh.error.message ?: stringResource(R.string.error_generic),
-                        onRetry = { items.refresh() }
-                    )
-                }
+            LanguageFilterRow(
+                languages = uiState.suggestedFilterLanguages,
+                selectedLanguage = uiState.selectedLanguage,
+                onLanguageSelected = viewModel::selectLanguage,
+            )
+            HorizontalDivider(color = colors.divider)
 
-                items.itemCount == 0 && refresh is LoadState.NotLoading && refresh.endOfPaginationReached -> {
-                    ErrorMessage(
-                        message = stringResource(R.string.no_posts),
-                        onRefresh = { items.refresh() }
-                    )
-                }
+            Box(modifier = Modifier.weight(1f)) {
+                val refresh = items.loadState.refresh
+                when {
+                    refresh is LoadState.Error && items.itemCount == 0 -> {
+                        ErrorMessage(
+                            message = refresh.error.message ?: stringResource(R.string.error_generic),
+                            onRetry = { items.refresh() }
+                        )
+                    }
 
-                items.itemCount == 0 -> {
-                    // Initial load in progress (Loading, or pre-Loading NotLoading frame).
-                    FullScreenLoading()
-                }
+                    items.itemCount == 0 && refresh is LoadState.NotLoading && refresh.endOfPaginationReached -> {
+                        ErrorMessage(
+                            message = stringResource(R.string.no_posts),
+                            onRefresh = { items.refresh() }
+                        )
+                    }
 
-                else -> {
-                    PullToRefreshBox(
-                        isRefreshing = refresh is LoadState.Loading || uiState.isLoadingNewer,
-                        onRefresh = {
-                            if (items.itemCount > 0) viewModel.loadNewerPosts()
-                            else items.refresh()
-                        }
-                    ) {
-                        LazyColumn(state = listState) {
-                            items(
-                                count = newerPosts.size,
-                                key = { index ->
+                    items.itemCount == 0 -> {
+                        // Initial load in progress (Loading, or pre-Loading NotLoading frame).
+                        FullScreenLoading()
+                    }
+
+                    else -> {
+                        PullToRefreshBox(
+                            isRefreshing = refresh is LoadState.Loading || uiState.isLoadingNewer,
+                            onRefresh = {
+                                if (items.itemCount > 0) viewModel.loadNewerPosts()
+                                else items.refresh()
+                            }
+                        ) {
+                            LazyColumn(state = listState) {
+                                items(
+                                    count = newerPosts.size,
+                                    key = { index ->
+                                        val post = newerPosts[index]
+                                        "newer-${post.sharedPost?.id ?: post.id}"
+                                    }
+                                ) { index ->
                                     val post = newerPosts[index]
-                                    "newer-${post.sharedPost?.id ?: post.id}"
+                                    PostCard(
+                                        post = post,
+                                        onClick = { onPostClick(post.sharedPost?.id ?: post.id) },
+                                        onProfileClick = onProfileClick,
+                                        onReplyClick = {
+                                            onComposeClick(post.sharedPost?.id ?: post.id)
+                                        },
+                                        onShareClick = {
+                                            if (post.viewerHasShared) {
+                                                viewModel.unsharePost(post.id)
+                                            } else {
+                                                viewModel.sharePost(post.id)
+                                            }
+                                        },
+                                        onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
+                                        onReactionClick = { viewModel.toggleFavourite(post) },
+                                        onReactionLongPress = {
+                                            viewModel.showReactionPicker(post.sharedPost?.id ?: post.id)
+                                        },
+                                        onBookmarkClick = {
+                                            val displayPost = post.sharedPost ?: post
+                                            Toast.makeText(
+                                                context,
+                                                if (displayPost.viewerHasBookmarked) {
+                                                    bookmarkRemovedMessage
+                                                } else {
+                                                    bookmarkedMessage
+                                                },
+                                                Toast.LENGTH_SHORT
+                                            ).show()
+                                            viewModel.toggleBookmark(post)
+                                        },
+                                        onExternalShareClick = {
+                                            val displayPost = post.sharedPost ?: post
+                                            val shareUrl = displayPost.url ?: displayPost.iri
+                                            if (shareUrl != null) {
+                                                val sendIntent = Intent().apply {
+                                                    action = Intent.ACTION_SEND
+                                                    putExtra(Intent.EXTRA_TEXT, shareUrl)
+                                                    type = "text/plain"
+                                                }
+                                                context.startActivity(
+                                                    Intent.createChooser(sendIntent, null)
+                                                )
+                                            }
+                                        },
+                                        onQuotedPostClick = onPostClick
+                                    )
+                                    HorizontalDivider(
+                                        color = colors.divider,
+                                        thickness = 1.dp,
+                                        modifier = Modifier.padding(horizontal = 16.dp)
+                                    )
                                 }
-                            ) { index ->
-                                val post = newerPosts[index]
-                                PostCard(
-                                    post = post,
-                                    onClick = { onPostClick(post.sharedPost?.id ?: post.id) },
-                                    onProfileClick = onProfileClick,
-                                    onReplyClick = {
-                                        onComposeClick(post.sharedPost?.id ?: post.id)
-                                    },
-                                    onShareClick = {
-                                        if (post.viewerHasShared) {
-                                            viewModel.unsharePost(post.id)
-                                        } else {
-                                            viewModel.sharePost(post.id)
-                                        }
-                                    },
-                                    onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
-                                    onReactionClick = { viewModel.toggleFavourite(post) },
-                                    onReactionLongPress = {
-                                        viewModel.showReactionPicker(post.sharedPost?.id ?: post.id)
-                                    },
-                                    onBookmarkClick = {
-                                        val displayPost = post.sharedPost ?: post
-                                        Toast.makeText(
-                                            context,
-                                            if (displayPost.viewerHasBookmarked) {
-                                                bookmarkRemovedMessage
-                                            } else {
-                                                bookmarkedMessage
-                                            },
-                                            Toast.LENGTH_SHORT
-                                        ).show()
-                                        viewModel.toggleBookmark(post)
-                                    },
-                                    onExternalShareClick = {
-                                        val displayPost = post.sharedPost ?: post
-                                        val shareUrl = displayPost.url ?: displayPost.iri
-                                        if (shareUrl != null) {
-                                            val sendIntent = Intent().apply {
-                                                action = Intent.ACTION_SEND
-                                                putExtra(Intent.EXTRA_TEXT, shareUrl)
-                                                type = "text/plain"
-                                            }
-                                            context.startActivity(
-                                                Intent.createChooser(sendIntent, null)
-                                            )
-                                        }
-                                    },
-                                    onQuotedPostClick = onPostClick
-                                )
-                                HorizontalDivider(
-                                    color = colors.divider,
-                                    thickness = 1.dp,
-                                    modifier = Modifier.padding(horizontal = 16.dp)
-                                )
-                            }
 
-                            items(
-                                count = items.itemCount,
-                                key = items.itemKey { it.id }
-                            ) { index ->
-                                val post = items[index] ?: return@items
-                                PostCard(
-                                    post = post,
-                                    onClick = { onPostClick(post.sharedPost?.id ?: post.id) },
-                                    onProfileClick = onProfileClick,
-                                    onReplyClick = {
-                                        onComposeClick(post.sharedPost?.id ?: post.id)
-                                    },
-                                    onShareClick = {
-                                        if (post.viewerHasShared) {
-                                            viewModel.unsharePost(post.id)
-                                        } else {
-                                            viewModel.sharePost(post.id)
-                                        }
-                                    },
-                                    onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
-                                    onReactionClick = { viewModel.toggleFavourite(post) },
-                                    onReactionLongPress = {
-                                        viewModel.showReactionPicker(post.sharedPost?.id ?: post.id)
-                                    },
-                                    onBookmarkClick = {
-                                        val displayPost = post.sharedPost ?: post
-                                        Toast.makeText(
-                                            context,
-                                            if (displayPost.viewerHasBookmarked) {
-                                                bookmarkRemovedMessage
+                                items(
+                                    count = items.itemCount,
+                                    key = items.itemKey { it.id }
+                                ) { index ->
+                                    val post = items[index] ?: return@items
+                                    PostCard(
+                                        post = post,
+                                        onClick = { onPostClick(post.sharedPost?.id ?: post.id) },
+                                        onProfileClick = onProfileClick,
+                                        onReplyClick = {
+                                            onComposeClick(post.sharedPost?.id ?: post.id)
+                                        },
+                                        onShareClick = {
+                                            if (post.viewerHasShared) {
+                                                viewModel.unsharePost(post.id)
                                             } else {
-                                                bookmarkedMessage
-                                            },
-                                            Toast.LENGTH_SHORT
-                                        ).show()
-                                        viewModel.toggleBookmark(post)
-                                    },
-                                    onExternalShareClick = {
-                                        val displayPost = post.sharedPost ?: post
-                                        val shareUrl = displayPost.url ?: displayPost.iri
-                                        if (shareUrl != null) {
-                                            val sendIntent = Intent().apply {
-                                                action = Intent.ACTION_SEND
-                                                putExtra(Intent.EXTRA_TEXT, shareUrl)
-                                                type = "text/plain"
+                                                viewModel.sharePost(post.id)
                                             }
-                                            context.startActivity(
-                                                Intent.createChooser(sendIntent, null)
-                                            )
-                                        }
-                                    },
-                                    onQuotedPostClick = onPostClick
-                                )
-                                HorizontalDivider(
-                                    color = colors.divider,
-                                    thickness = 1.dp,
-                                    modifier = Modifier.padding(horizontal = 16.dp)
-                                )
-                            }
+                                        },
+                                        onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
+                                        onReactionClick = { viewModel.toggleFavourite(post) },
+                                        onReactionLongPress = {
+                                            viewModel.showReactionPicker(post.sharedPost?.id ?: post.id)
+                                        },
+                                        onBookmarkClick = {
+                                            val displayPost = post.sharedPost ?: post
+                                            Toast.makeText(
+                                                context,
+                                                if (displayPost.viewerHasBookmarked) {
+                                                    bookmarkRemovedMessage
+                                                } else {
+                                                    bookmarkedMessage
+                                                },
+                                                Toast.LENGTH_SHORT
+                                            ).show()
+                                            viewModel.toggleBookmark(post)
+                                        },
+                                        onExternalShareClick = {
+                                            val displayPost = post.sharedPost ?: post
+                                            val shareUrl = displayPost.url ?: displayPost.iri
+                                            if (shareUrl != null) {
+                                                val sendIntent = Intent().apply {
+                                                    action = Intent.ACTION_SEND
+                                                    putExtra(Intent.EXTRA_TEXT, shareUrl)
+                                                    type = "text/plain"
+                                                }
+                                                context.startActivity(
+                                                    Intent.createChooser(sendIntent, null)
+                                                )
+                                            }
+                                        },
+                                        onQuotedPostClick = onPostClick
+                                    )
+                                    HorizontalDivider(
+                                        color = colors.divider,
+                                        thickness = 1.dp,
+                                        modifier = Modifier.padding(horizontal = 16.dp)
+                                    )
+                                }
 
-                            if (items.loadState.append is LoadState.Loading) {
-                                item { LoadingItem() }
+                                if (items.loadState.append is LoadState.Loading) {
+                                    item { LoadingItem() }
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
@@ -6,6 +6,7 @@ import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,6 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -33,8 +35,11 @@ data class TimelineUiState(
     val reactionPickerPostId: String? = null,
     val draftCount: Int = 0,
     val isLoadingNewer: Boolean = false,
+    val suggestedFilterLanguages: List<String> = emptyList(),
+    val selectedLanguage: String? = null,
 )
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class TimelineViewModel @Inject constructor(
     private val repository: HackersPubRepository,
@@ -65,6 +70,7 @@ class TimelineViewModel @Inject constructor(
     )
 
     private var topCursor: String? = null
+    private val selectedLanguage = MutableStateFlow<String?>(null)
     private val _newerPosts = MutableStateFlow<List<Post>>(emptyList())
     val newerPosts: StateFlow<List<Post>> = combine(
         _newerPosts,
@@ -74,15 +80,18 @@ class TimelineViewModel @Inject constructor(
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     val posts: Flow<PagingData<Post>> = combine(
-        cursorPager { after ->
-            repository.personalTimelinePage(after).onSuccess { page ->
-                if (after == null && _newerPosts.value.isEmpty()) {
-                    topCursor = page.startCursor
+        selectedLanguage.flatMapLatest { language ->
+            val languages = listOfNotNull(language)
+            cursorPager { after ->
+                repository.personalTimelinePage(after, languages).onSuccess { page ->
+                    if (after == null && _newerPosts.value.isEmpty()) {
+                        topCursor = page.startCursor
+                    }
                 }
-            }
-        }.flow
-            .distinctByEffectiveId()
-            .cachedIn(viewModelScope),
+            }.flow
+                .distinctByEffectiveId()
+                .cachedIn(viewModelScope)
+        },
         overlayStore.overlays,
     ) { paging, overlays ->
         paging.map { post -> post.applyOverlays(overlays) }
@@ -90,6 +99,7 @@ class TimelineViewModel @Inject constructor(
 
     init {
         loadDraftCount()
+        loadSuggestedFilterLanguages()
         viewModelScope.launch {
             refreshTrigger.refreshAt.drop(1).collect {
                 loadNewerPosts()
@@ -97,17 +107,48 @@ class TimelineViewModel @Inject constructor(
         }
     }
 
+    fun selectLanguage(language: String?) {
+        if (selectedLanguage.value == language) return
+        topCursor = null
+        _newerPosts.value = emptyList()
+        _uiState.update {
+            it.copy(
+                selectedLanguage = language,
+                error = null,
+                isLoadingNewer = false,
+            )
+        }
+        selectedLanguage.value = language
+    }
+
     fun loadNewerPosts() {
         val before = topCursor ?: return
         if (_uiState.value.isLoadingNewer) return
+        val language = selectedLanguage.value
         _uiState.update { it.copy(isLoadingNewer = true, error = null) }
         viewModelScope.launch {
-            repository.getPersonalTimeline(before = before, refresh = true)
+            val result = repository.getPersonalTimeline(
+                before = before,
+                refresh = true,
+                languages = listOfNotNull(language),
+            )
+            if (selectedLanguage.value != language) return@launch
+            result
                 .onSuccess { page -> prependNewerPosts(page.posts, page.startCursor) }
                 .onFailure { error ->
                     _uiState.update { it.copy(error = error.message) }
                 }
             _uiState.update { it.copy(isLoadingNewer = false) }
+        }
+    }
+
+    private fun loadSuggestedFilterLanguages() {
+        viewModelScope.launch {
+            runCatching {
+                repository.getSuggestedFilterLanguages().onSuccess { languages ->
+                    _uiState.update { it.copy(suggestedFilterLanguages = languages) }
+                }
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <!-- Compose -->
     <string name="compose">Compose</string>
     <string name="compose_hint">What\'s on your mind?</string>
+    <string name="compose_language_label">Language</string>
     <string name="post">Post</string>
     <string name="cancel">Cancel</string>
     <string name="compose_edit">Edit</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="local_timeline">Hackers\' Pub</string>
     <string name="global_timeline">Fediverse</string>
     <string name="personal_timeline">Home</string>
+    <string name="all_languages">All languages</string>
     <string name="no_posts">No posts yet</string>
     <string name="load_more">Load more</string>
     <string name="refresh">Refresh</string>

--- a/app/src/test/java/pub/hackers/android/ui/screens/compose/ComposeViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/compose/ComposeViewModelTest.kt
@@ -158,6 +158,41 @@ class ComposeViewModelTest {
     }
 
     @Test
+    fun `updateLanguage normalizes tag and post uses selected language`() = runTest {
+        val createdPost = samplePost(id = "created")
+        coEvery {
+            repository.createNote(
+                content = "bonjour",
+                language = "fr-CA",
+                visibility = PostVisibility.PUBLIC,
+                quotePolicy = QuotePolicy.EVERYONE,
+                replyTargetId = null,
+                quotedPostId = null,
+            )
+        } returns Result.success(createdPost)
+
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.updateContent("bonjour")
+        vm.updateLanguage(" fr_CA ")
+        vm.post()
+        advanceUntilIdle()
+
+        assertEquals("fr-CA", vm.uiState.value.language)
+        coVerify {
+            repository.createNote(
+                content = "bonjour",
+                language = "fr-CA",
+                visibility = PostVisibility.PUBLIC,
+                quotePolicy = QuotePolicy.EVERYONE,
+                replyTargetId = null,
+                quotedPostId = null,
+            )
+        }
+    }
+
+    @Test
     fun `post clamps quote policy to self for followers-only notes`() = runTest {
         val createdPost = samplePost(id = "created")
         coEvery {


### PR DESCRIPTION
## Summary
- add `suggestedFilterLanguages` and timeline `languages` arguments to Android GraphQL operations
- thread selected language filters through personal, local, and global timeline paging and newer-post loads
- add a reusable horizontal language filter row that shows suggested languages and preserves the active selection
- add a selectable note compose language control beside the Post button, using suggested languages plus the detected language

## Reference
- hackers-pub/hackerspub#302

## Tests
- `./gradlew :app:testDebugUnitTest :app:lintDebug`
- `./gradlew :app:testDebugUnitTest --tests pub.hackers.android.ui.screens.compose.ComposeViewModelTest :app:lintDebug`