### PR TITLE
Support post pinning

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -3,6 +3,7 @@ fragment ActorFields on Actor {
     name
     handle
     avatarUrl
+    isViewer
 }
 
 fragment MediaFields on PostMedium {
@@ -35,7 +36,9 @@ fragment PostFields on Post {
     iri
     viewerHasShared
     viewerHasBookmarked
+    viewerHasPinned
     viewerCanQuote
+    visibility
     quotePolicy
     actor {
         ...ActorFields
@@ -108,7 +111,9 @@ fragment SharedPostFields on Post {
     iri
     viewerHasShared
     viewerHasBookmarked
+    viewerHasPinned
     viewerCanQuote
+    visibility
     quotePolicy
     actor {
         ...ActorFields
@@ -345,6 +350,27 @@ query ActorPosts($handle: String!, $after: String) {
     actorByHandle(handle: $handle, allowLocalHandle: true) {
         id
         posts(first: 20, after: $after) {
+            edges {
+                cursor
+                node {
+                    ...PostFields
+                    sharedPost {
+                        ...SharedPostFields
+                    }
+                }
+            }
+            pageInfo {
+                hasNextPage
+                endCursor
+            }
+        }
+    }
+}
+
+query ActorPins($handle: String!) {
+    actorByHandle(handle: $handle, allowLocalHandle: true) {
+        id
+        pins(first: 20) {
             edges {
                 cursor
                 node {
@@ -890,6 +916,41 @@ mutation DeletePost($id: ID!) {
         }
         ... on SharedPostDeletionNotAllowedError {
             inputPath
+        }
+    }
+}
+
+mutation PinPost($postId: ID!) {
+    pinPost(input: { postId: $postId }) {
+        ... on PinPostPayload {
+            post {
+                id
+                viewerHasPinned
+            }
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+    }
+}
+
+mutation UnpinPost($postId: ID!) {
+    unpinPost(input: { postId: $postId }) {
+        ... on UnpinPostPayload {
+            post {
+                id
+                viewerHasPinned
+            }
+            unpinnedPostId
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
         }
     }
 }

--- a/app/src/main/graphql/pub/hackers/android/schema.graphqls
+++ b/app/src/main/graphql/pub/hackers/android/schema.graphqls
@@ -492,6 +492,8 @@ type Article implements Node & Post & Reactable {
 
   viewerHasBookmarked: Boolean!
 
+  viewerHasPinned: Boolean!
+
   viewerHasShared: Boolean!
 
   visibility: PostVisibility!
@@ -940,6 +942,20 @@ type MediumUploadHeader {
   value: String!
 }
 
+input PinPostInput {
+  clientMutationId: ID
+
+  postId: ID!
+}
+
+type PinPostPayload {
+  clientMutationId: ID
+
+  post: Post!
+}
+
+union PinPostResult = InvalidInputError | NotAuthenticatedError | PinPostPayload
+
 type MentionNotification implements Node & Notification {
   account: Account!
 
@@ -994,6 +1010,8 @@ type Mutation {
 
   publishArticleDraft(input: PublishArticleDraftInput!): PublishArticleDraftResult!
 
+  pinPost(input: PinPostInput!): PinPostResult!
+
   redeemInvitationLink(email: Email!, id: UUID!, locale: Locale!, verifyUrl: URITemplate!): RedeemInvitationLinkResult!
 
   registerApnsDeviceToken(input: RegisterApnsDeviceTokenInput!): RegisterApnsDeviceTokenResult!
@@ -1024,6 +1042,8 @@ type Mutation {
   unbookmarkPost(input: UnbookmarkPostInput!): UnbookmarkPostResult!
 
   unfollowActor(input: UnfollowActorInput!): UnfollowActorResult!
+
+  unpinPost(input: UnpinPostInput!): UnpinPostResult!
 
   unregisterApnsDeviceToken(input: UnregisterApnsDeviceTokenInput!): UnregisterApnsDeviceTokenResult!
 
@@ -1104,6 +1124,8 @@ type Note implements Node & Post & Reactable {
   viewerCanRevokeQuote: Boolean!
 
   viewerHasBookmarked: Boolean!
+
+  viewerHasPinned: Boolean!
 
   viewerHasShared: Boolean!
 
@@ -1312,6 +1334,8 @@ interface Post implements Node & Reactable {
   viewerCanRevokeQuote: Boolean!
 
   viewerHasBookmarked: Boolean!
+
+  viewerHasPinned: Boolean!
 
   viewerHasShared: Boolean!
 
@@ -1669,6 +1693,8 @@ type Question implements Node & Post & Reactable {
   viewerCanRevokeQuote: Boolean!
 
   viewerHasBookmarked: Boolean!
+
+  viewerHasPinned: Boolean!
 
   viewerHasShared: Boolean!
 
@@ -2130,6 +2156,22 @@ type UnbookmarkPostPayload {
 }
 
 union UnbookmarkPostResult = InvalidInputError|NotAuthenticatedError|UnbookmarkPostPayload
+
+input UnpinPostInput {
+  clientMutationId: ID
+
+  postId: ID!
+}
+
+type UnpinPostPayload {
+  clientMutationId: ID
+
+  post: Post!
+
+  unpinnedPostId: ID!
+}
+
+union UnpinPostResult = InvalidInputError|NotAuthenticatedError|UnpinPostPayload
 
 input UnfollowActorInput {
   actorId: ID!

--- a/app/src/main/java/pub/hackers/android/data/paging/PostOverlay.kt
+++ b/app/src/main/java/pub/hackers/android/data/paging/PostOverlay.kt
@@ -23,6 +23,7 @@ import pub.hackers.android.domain.model.ReactionGroup
 data class PostOverlay(
     val viewerHasShared: Boolean? = null,      // null = no override
     val viewerHasBookmarked: Boolean? = null,  // null = no override
+    val viewerHasPinned: Boolean? = null,      // null = no override
     val shareDelta: Int = 0,                    // added to engagementStats.shares
     val reactionOverride: List<ReactionGroup>? = null, // full replacement when we touched reactions
     val reactionCountOverride: Int? = null,     // engagementStats.reactions override
@@ -36,6 +37,7 @@ fun Post.applyOverlay(overlay: PostOverlay?): Post {
     return copy(
         viewerHasShared = overlay.viewerHasShared ?: viewerHasShared,
         viewerHasBookmarked = overlay.viewerHasBookmarked ?: viewerHasBookmarked,
+        viewerHasPinned = overlay.viewerHasPinned ?: viewerHasPinned,
         engagementStats = engagementStats.copy(
             shares = maxOf(0, engagementStats.shares + overlay.shareDelta),
             reactions = overlay.reactionCountOverride ?: engagementStats.reactions,

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -27,6 +27,7 @@ import pub.hackers.android.graphql.ArticleDraftsQuery
 import pub.hackers.android.graphql.ActorArticlesQuery
 import pub.hackers.android.graphql.ActorByHandleQuery
 import pub.hackers.android.graphql.ActorNotesQuery
+import pub.hackers.android.graphql.ActorPinsQuery
 import pub.hackers.android.graphql.ActorPostsQuery
 import pub.hackers.android.graphql.AddReactionToPostMutation
 import pub.hackers.android.graphql.BookmarkPostMutation
@@ -48,6 +49,7 @@ import pub.hackers.android.graphql.MarkNotificationsAsReadMutation
 import pub.hackers.android.graphql.MediumGeneratedAltTextQuery
 import pub.hackers.android.graphql.NotificationsQuery
 import pub.hackers.android.graphql.PersonalTimelineQuery
+import pub.hackers.android.graphql.PinPostMutation
 import pub.hackers.android.graphql.PostQuotesQuery
 import pub.hackers.android.graphql.PostRepliesQuery
 import pub.hackers.android.graphql.PostSharesQuery
@@ -72,6 +74,7 @@ import pub.hackers.android.graphql.SuggestedFilterLanguagesQuery
 import pub.hackers.android.graphql.UnblockActorMutation
 import pub.hackers.android.graphql.UnfollowActorMutation
 import pub.hackers.android.graphql.UnbookmarkPostMutation
+import pub.hackers.android.graphql.UnpinPostMutation
 import pub.hackers.android.graphql.UnsharePostMutation
 import pub.hackers.android.graphql.UpdateAccountMutation
 import pub.hackers.android.graphql.ViewerQuery
@@ -492,7 +495,8 @@ class HackersPubRepository @Inject constructor(
                                 id = actor.id,
                                 name = actor.name?.toString(),
                                 handle = actor.handle,
-                                avatarUrl = actor.avatarUrl.toString()
+                                avatarUrl = actor.avatarUrl.toString(),
+                                isViewer = actor.isViewer,
                             ),
                             bio = actor.bio?.toString(),
                             fields = actor.fields.map { field ->
@@ -593,6 +597,29 @@ class HackersPubRepository @Inject constructor(
                             hasNextPage = posts.pageInfo.hasNextPage,
                             endCursor = posts.pageInfo.endCursor
                         )
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getActorPins(handle: String): Result<List<Post>> {
+        return try {
+            val response = apolloClient.query(ActorPinsQuery(handle)).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                withContext(Dispatchers.Default) {
+                    val pins = response.data?.actorByHandle?.pins
+                        ?: return@withContext Result.failure(Exception("Actor not found"))
+
+                    Result.success(
+                        pins.edges.map { edge ->
+                            edge.node.postFields.toPost(edge.node.sharedPost?.sharedPostFields?.toPost())
+                        }.distinctBy { it.id }
                     )
                 }
             }
@@ -1505,6 +1532,48 @@ class HackersPubRepository @Inject constructor(
         }
     }
 
+    suspend fun pinPost(postId: String): Result<Unit> {
+        return try {
+            val response = apolloClient.mutation(PinPostMutation(postId)).execute()
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.pinPost
+                when {
+                    result?.onPinPostPayload != null -> Result.success(Unit)
+                    result?.onInvalidInputError != null ->
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    result?.onNotAuthenticatedError != null ->
+                        Result.failure(Exception("Not authenticated"))
+                    else -> Result.failure(Exception("Unknown error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun unpinPost(postId: String): Result<Unit> {
+        return try {
+            val response = apolloClient.mutation(UnpinPostMutation(postId)).execute()
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.unpinPost
+                when {
+                    result?.onUnpinPostPayload != null -> Result.success(Unit)
+                    result?.onInvalidInputError != null ->
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    result?.onNotAuthenticatedError != null ->
+                        Result.failure(Exception("Not authenticated"))
+                    else -> Result.failure(Exception("Unknown error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     suspend fun saveArticleDraft(
         title: String,
         content: String,
@@ -1685,7 +1754,7 @@ class HackersPubRepository @Inject constructor(
     private fun PostFields.toPost(
         sharedPost: Post? = null,
         replyTarget: Post? = null,
-        visibility: PostVisibility = PostVisibility.PUBLIC,
+        visibility: PostVisibility? = null,
         lastSharer: Actor? = null,
         sharersCount: Int = 0
     ): Post {
@@ -1702,6 +1771,7 @@ class HackersPubRepository @Inject constructor(
             iri = iri.toString(),
             viewerHasShared = viewerHasShared,
             viewerHasBookmarked = viewerHasBookmarked,
+            viewerHasPinned = viewerHasPinned,
             viewerCanQuote = viewerCanQuote,
             actor = actor.actorFields.toActor(),
             media = media.map { it.mediaFields.toMedia() },
@@ -1730,7 +1800,7 @@ class HackersPubRepository @Inject constructor(
             sharedPost = sharedPost,
             replyTarget = replyTarget,
             quotedPost = quotedPost?.sharedPostFields?.toPost(),
-            visibility = visibility,
+            visibility = visibility ?: this.visibility.toPostVisibility(),
             quotePolicy = quotePolicy.toQuotePolicy(),
             reactionGroups = reactionGroups.mapNotNull { group ->
                 when {
@@ -1772,11 +1842,13 @@ class HackersPubRepository @Inject constructor(
             iri = iri.toString(),
             viewerHasShared = viewerHasShared,
             viewerHasBookmarked = viewerHasBookmarked,
+            viewerHasPinned = viewerHasPinned,
             viewerCanQuote = viewerCanQuote,
             actor = actor.actorFields.toActor(),
             media = media.map { it.mediaFields.toMedia() },
             engagementStats = engagementStats.engagementStatsFields.toEngagementStats(),
             mentions = mentions.edges.map { it.node.handle },
+            visibility = visibility.toPostVisibility(),
             quotePolicy = quotePolicy.toQuotePolicy()
         )
     }
@@ -1795,7 +1867,8 @@ class HackersPubRepository @Inject constructor(
             id = id,
             name = name?.toString(),
             handle = handle,
-            avatarUrl = avatarUrl.toString()
+            avatarUrl = avatarUrl.toString(),
+            isViewer = isViewer,
         )
     }
 

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -9,6 +9,7 @@ data class Actor(
     val name: String?,
     val handle: String,
     val avatarUrl: String,
+    val isViewer: Boolean = false,
     val bio: String? = null
 )
 
@@ -95,6 +96,7 @@ data class Post(
     val iri: String? = null,
     val viewerHasShared: Boolean,
     val viewerHasBookmarked: Boolean = false,
+    val viewerHasPinned: Boolean = false,
     val viewerCanQuote: Boolean = true,
     val actor: Actor,
     val media: List<Media>,

--- a/app/src/main/java/pub/hackers/android/ui/components/ActorAvatar.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/ActorAvatar.kt
@@ -9,6 +9,9 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -22,9 +25,11 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
+import pub.hackers.android.R
 import pub.hackers.android.domain.model.Actor
 import pub.hackers.android.ui.theme.AppShapes
 import pub.hackers.android.ui.theme.LocalAppColors
+import androidx.compose.ui.res.stringResource
 
 @Composable
 fun ActorAvatar(
@@ -35,6 +40,7 @@ fun ActorAvatar(
     onClick: (() -> Unit)? = null,
     overlayActor: Actor? = null,
     overlaySize: Dp = AppShapes.avatarRepost,
+    isPinned: Boolean = false,
 ) {
     Box(
         modifier = modifier
@@ -57,6 +63,37 @@ fun ActorAvatar(
                     .offset(x = 5.dp, y = 5.dp),
             )
         }
+
+        if (isPinned) {
+            PinBadge(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset(x = 4.dp, y = (-4).dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PinBadge(
+    modifier: Modifier = Modifier,
+) {
+    val colors = LocalAppColors.current
+
+    Box(
+        modifier = modifier
+            .size(20.dp)
+            .clip(CircleShape)
+            .background(colors.surface)
+            .border(1.dp, colors.background, CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.PushPin,
+            contentDescription = stringResource(R.string.pinned),
+            tint = colors.accent,
+            modifier = Modifier.size(12.dp),
+        )
     }
 }
 

--- a/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/ArticleCard.kt
@@ -19,12 +19,17 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material.icons.outlined.Favorite
+import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -64,6 +69,7 @@ fun ArticleCard(
     onReactionClick: (() -> Unit)? = null,
     onReactionLongPress: (() -> Unit)? = null,
     onBookmarkClick: (() -> Unit)? = null,
+    onPinClick: ((Post) -> Unit)? = null,
     onExternalShareClick: (() -> Unit)? = null
 ) {
     val displayPost = post.sharedPost ?: post
@@ -139,6 +145,7 @@ fun ArticleCard(
                         size = AppShapes.avatarTimeline,
                         contentDescription = "Avatar",
                         onClick = { onProfileClick(displayPost.actor.handle) },
+                        isPinned = displayPost.viewerHasPinned,
                     )
 
                     Spacer(modifier = Modifier.width(12.dp))
@@ -172,6 +179,7 @@ fun ArticleCard(
                             overflow = TextOverflow.Ellipsis
                         )
                     }
+
                 }
 
                 Spacer(modifier = Modifier.height(12.dp))
@@ -238,7 +246,51 @@ fun ArticleCard(
                 onReactionClick = onReactionClick,
                 onReactionLongPress = onReactionLongPress,
                 onBookmarkClick = onBookmarkClick,
+                onPinClick = onPinClick?.takeIf { displayPost.canPinToViewerProfile() }?.let {
+                    { it(displayPost) }
+                },
                 onExternalShareClick = onExternalShareClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun PostPinActionMenu(
+    isPinned: Boolean,
+    onPinClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        IconButton(onClick = { expanded = true }, modifier = Modifier.size(32.dp)) {
+            Icon(
+                imageVector = Icons.Filled.MoreVert,
+                contentDescription = stringResource(R.string.more_actions),
+                tint = LocalAppColors.current.textSecondary,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            DropdownMenuItem(
+                text = {
+                    Text(stringResource(if (isPinned) R.string.unpin_post else R.string.pin_post))
+                },
+                onClick = {
+                    expanded = false
+                    onPinClick()
+                },
+                leadingIcon = {
+                    Icon(
+                        imageVector = if (isPinned) Icons.Filled.PushPin else Icons.Outlined.PushPin,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                    )
+                },
             )
         }
     }
@@ -253,6 +305,7 @@ private fun ArticleEngagementBar(
     onReactionClick: (() -> Unit)?,
     onReactionLongPress: (() -> Unit)?,
     onBookmarkClick: (() -> Unit)?,
+    onPinClick: (() -> Unit)?,
     onExternalShareClick: (() -> Unit)?
 ) {
     val colors = LocalAppColors.current
@@ -304,6 +357,12 @@ private fun ArticleEngagementBar(
                     tint = if (isBookmarked) colors.bookmark else colors.textSecondary
                 )
             }
+        }
+        if (onPinClick != null) {
+            PostPinActionMenu(
+                isPinned = post.viewerHasPinned,
+                onPinClick = onPinClick,
+            )
         }
         if (onExternalShareClick != null) {
             IconButton(onClick = onExternalShareClick) {

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -39,6 +39,8 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
@@ -46,6 +48,7 @@ import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.FormatQuote
 import androidx.compose.material.icons.outlined.Group
 import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material.icons.outlined.Repeat
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.DropdownMenu
@@ -110,6 +113,7 @@ fun PostCard(
     onReactionClick: (() -> Unit)? = null,
     onReactionLongPress: (() -> Unit)? = null,
     onBookmarkClick: (() -> Unit)? = null,
+    onPinClick: ((Post) -> Unit)? = null,
     onExternalShareClick: (() -> Unit)? = null,
     onQuotedPostClick: ((String) -> Unit)? = null,
     contentMaxLength: Int = 0
@@ -127,6 +131,7 @@ fun PostCard(
             onReactionClick = onReactionClick,
             onReactionLongPress = onReactionLongPress,
             onBookmarkClick = onBookmarkClick,
+            onPinClick = onPinClick,
             onExternalShareClick = onExternalShareClick,
             modifier = modifier
         )
@@ -141,6 +146,7 @@ fun PostCard(
             onReactionClick = onReactionClick,
             onReactionLongPress = onReactionLongPress,
             onBookmarkClick = onBookmarkClick,
+            onPinClick = onPinClick,
             onExternalShareClick = onExternalShareClick,
             onQuotedPostClick = onQuotedPostClick,
             contentMaxLength = contentMaxLength,
@@ -161,6 +167,7 @@ private fun NoteCard(
     onReactionClick: (() -> Unit)? = null,
     onReactionLongPress: (() -> Unit)? = null,
     onBookmarkClick: (() -> Unit)? = null,
+    onPinClick: ((Post) -> Unit)? = null,
     onExternalShareClick: (() -> Unit)? = null,
     onQuotedPostClick: ((String) -> Unit)? = null,
     contentMaxLength: Int = 0
@@ -278,6 +285,7 @@ private fun NoteCard(
                 size = AppShapes.avatarTimeline,
                 contentDescription = "Avatar",
                 onClick = { onProfileClick(displayPost.actor.handle) },
+                isPinned = displayPost.viewerHasPinned,
             )
 
             Spacer(modifier = Modifier.width(12.dp))
@@ -558,6 +566,9 @@ private fun NoteCard(
                     onReactionClick = onReactionClick,
                     onReactionLongPress = onReactionLongPress,
                     onBookmarkClick = onBookmarkClick,
+                    onPinClick = onPinClick?.takeIf { displayPost.canPinToViewerProfile() }?.let {
+                        { it(displayPost) }
+                    },
                     onExternalShareClick = onExternalShareClick
                 )
             }
@@ -575,6 +586,7 @@ private fun EngagementBar(
     onReactionClick: (() -> Unit)? = null,
     onReactionLongPress: (() -> Unit)? = null,
     onBookmarkClick: (() -> Unit)? = null,
+    onPinClick: (() -> Unit)? = null,
     onExternalShareClick: (() -> Unit)? = null
 ) {
     val colors = LocalAppColors.current
@@ -624,6 +636,14 @@ private fun EngagementBar(
 
         Spacer(modifier = Modifier.weight(1f))
 
+        if (onPinClick != null) {
+            PostPinActionMenu(
+                isPinned = post.viewerHasPinned,
+                onPinClick = onPinClick,
+                modifier = Modifier.offset(x = 14.dp),
+            )
+        }
+
         // External share — always textSecondary, offset back to align right edge
         if (onExternalShareClick != null) {
             IconButton(
@@ -637,6 +657,47 @@ private fun EngagementBar(
                     modifier = Modifier.size(20.dp)
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun PostPinActionMenu(
+    isPinned: Boolean,
+    onPinClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        IconButton(onClick = { expanded = true }, modifier = Modifier.size(32.dp)) {
+            Icon(
+                imageVector = Icons.Filled.MoreVert,
+                contentDescription = stringResource(R.string.more_actions),
+                tint = LocalAppColors.current.textSecondary,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            DropdownMenuItem(
+                text = {
+                    Text(stringResource(if (isPinned) R.string.unpin_post else R.string.pin_post))
+                },
+                onClick = {
+                    expanded = false
+                    onPinClick()
+                },
+                leadingIcon = {
+                    Icon(
+                        imageVector = if (isPinned) Icons.Filled.PushPin else Icons.Outlined.PushPin,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                    )
+                },
+            )
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/components/PostPinning.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostPinning.kt
@@ -1,0 +1,10 @@
+package pub.hackers.android.ui.components
+
+import pub.hackers.android.domain.model.Post
+import pub.hackers.android.domain.model.PostVisibility
+
+fun Post.canPinToViewerProfile(): Boolean {
+    return actor.isViewer &&
+        sharedPost == null &&
+        (visibility == PostVisibility.PUBLIC || visibility == PostVisibility.UNLISTED)
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -38,12 +38,14 @@ import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.outlined.AddReaction
 import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material.icons.outlined.FormatQuote
 import androidx.compose.material.icons.outlined.Group
 import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
@@ -107,6 +109,7 @@ import pub.hackers.android.R
 import pub.hackers.android.domain.model.Post
 import pub.hackers.android.domain.model.ReactionGroup
 import pub.hackers.android.domain.model.TocItem
+import pub.hackers.android.ui.components.ActorAvatar
 import pub.hackers.android.ui.components.ErrorMessage
 import pub.hackers.android.ui.components.FullScreenLoading
 import pub.hackers.android.ui.components.ContentWarningNotice
@@ -121,6 +124,7 @@ import pub.hackers.android.ui.components.QuotedPostPreview
 import pub.hackers.android.ui.components.ReactionPicker
 import pub.hackers.android.ui.components.TocList
 import pub.hackers.android.ui.components.TocPanel
+import pub.hackers.android.ui.components.canPinToViewerProfile
 import pub.hackers.android.ui.components.contentWarningText
 import pub.hackers.android.ui.components.hasContentWarning
 import androidx.compose.foundation.lazy.LazyListState
@@ -396,7 +400,11 @@ fun PostDetailScreen(
                         )
                     }
                 },
-                trailingContent = if (tocAvailable || uiState.canDelete) {
+                trailingContent = if (
+                    tocAvailable ||
+                    uiState.canDelete ||
+                    uiState.post?.canPinToViewerProfile() == true
+                ) {
                     {
                         if (tocAvailable) {
                             IconButton(onClick = { showTocSheet = true }) {
@@ -414,9 +422,12 @@ fun PostDetailScreen(
                                 )
                             }
                         }
-                        if (uiState.canDelete) {
+                        if (uiState.canDelete || uiState.post?.canPinToViewerProfile() == true) {
                             PostDetailActionMenu(
+                                canDelete = uiState.canDelete,
                                 isDeleting = uiState.isDeleting,
+                                post = uiState.post,
+                                onPinClick = { viewModel.togglePin() },
                                 onDelete = {
                                     if (confirmBeforeDelete) {
                                         showDeleteConfirmation = true
@@ -535,7 +546,10 @@ fun PostDetailScreen(
 
 @Composable
 private fun PostDetailActionMenu(
+    canDelete: Boolean,
     isDeleting: Boolean,
+    post: Post?,
+    onPinClick: () -> Unit,
     onDelete: () -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -553,26 +567,45 @@ private fun PostDetailActionMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false }
         ) {
-            DropdownMenuItem(
-                text = {
-                    Text(
-                        text = stringResource(R.string.delete_post),
-                        color = colors.reaction
-                    )
-                },
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Filled.Delete,
-                        contentDescription = null,
-                        tint = colors.reaction
-                    )
-                },
-                onClick = {
-                    expanded = false
-                    onDelete()
-                },
-                enabled = !isDeleting
-            )
+            if (post?.canPinToViewerProfile() == true) {
+                DropdownMenuItem(
+                    text = {
+                        Text(stringResource(if (post.viewerHasPinned) R.string.unpin_post else R.string.pin_post))
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = if (post.viewerHasPinned) Icons.Filled.PushPin else Icons.Outlined.PushPin,
+                            contentDescription = null,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onPinClick()
+                    },
+                )
+            }
+            if (canDelete) {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = stringResource(R.string.delete_post),
+                            color = colors.reaction
+                        )
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = null,
+                            tint = colors.reaction
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onDelete()
+                    },
+                    enabled = !isDeleting
+                )
+            }
         }
     }
 }
@@ -671,14 +704,12 @@ internal fun PostDetailContent(
                 Row(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    AsyncImage(
-                        model = post.actor.avatarUrl,
+                    ActorAvatar(
+                        actor = post.actor,
+                        size = AppShapes.avatarTimeline,
                         contentDescription = null,
-                        modifier = Modifier
-                            .size(AppShapes.avatarTimeline)
-                            .clip(CircleShape)
-                            .clickable { onProfileClick(post.actor.handle) },
-                        contentScale = ContentScale.Crop
+                        onClick = { onProfileClick(post.actor.handle) },
+                        isPinned = post.viewerHasPinned,
                     )
 
                     Spacer(modifier = Modifier.width(12.dp))

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailViewModel.kt
@@ -24,6 +24,7 @@ import pub.hackers.android.domain.model.Post
 import pub.hackers.android.domain.model.ReactionGroup
 import pub.hackers.android.domain.model.TocItem
 import pub.hackers.android.ui.bookmark.BookmarkMutationCoordinator
+import pub.hackers.android.ui.components.canPinToViewerProfile
 import pub.hackers.android.ui.screens.compose.ReplyPostedSignal
 import javax.inject.Inject
 
@@ -311,6 +312,32 @@ class PostDetailViewModel @Inject constructor(
     fun toggleBookmark() {
         val post = _uiState.value.post ?: return
         bookmarkCoordinator.toggle(post.id, post.viewerHasBookmarked)
+    }
+
+    fun togglePin() {
+        val post = _uiState.value.post ?: return
+        if (!post.canPinToViewerProfile()) return
+        val shouldPin = !post.viewerHasPinned
+
+        _uiState.update { state ->
+            state.post?.let {
+                state.copy(post = it.copy(viewerHasPinned = shouldPin))
+            } ?: state
+        }
+        viewModelScope.launch {
+            val result = if (shouldPin) {
+                repository.pinPost(post.id)
+            } else {
+                repository.unpinPost(post.id)
+            }
+            result.onFailure {
+                _uiState.update { state ->
+                    state.post?.let { current ->
+                        state.copy(post = current.copy(viewerHasPinned = !shouldPin))
+                    } ?: state
+                }
+            }
+        }
     }
 
     fun toggleReaction(emoji: String) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.RssFeed
 import androidx.compose.material.icons.outlined.Share
@@ -253,6 +254,35 @@ fun ProfileScreen(
                             )
                         }
 
+                        if (selectedTab == ProfileTab.POSTS && uiState.pinnedPosts.isNotEmpty()) {
+                            item {
+                                PinnedPostsSection(
+                                    posts = uiState.pinnedPosts,
+                                    onPostClick = onPostClick,
+                                    onProfileClick = onProfileClick,
+                                    onReplyClick = onReplyClick,
+                                    onQuoteClick = onQuoteClick,
+                                    onPinClick = { viewModel.togglePin(it) },
+                                    onExternalShareClick = { post ->
+                                        val shareUrl = post.url ?: post.iri
+                                        if (shareUrl != null) {
+                                            val sendIntent = Intent().apply {
+                                                action = Intent.ACTION_SEND
+                                                putExtra(Intent.EXTRA_TEXT, shareUrl)
+                                                type = "text/plain"
+                                            }
+                                            context.startActivity(
+                                                Intent.createChooser(
+                                                    sendIntent,
+                                                    null
+                                                )
+                                            )
+                                        }
+                                    }
+                                )
+                            }
+                        }
+
                         val refresh = items.loadState.refresh
                         when {
                             refresh is LoadState.Error && items.itemCount == 0 -> {
@@ -306,6 +336,7 @@ fun ProfileScreen(
                                                 post.sharedPost?.id ?: post.id
                                             )
                                         },
+                                        onPinClick = { viewModel.togglePin(it) },
                                         onReactionClick = null,
                                         onExternalShareClick = {
                                             val displayPost = post.sharedPost ?: post
@@ -341,6 +372,62 @@ fun ProfileScreen(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun PinnedPostsSection(
+    posts: List<Post>,
+    onPostClick: (String) -> Unit,
+    onProfileClick: (String) -> Unit,
+    onReplyClick: (String) -> Unit,
+    onQuoteClick: (String) -> Unit,
+    onPinClick: (Post) -> Unit,
+    onExternalShareClick: (Post) -> Unit,
+) {
+    val colors = LocalAppColors.current
+    val typography = LocalAppTypography.current
+
+    Column(
+        modifier = Modifier.padding(top = 12.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.PushPin,
+                contentDescription = null,
+                tint = colors.textSecondary,
+                modifier = Modifier.size(16.dp)
+            )
+            Text(
+                text = stringResource(R.string.pinned_posts),
+                style = typography.labelMedium,
+                color = colors.textSecondary
+            )
+        }
+
+        posts.forEach { post ->
+            PostCard(
+                post = post,
+                onClick = { onPostClick(post.sharedPost?.id ?: post.id) },
+                onProfileClick = onProfileClick,
+                onReplyClick = { onReplyClick(post.sharedPost?.id ?: post.id) },
+                onShareClick = null,
+                onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
+                onReactionClick = null,
+                onPinClick = onPinClick,
+                onExternalShareClick = { onExternalShareClick(post.sharedPost ?: post) },
+                onQuotedPostClick = onPostClick,
+            )
+            HorizontalDivider(
+                color = colors.divider,
+                thickness = 1.dp,
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileViewModel.kt
@@ -29,6 +29,7 @@ import pub.hackers.android.domain.model.ActorField
 import pub.hackers.android.domain.model.Post
 import pub.hackers.android.domain.model.ReactionGroup
 import pub.hackers.android.ui.bookmark.BookmarkMutationCoordinator
+import pub.hackers.android.ui.components.canPinToViewerProfile
 import javax.inject.Inject
 
 enum class ProfileTab {
@@ -49,6 +50,7 @@ data class ProfileUiState(
     val viewerBlocks: Boolean = false,
     val isPerformingAction: Boolean = false,
     val actionError: String? = null,
+    val pinnedPosts: List<Post> = emptyList(),
 )
 
 @HiltViewModel
@@ -135,6 +137,7 @@ class ProfileViewModel @Inject constructor(
                             viewerBlocks = profile.viewerBlocks,
                         )
                     }
+                    loadPinnedPosts()
                 }
                 .onFailure { error ->
                     _uiState.update {
@@ -163,6 +166,7 @@ class ProfileViewModel @Inject constructor(
                             viewerBlocks = profile.viewerBlocks,
                         )
                     }
+                    loadPinnedPosts()
                 }
                 .onFailure {
                     _uiState.update { it.copy(isRefreshing = false) }
@@ -172,6 +176,15 @@ class ProfileViewModel @Inject constructor(
 
     fun selectTab(tab: ProfileTab) {
         _selectedTab.value = tab
+    }
+
+    private fun loadPinnedPosts() {
+        viewModelScope.launch {
+            repository.getActorPins(handle)
+                .onSuccess { pins ->
+                    _uiState.update { it.copy(pinnedPosts = pins) }
+                }
+        }
     }
 
     fun followActor() {
@@ -291,6 +304,43 @@ class ProfileViewModel @Inject constructor(
     fun toggleBookmark(post: Post) {
         val target = post.sharedPost ?: post
         bookmarkCoordinator.toggle(target.id, target.viewerHasBookmarked)
+    }
+
+    fun togglePin(post: Post) {
+        val target = post.sharedPost ?: post
+        if (!target.canPinToViewerProfile()) return
+        val shouldPin = !target.viewerHasPinned
+        val previousPins = _uiState.value.pinnedPosts
+
+        overlayStore.mutate(target.id) { it.copy(viewerHasPinned = shouldPin) }
+        _uiState.update { state ->
+            val updatedPins = if (shouldPin) {
+                listOf(target.copy(viewerHasPinned = true)) +
+                    state.pinnedPosts.filterNot { it.id == target.id }
+            } else {
+                state.pinnedPosts.filterNot { it.id == target.id }
+            }
+            state.copy(pinnedPosts = updatedPins)
+        }
+
+        viewModelScope.launch {
+            val result = if (shouldPin) {
+                repository.pinPost(target.id)
+            } else {
+                repository.unpinPost(target.id)
+            }
+            result
+                .onSuccess { loadPinnedPosts() }
+                .onFailure { error ->
+                    overlayStore.mutate(target.id) { it.copy(viewerHasPinned = !shouldPin) }
+                    _uiState.update {
+                        it.copy(
+                            pinnedPosts = previousPins,
+                            actionError = error.message,
+                        )
+                    }
+                }
+        }
     }
 
     @Suppress("unused")

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -298,6 +298,7 @@ fun TimelineScreen(
                                             ).show()
                                             viewModel.toggleBookmark(post)
                                         },
+                                        onPinClick = { viewModel.togglePin(it) },
                                         onExternalShareClick = {
                                             val displayPost = post.sharedPost ?: post
                                             val shareUrl = displayPost.url ?: displayPost.iri
@@ -358,6 +359,7 @@ fun TimelineScreen(
                                             ).show()
                                             viewModel.toggleBookmark(post)
                                         },
+                                        onPinClick = { viewModel.togglePin(it) },
                                         onExternalShareClick = {
                                             val displayPost = post.sharedPost ?: post
                                             val shareUrl = displayPost.url ?: displayPost.iri

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineViewModel.kt
@@ -28,6 +28,7 @@ import pub.hackers.android.data.repository.HackersPubRepository
 import pub.hackers.android.domain.model.Post
 import pub.hackers.android.domain.model.ReactionGroup
 import pub.hackers.android.ui.bookmark.BookmarkMutationCoordinator
+import pub.hackers.android.ui.components.canPinToViewerProfile
 import javax.inject.Inject
 
 data class TimelineUiState(
@@ -209,6 +210,26 @@ class TimelineViewModel @Inject constructor(
     fun toggleBookmark(post: Post) {
         val target = post.sharedPost ?: post
         bookmarkCoordinator.toggle(target.id, target.viewerHasBookmarked)
+    }
+
+    fun togglePin(post: Post) {
+        val target = post.sharedPost ?: post
+        if (!target.canPinToViewerProfile()) return
+        val shouldPin = !target.viewerHasPinned
+
+        overlayStore.mutate(target.id) { it.copy(viewerHasPinned = shouldPin) }
+        viewModelScope.launch {
+            val result = if (shouldPin) {
+                repository.pinPost(target.id)
+            } else {
+                repository.unpinPost(target.id)
+            }
+            result.onFailure {
+                overlayStore.mutate(target.id) { prev ->
+                    prev.copy(viewerHasPinned = !shouldPin)
+                }
+            }
+        }
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="no_posts">No posts yet</string>
     <string name="load_more">Load more</string>
     <string name="refresh">Refresh</string>
+    <string name="more_actions">More actions</string>
 
     <!-- Compose -->
     <string name="compose">Compose</string>
@@ -129,6 +130,12 @@
     <string name="read_full_article">Read full article</string>
     <string name="read_on_web">Read on web</string>
     <string name="bookmark">Bookmark</string>
+    <string name="pin_post">Pin to profile</string>
+    <string name="unpin_post">Unpin from profile</string>
+    <string name="pinned_posts">Pinned posts</string>
+    <string name="pinned">Pinned</string>
+    <string name="pin_failed">Failed to pin post</string>
+    <string name="unpin_failed">Failed to unpin post</string>
     <string name="bookmarks">Bookmarks</string>
     <string name="bookmarked">Bookmarked</string>
     <string name="bookmark_removed">Bookmark removed</string>

--- a/app/src/test/java/pub/hackers/android/ui/screens/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/profile/ProfileViewModelTest.kt
@@ -16,8 +16,11 @@ import pub.hackers.android.data.repository.HackersPubRepository
 import pub.hackers.android.domain.model.AccountLink
 import pub.hackers.android.domain.model.Actor
 import pub.hackers.android.domain.model.ActorField
+import pub.hackers.android.domain.model.EngagementStats
+import pub.hackers.android.domain.model.Post
 import pub.hackers.android.domain.model.ProfileResult
 import pub.hackers.android.testutil.MainDispatcherRule
+import java.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ProfileViewModelTest {
@@ -58,6 +61,7 @@ class ProfileViewModelTest {
         // calls (refresh = true) — MockK treats different default-arg call sites
         // as distinct signatures.
         coEvery { repository.getProfile(any(), any()) } returns Result.success(result)
+        coEvery { repository.getActorPins(any()) } returns Result.success(emptyList())
     }
 
     private fun newViewModel(): ProfileViewModel {
@@ -274,6 +278,39 @@ class ProfileViewModelTest {
 
     // endregion
 
+    // region pinning
+
+    @Test
+    fun `togglePin pins eligible owned post`() = runTest {
+        stubLoadProfile()
+        coEvery { repository.pinPost(any()) } returns Result.success(Unit)
+        val post = samplePost(actor = sampleActor.copy(isViewer = true))
+        coEvery { repository.getActorPins(any()) } returns Result.success(listOf(post.copy(viewerHasPinned = true)))
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.togglePin(post)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.pinPost("post-1") }
+        assertTrue(vm.uiState.value.pinnedPosts.any { it.id == "post-1" })
+    }
+
+    @Test
+    fun `togglePin ignores non-owned post`() = runTest {
+        stubLoadProfile()
+        val post = samplePost(actor = sampleActor.copy(isViewer = false))
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.togglePin(post)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repository.pinPost(any()) }
+    }
+
+    // endregion
+
     // region refresh
 
     @Test
@@ -291,4 +328,24 @@ class ProfileViewModelTest {
     }
 
     // endregion
+
+    private fun samplePost(
+        actor: Actor,
+        viewerHasPinned: Boolean = false,
+    ) = Post(
+        id = "post-1",
+        typename = "Note",
+        name = null,
+        published = Instant.parse("2025-01-01T00:00:00Z"),
+        summary = null,
+        content = "<p>body</p>",
+        excerpt = "body",
+        url = null,
+        viewerHasShared = false,
+        viewerHasPinned = viewerHasPinned,
+        actor = actor,
+        media = emptyList(),
+        engagementStats = EngagementStats(replies = 0, reactions = 0, shares = 0, quotes = 0),
+        mentions = emptyList(),
+    )
 }


### PR DESCRIPTION
## Summary
- add GraphQL support for `viewerHasPinned`, actor pins, and pin/unpin mutations
- allow viewer-owned public/unlisted posts to be pinned or unpinned from More actions
- display pinned state as a passive badge on post avatars
- render pinned posts at the top of the profile Posts tab
- add profile ViewModel coverage for pin eligibility and pin calls

## Tests
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:testDebugUnitTest --tests pub.hackers.android.ui.screens.profile.ProfileViewModelTest :app:lintDebug`
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug`