### PR TITLE
Add Android text share target

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix = ".dev"
-            resValue("string", "app_name", "Hackers\\' Pub Dev")
+            resValue("string", "app_name", "Hackers Pub Dev")
         }
         release {
             resValue("string", "app_name", "Hackers\\' Pub")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/app/src/main/java/pub/hackers/android/MainActivity.kt
+++ b/app/src/main/java/pub/hackers/android/MainActivity.kt
@@ -32,7 +32,9 @@ import pub.hackers.android.data.local.PreferencesManager
 import pub.hackers.android.data.local.SessionManager
 import pub.hackers.android.navigation.HackersPubRoute
 import pub.hackers.android.navigation.HackersPubUrlRouter
+import pub.hackers.android.navigation.ShareTargetText
 import pub.hackers.android.navigation.toNavRoute
+import pub.hackers.android.ui.DetailScreen
 import pub.hackers.android.ui.HackersPubApp
 import pub.hackers.android.ui.theme.HackersPubTheme
 import pub.hackers.android.ui.theme.LocalAppColors
@@ -85,6 +87,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         if (savedInstanceState == null) {
             handleDeepLink(intent)
+            handleShareIntent(intent)
             handleNavigationIntent(intent)
         }
         requestNotificationPermissionIfNeeded()
@@ -117,6 +120,7 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         handleDeepLink(intent)
+        handleShareIntent(intent)
         handleNavigationIntent(intent)
     }
 
@@ -166,6 +170,20 @@ class MainActivity : ComponentActivity() {
     private fun handleNavigationIntent(intent: Intent?) {
         val route = intent?.getStringExtra("navigate_to") ?: return
         navigationIntent = NavigationIntent(route = route)
+    }
+
+    private fun handleShareIntent(intent: Intent?) {
+        if (intent?.action != Intent.ACTION_SEND) return
+        if (intent.type != "text/plain") return
+
+        val sharedText = ShareTargetText.format(
+            subject = intent.getCharSequenceExtra(Intent.EXTRA_SUBJECT),
+            text = intent.getCharSequenceExtra(Intent.EXTRA_TEXT),
+        ) ?: return
+
+        navigationIntent = NavigationIntent(
+            route = DetailScreen.Compose.createRoute(prefill = sharedText)
+        )
     }
 
     private fun handleDeepLink(intent: Intent?) {

--- a/app/src/main/java/pub/hackers/android/navigation/ShareTargetText.kt
+++ b/app/src/main/java/pub/hackers/android/navigation/ShareTargetText.kt
@@ -1,0 +1,14 @@
+package pub.hackers.android.navigation
+
+internal object ShareTargetText {
+    fun format(subject: CharSequence?, text: CharSequence?): String? {
+        val sharedText = text?.toString()?.takeIf { it.isNotBlank() } ?: return null
+        val sharedSubject = subject?.toString()?.takeIf { it.isNotBlank() }
+
+        return if (sharedSubject != null) {
+            "$sharedSubject\n\n$sharedText"
+        } else {
+            sharedText
+        }
+    }
+}

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -116,11 +116,12 @@ sealed class DetailScreen(val route: String) {
             return if (params.isEmpty()) "signin" else "signin?${params.joinToString("&")}"
         }
     }
-    data object Compose : DetailScreen("compose?replyTo={replyTo}&quoteOf={quoteOf}") {
-        fun createRoute(replyTo: String? = null, quoteOf: String? = null): String {
+    data object Compose : DetailScreen("compose?replyTo={replyTo}&quoteOf={quoteOf}&prefill={prefill}") {
+        fun createRoute(replyTo: String? = null, quoteOf: String? = null, prefill: String? = null): String {
             val params = mutableListOf<String>()
-            if (replyTo != null) params.add("replyTo=$replyTo")
-            if (quoteOf != null) params.add("quoteOf=$quoteOf")
+            if (replyTo != null) params.add("replyTo=${android.net.Uri.encode(replyTo)}")
+            if (quoteOf != null) params.add("quoteOf=${android.net.Uri.encode(quoteOf)}")
+            if (prefill != null) params.add("prefill=${android.net.Uri.encode(prefill)}")
             return if (params.isEmpty()) "compose" else "compose?${params.joinToString("&")}"
         }
     }
@@ -487,14 +488,21 @@ fun HackersPubApp(
                         type = NavType.StringType
                         nullable = true
                         defaultValue = null
+                    },
+                    navArgument("prefill") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
                     }
                 )
             ) { backStackEntry ->
                 val replyTo = backStackEntry.arguments?.getString("replyTo")
                 val quoteOf = backStackEntry.arguments?.getString("quoteOf")
+                val prefill = backStackEntry.arguments?.getString("prefill")
                 ComposeScreen(
                     replyToId = replyTo,
                     quotedPostId = quoteOf,
+                    initialContent = prefill,
                     onPostSuccess = {
                         viewModel.timelineRefreshTrigger.requestRefresh()
                         navController.popBackStack()

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -140,6 +140,7 @@ private fun calculateMentionPopupOffset(
 fun ComposeScreen(
     replyToId: String?,
     quotedPostId: String? = null,
+    initialContent: String? = null,
     onPostSuccess: () -> Unit,
     onNavigateBack: () -> Unit,
     viewModel: ComposeViewModel = hiltViewModel()
@@ -233,6 +234,10 @@ fun ComposeScreen(
 
     LaunchedEffect(quotedPostId) {
         quotedPostId?.let { viewModel.setQuotedPost(it) }
+    }
+
+    LaunchedEffect(initialContent) {
+        initialContent?.let { viewModel.setInitialContent(it) }
     }
 
     LaunchedEffect(uiState.isPosted) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
@@ -299,6 +299,22 @@ class ComposeViewModel @Inject constructor(
         }
     }
 
+    fun setInitialContent(content: String) {
+        if (content.isBlank()) return
+
+        _uiState.update {
+            if (it.content.isBlank()) {
+                it.copy(
+                    content = content,
+                    cursorPosition = content.length,
+                )
+            } else {
+                it
+            }
+        }
+        detectLanguage(content)
+    }
+
     fun updateContent(content: String, cursorPosition: Int = content.length) {
         _uiState.update { it.copy(content = content, cursorPosition = cursorPosition) }
 

--- a/app/src/test/java/pub/hackers/android/navigation/ShareTargetTextTest.kt
+++ b/app/src/test/java/pub/hackers/android/navigation/ShareTargetTextTest.kt
@@ -1,0 +1,37 @@
+package pub.hackers.android.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ShareTargetTextTest {
+    @Test
+    fun `formats subject and text separated by blank line`() {
+        val result = ShareTargetText.format(
+            subject = "Article title",
+            text = "https://example.com/article",
+        )
+
+        assertEquals("Article title\n\nhttps://example.com/article", result)
+    }
+
+    @Test
+    fun `uses text as-is when subject is missing`() {
+        val result = ShareTargetText.format(
+            subject = null,
+            text = "  https://example.com/article\n",
+        )
+
+        assertEquals("  https://example.com/article\n", result)
+    }
+
+    @Test
+    fun `ignores subject without shared text`() {
+        val result = ShareTargetText.format(
+            subject = "Article title",
+            text = "   ",
+        )
+
+        assertNull(result)
+    }
+}

--- a/app/src/test/java/pub/hackers/android/ui/screens/compose/ComposeViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/compose/ComposeViewModelTest.kt
@@ -124,6 +124,28 @@ class ComposeViewModelTest {
     }
 
     @Test
+    fun `setInitialContent preloads blank composer`() = runTest {
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.setInitialContent("Shared title\n\nhttps://example.com")
+
+        assertEquals("Shared title\n\nhttps://example.com", vm.uiState.value.content)
+        assertEquals("Shared title\n\nhttps://example.com".length, vm.uiState.value.cursorPosition)
+    }
+
+    @Test
+    fun `setInitialContent does not overwrite typed content`() = runTest {
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.updateContent("user typed this")
+        vm.setInitialContent("shared content")
+
+        assertEquals("user typed this", vm.uiState.value.content)
+    }
+
+    @Test
     fun `post sends selected quote policy for public notes`() = runTest {
         val createdPost = samplePost(id = "created")
         coEvery {


### PR DESCRIPTION
## Summary
- Register Hackers' Pub as an Android text share target for `ACTION_SEND` / `text/plain`.
- Route shared subject/text into the existing note composer as prefilled content without publishing automatically.
- Keep unsupported share types ignored and make the debug app label read `Hackers Pub Dev` in share targets.

## Validation
- `./gradlew :app:testDebugUnitTest --tests pub.hackers.android.navigation.ShareTargetTextTest --tests pub.hackers.android.ui.screens.compose.ComposeViewModelTest :app:lintDebug`