### PR TITLE
Support note editing

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -38,8 +38,12 @@ fragment PostFields on Post {
     viewerHasBookmarked
     viewerHasPinned
     viewerCanQuote
+    language
     visibility
     quotePolicy
+    ... on Note {
+        rawContent
+    }
     actor {
         ...ActorFields
     }
@@ -113,8 +117,12 @@ fragment SharedPostFields on Post {
     viewerHasBookmarked
     viewerHasPinned
     viewerCanQuote
+    language
     visibility
     quotePolicy
+    ... on Note {
+        rawContent
+    }
     actor {
         ...ActorFields
     }
@@ -643,6 +651,22 @@ query ViewerPasskeys {
 mutation CreateNote($content: Markdown!, $language: Locale!, $visibility: PostVisibility!, $quotePolicy: QuotePolicy, $replyTargetId: ID, $quotedPostId: ID, $media: [CreateNoteMediumInput!] = []) {
     createNote(input: { content: $content, language: $language, visibility: $visibility, quotePolicy: $quotePolicy, replyTargetId: $replyTargetId, quotedPostId: $quotedPostId, media: $media }) {
         ... on CreateNotePayload {
+            note {
+                ...PostFields
+            }
+        }
+        ... on InvalidInputError {
+            inputPath
+        }
+        ... on NotAuthenticatedError {
+            notAuthenticated
+        }
+    }
+}
+
+mutation UpdateNote($noteId: ID!, $content: Markdown!, $language: Locale!, $quotePolicy: QuotePolicy) {
+    updateNote(input: { noteId: $noteId, content: $content, language: $language, quotePolicy: $quotePolicy }) {
+        ... on UpdateNotePayload {
             note {
                 ...PostFields
             }

--- a/app/src/main/graphql/pub/hackers/android/schema.graphqls
+++ b/app/src/main/graphql/pub/hackers/android/schema.graphqls
@@ -1053,6 +1053,8 @@ type Mutation {
 
   updateAccount(input: UpdateAccountInput!): UpdateAccountPayload!
 
+  updateNote(input: UpdateNoteInput!): UpdateNoteResult!
+
   uploadMedia(input: UploadMediaInput!): UploadMediaResult!
 
   verifyPasskeyRegistration(accountId: ID!, name: String!, platform: String = "web", registrationResponse: JSON!): PasskeyRegistrationResult!
@@ -1096,6 +1098,8 @@ type Note implements Node & Post & Reactable {
   quotePolicy: QuotePolicy!
 
   quotedPost: Post
+
+  rawContent: Markdown
 
   quotes(after: String, before: String, first: Int, last: Int): PostQuotesConnection!
 
@@ -2274,6 +2278,26 @@ type UpdateAccountPayload {
 
   clientMutationId: ID
 }
+
+input UpdateNoteInput {
+  clientMutationId: ID
+
+  content: Markdown
+
+  language: Locale
+
+  noteId: ID!
+
+  quotePolicy: QuotePolicy
+}
+
+type UpdateNotePayload {
+  clientMutationId: ID
+
+  note: Note!
+}
+
+union UpdateNoteResult = InvalidInputError|NotAuthenticatedError|UpdateNotePayload
 
 input UploadMediaInput {
   clientMutationId: ID

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -77,6 +77,7 @@ import pub.hackers.android.graphql.UnbookmarkPostMutation
 import pub.hackers.android.graphql.UnpinPostMutation
 import pub.hackers.android.graphql.UnsharePostMutation
 import pub.hackers.android.graphql.UpdateAccountMutation
+import pub.hackers.android.graphql.UpdateNoteMutation
 import pub.hackers.android.graphql.ViewerQuery
 import pub.hackers.android.graphql.type.AccountLinkInput
 import pub.hackers.android.graphql.type.CreateNoteMediumInput
@@ -1061,6 +1062,50 @@ class HackersPubRepository @Inject constructor(
         }
     }
 
+    suspend fun updateNote(
+        noteId: String,
+        content: String,
+        language: String,
+        quotePolicy: QuotePolicy,
+    ): Result<Post> {
+        return try {
+            val gqlQuotePolicy = when (quotePolicy) {
+                QuotePolicy.EVERYONE -> GqlQuotePolicy.EVERYONE
+                QuotePolicy.FOLLOWERS -> GqlQuotePolicy.FOLLOWERS
+                QuotePolicy.SELF -> GqlQuotePolicy.SELF
+            }
+
+            val response = apolloClient.mutation(
+                UpdateNoteMutation(
+                    noteId = noteId,
+                    content = content,
+                    language = language,
+                    quotePolicy = Optional.present(gqlQuotePolicy),
+                )
+            ).execute()
+
+            if (response.hasErrors()) {
+                Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
+            } else {
+                val result = response.data?.updateNote
+                when {
+                    result?.onUpdateNotePayload != null -> {
+                        Result.success(result.onUpdateNotePayload.note.postFields.toPost())
+                    }
+                    result?.onInvalidInputError != null -> {
+                        Result.failure(Exception("Invalid input: ${result.onInvalidInputError.inputPath}"))
+                    }
+                    result?.onNotAuthenticatedError != null -> {
+                        Result.failure(Exception("Not authenticated"))
+                    }
+                    else -> Result.failure(Exception("Unknown error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     suspend fun uploadMedium(
         uri: Uri,
         onProgress: (Int) -> Unit = {},
@@ -1773,6 +1818,8 @@ class HackersPubRepository @Inject constructor(
             viewerHasBookmarked = viewerHasBookmarked,
             viewerHasPinned = viewerHasPinned,
             viewerCanQuote = viewerCanQuote,
+            rawContent = onNote?.rawContent?.toString(),
+            language = language,
             actor = actor.actorFields.toActor(),
             media = media.map { it.mediaFields.toMedia() },
             link = link?.let { l ->
@@ -1844,6 +1891,8 @@ class HackersPubRepository @Inject constructor(
             viewerHasBookmarked = viewerHasBookmarked,
             viewerHasPinned = viewerHasPinned,
             viewerCanQuote = viewerCanQuote,
+            rawContent = onNote?.rawContent?.toString(),
+            language = language,
             actor = actor.actorFields.toActor(),
             media = media.map { it.mediaFields.toMedia() },
             engagementStats = engagementStats.engagementStatsFields.toEngagementStats(),

--- a/app/src/main/java/pub/hackers/android/domain/model/Models.kt
+++ b/app/src/main/java/pub/hackers/android/domain/model/Models.kt
@@ -98,6 +98,8 @@ data class Post(
     val viewerHasBookmarked: Boolean = false,
     val viewerHasPinned: Boolean = false,
     val viewerCanQuote: Boolean = true,
+    val rawContent: String? = null,
+    val language: String? = null,
     val actor: Actor,
     val media: List<Media>,
     val link: PostLink? = null,

--- a/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
+++ b/app/src/main/java/pub/hackers/android/ui/HackersPubApp.kt
@@ -57,6 +57,7 @@ import pub.hackers.android.ui.screens.timeline.TimelineScreen
 import pub.hackers.android.ui.screens.webview.WebViewScreen
 
 private const val PROFILE_REFRESH_KEY = "profile_refresh"
+private const val POST_DETAIL_REFRESH_KEY = "post_detail_refresh"
 
 sealed class Screen(
     val route: String,
@@ -116,12 +117,18 @@ sealed class DetailScreen(val route: String) {
             return if (params.isEmpty()) "signin" else "signin?${params.joinToString("&")}"
         }
     }
-    data object Compose : DetailScreen("compose?replyTo={replyTo}&quoteOf={quoteOf}&prefill={prefill}") {
-        fun createRoute(replyTo: String? = null, quoteOf: String? = null, prefill: String? = null): String {
+    data object Compose : DetailScreen("compose?replyTo={replyTo}&quoteOf={quoteOf}&prefill={prefill}&editPost={editPost}") {
+        fun createRoute(
+            replyTo: String? = null,
+            quoteOf: String? = null,
+            prefill: String? = null,
+            editPost: String? = null,
+        ): String {
             val params = mutableListOf<String>()
             if (replyTo != null) params.add("replyTo=${android.net.Uri.encode(replyTo)}")
             if (quoteOf != null) params.add("quoteOf=${android.net.Uri.encode(quoteOf)}")
             if (prefill != null) params.add("prefill=${android.net.Uri.encode(prefill)}")
+            if (editPost != null) params.add("editPost=${android.net.Uri.encode(editPost)}")
             return if (params.isEmpty()) "compose" else "compose?${params.joinToString("&")}"
         }
     }
@@ -337,6 +344,9 @@ fun HackersPubApp(
                     onQuoteClick = { postId ->
                         navController.navigate(DetailScreen.Compose.createRoute(quoteOf = postId))
                     },
+                    onEditClick = { postId ->
+                        navController.navigate(DetailScreen.Compose.createRoute(editPost = postId))
+                    },
                     onSettingsClick = {
                         navController.navigate(Screen.Settings.route)
                     },
@@ -377,6 +387,9 @@ fun HackersPubApp(
                     onQuoteClick = { postId ->
                         navController.navigate(DetailScreen.Compose.createRoute(quoteOf = postId))
                     },
+                    onEditClick = { postId ->
+                        navController.navigate(DetailScreen.Compose.createRoute(editPost = postId))
+                    },
                     onSignInClick = {
                         navController.navigate(DetailScreen.SignIn.createRoute())
                     },
@@ -408,6 +421,9 @@ fun HackersPubApp(
                     },
                     onQuoteClick = { postId ->
                         navController.navigate(DetailScreen.Compose.createRoute(quoteOf = postId))
+                    },
+                    onEditClick = { postId ->
+                        navController.navigate(DetailScreen.Compose.createRoute(editPost = postId))
                     }
                 )
             }
@@ -493,18 +509,28 @@ fun HackersPubApp(
                         type = NavType.StringType
                         nullable = true
                         defaultValue = null
+                    },
+                    navArgument("editPost") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
                     }
                 )
             ) { backStackEntry ->
                 val replyTo = backStackEntry.arguments?.getString("replyTo")
                 val quoteOf = backStackEntry.arguments?.getString("quoteOf")
                 val prefill = backStackEntry.arguments?.getString("prefill")
+                val editPost = backStackEntry.arguments?.getString("editPost")
                 ComposeScreen(
                     replyToId = replyTo,
                     quotedPostId = quoteOf,
                     initialContent = prefill,
+                    editPostId = editPost,
                     onPostSuccess = {
                         viewModel.timelineRefreshTrigger.requestRefresh()
+                        navController.previousBackStackEntry
+                            ?.savedStateHandle
+                            ?.set(POST_DETAIL_REFRESH_KEY, true)
                         navController.popBackStack()
                     },
                     onNavigateBack = {
@@ -518,8 +544,15 @@ fun HackersPubApp(
                 arguments = listOf(navArgument("postId") { type = NavType.StringType })
             ) { backStackEntry ->
                 val postId = backStackEntry.arguments?.getString("postId") ?: return@composable
+                val postDetailRefreshFlag = backStackEntry.savedStateHandle
+                    .getStateFlow(POST_DETAIL_REFRESH_KEY, false)
+                    .collectAsState()
                 PostDetailScreen(
                     postId = postId,
+                    refreshSignal = postDetailRefreshFlag.value,
+                    onRefreshConsumed = {
+                        backStackEntry.savedStateHandle[POST_DETAIL_REFRESH_KEY] = false
+                    },
                     onNavigateBack = {
                         navController.popBackStack()
                     },
@@ -531,6 +564,9 @@ fun HackersPubApp(
                     },
                     onQuoteClick = { id ->
                         navController.navigate(DetailScreen.Compose.createRoute(quoteOf = id))
+                    },
+                    onEditClick = { id ->
+                        navController.navigate(DetailScreen.Compose.createRoute(editPost = id))
                     },
                     onPostClick = { id ->
                         navController.navigate(DetailScreen.PostDetail.createRoute(id))
@@ -587,6 +623,9 @@ fun HackersPubApp(
                     },
                     onQuoteClick = { postId ->
                         navController.navigate(DetailScreen.Compose.createRoute(quoteOf = postId))
+                    },
+                    onEditClick = { postId ->
+                        navController.navigate(DetailScreen.Compose.createRoute(editPost = postId))
                     },
                     onEditProfileClick = {
                         navController.navigate(DetailScreen.EditProfile.route)
@@ -661,6 +700,9 @@ fun HackersPubApp(
                     },
                     onQuoteClick = { postId ->
                         navController.navigate(DetailScreen.Compose.createRoute(quoteOf = postId))
+                    },
+                    onEditClick = { postId ->
+                        navController.navigate(DetailScreen.Compose.createRoute(editPost = postId))
                     },
                 )
             }

--- a/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostCard.kt
@@ -44,6 +44,7 @@ import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.FormatQuote
 import androidx.compose.material.icons.outlined.Group
@@ -114,6 +115,7 @@ fun PostCard(
     onReactionLongPress: (() -> Unit)? = null,
     onBookmarkClick: (() -> Unit)? = null,
     onPinClick: ((Post) -> Unit)? = null,
+    onEditClick: ((Post) -> Unit)? = null,
     onExternalShareClick: (() -> Unit)? = null,
     onQuotedPostClick: ((String) -> Unit)? = null,
     contentMaxLength: Int = 0
@@ -147,6 +149,7 @@ fun PostCard(
             onReactionLongPress = onReactionLongPress,
             onBookmarkClick = onBookmarkClick,
             onPinClick = onPinClick,
+            onEditClick = onEditClick,
             onExternalShareClick = onExternalShareClick,
             onQuotedPostClick = onQuotedPostClick,
             contentMaxLength = contentMaxLength,
@@ -168,6 +171,7 @@ private fun NoteCard(
     onReactionLongPress: (() -> Unit)? = null,
     onBookmarkClick: (() -> Unit)? = null,
     onPinClick: ((Post) -> Unit)? = null,
+    onEditClick: ((Post) -> Unit)? = null,
     onExternalShareClick: (() -> Unit)? = null,
     onQuotedPostClick: ((String) -> Unit)? = null,
     contentMaxLength: Int = 0
@@ -569,6 +573,9 @@ private fun NoteCard(
                     onPinClick = onPinClick?.takeIf { displayPost.canPinToViewerProfile() }?.let {
                         { it(displayPost) }
                     },
+                    onEditClick = onEditClick?.takeIf { displayPost.canEditNote() }?.let {
+                        { it(displayPost) }
+                    },
                     onExternalShareClick = onExternalShareClick
                 )
             }
@@ -587,6 +594,7 @@ private fun EngagementBar(
     onReactionLongPress: (() -> Unit)? = null,
     onBookmarkClick: (() -> Unit)? = null,
     onPinClick: (() -> Unit)? = null,
+    onEditClick: (() -> Unit)? = null,
     onExternalShareClick: (() -> Unit)? = null
 ) {
     val colors = LocalAppColors.current
@@ -636,10 +644,11 @@ private fun EngagementBar(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        if (onPinClick != null) {
-            PostPinActionMenu(
+        if (onPinClick != null || onEditClick != null) {
+            PostMoreActionMenu(
                 isPinned = post.viewerHasPinned,
                 onPinClick = onPinClick,
+                onEditClick = onEditClick,
                 modifier = Modifier.offset(x = 14.dp),
             )
         }
@@ -662,9 +671,10 @@ private fun EngagementBar(
 }
 
 @Composable
-private fun PostPinActionMenu(
+private fun PostMoreActionMenu(
     isPinned: Boolean,
-    onPinClick: () -> Unit,
+    onPinClick: (() -> Unit)?,
+    onEditClick: (() -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -682,22 +692,40 @@ private fun PostPinActionMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {
-            DropdownMenuItem(
-                text = {
-                    Text(stringResource(if (isPinned) R.string.unpin_post else R.string.pin_post))
-                },
-                onClick = {
-                    expanded = false
-                    onPinClick()
-                },
-                leadingIcon = {
-                    Icon(
-                        imageVector = if (isPinned) Icons.Filled.PushPin else Icons.Outlined.PushPin,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp),
-                    )
-                },
-            )
+            if (onEditClick != null) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.compose_edit)) },
+                    onClick = {
+                        expanded = false
+                        onEditClick()
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Outlined.Edit,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    },
+                )
+            }
+            if (onPinClick != null) {
+                DropdownMenuItem(
+                    text = {
+                        Text(stringResource(if (isPinned) R.string.unpin_post else R.string.pin_post))
+                    },
+                    onClick = {
+                        expanded = false
+                        onPinClick()
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = if (isPinned) Icons.Filled.PushPin else Icons.Outlined.PushPin,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    },
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/pub/hackers/android/ui/components/PostPinning.kt
+++ b/app/src/main/java/pub/hackers/android/ui/components/PostPinning.kt
@@ -8,3 +8,10 @@ fun Post.canPinToViewerProfile(): Boolean {
         sharedPost == null &&
         (visibility == PostVisibility.PUBLIC || visibility == PostVisibility.UNLISTED)
 }
+
+fun Post.canEditNote(): Boolean {
+    return actor.isViewer &&
+        sharedPost == null &&
+        typename == "Note" &&
+        rawContent != null
+}

--- a/app/src/main/java/pub/hackers/android/ui/screens/bookmarks/BookmarksScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/bookmarks/BookmarksScreen.kt
@@ -61,6 +61,7 @@ fun BookmarksScreen(
     onProfileClick: (String) -> Unit,
     onReplyClick: (String) -> Unit,
     onQuoteClick: (String) -> Unit,
+    onEditClick: (String) -> Unit,
     viewModel: BookmarksViewModel = hiltViewModel(),
 ) {
     val items = viewModel.posts.collectAsLazyPagingItems()
@@ -212,6 +213,7 @@ fun BookmarksScreen(
                                         onQuoteClick = {
                                             onQuoteClick(post.sharedPost?.id ?: post.id)
                                         },
+                                        onEditClick = { onEditClick(it.id) },
                                         onReactionClick = {
                                             viewModel.toggleFavourite(post)
                                         },
@@ -275,6 +277,7 @@ fun BookmarksScreen(
                                         onQuoteClick = {
                                             onQuoteClick(post.sharedPost?.id ?: post.id)
                                         },
+                                        onEditClick = { onEditClick(it.id) },
                                         onReactionClick = {
                                             viewModel.toggleFavourite(post)
                                         },

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeScreen.kt
@@ -141,6 +141,7 @@ fun ComposeScreen(
     replyToId: String?,
     quotedPostId: String? = null,
     initialContent: String? = null,
+    editPostId: String? = null,
     onPostSuccess: () -> Unit,
     onNavigateBack: () -> Unit,
     viewModel: ComposeViewModel = hiltViewModel()
@@ -153,6 +154,7 @@ fun ComposeScreen(
     val quotePolicyLocked = uiState.visibility != PostVisibility.PUBLIC &&
         uiState.visibility != PostVisibility.UNLISTED
     val effectiveQuotePolicy = if (quotePolicyLocked) QuotePolicy.SELF else uiState.quotePolicy
+    val isEditing = editPostId != null || uiState.editPostId != null
 
     val colors = LocalAppColors.current
     val typography = LocalAppTypography.current
@@ -233,11 +235,19 @@ fun ComposeScreen(
     }
 
     LaunchedEffect(quotedPostId) {
-        quotedPostId?.let { viewModel.setQuotedPost(it) }
+        if (!isEditing) {
+            quotedPostId?.let { viewModel.setQuotedPost(it) }
+        }
     }
 
     LaunchedEffect(initialContent) {
-        initialContent?.let { viewModel.setInitialContent(it) }
+        if (!isEditing) {
+            initialContent?.let { viewModel.setInitialContent(it) }
+        }
+    }
+
+    LaunchedEffect(editPostId) {
+        editPostId?.let { viewModel.setEditTarget(it) }
     }
 
     LaunchedEffect(uiState.isPosted) {
@@ -266,6 +276,7 @@ fun ComposeScreen(
     val postEnabled = uiState.content.isNotBlank() &&
         uiState.language.isNotBlank() &&
         !uiState.isPosting &&
+        !uiState.isLoadingEditTarget &&
         mediaReady
 
     Scaffold(
@@ -287,9 +298,11 @@ fun ComposeScreen(
                     )
                 }
                 Text(
-                    text = if (replyToId != null) stringResource(R.string.reply) else stringResource(
-                        R.string.compose
-                    ),
+                    text = when {
+                        isEditing -> stringResource(R.string.compose_edit)
+                        replyToId != null -> stringResource(R.string.reply)
+                        else -> stringResource(R.string.compose)
+                    },
                     style = typography.titleLarge,
                     color = colors.textPrimary,
                     modifier = Modifier.align(Alignment.Center)
@@ -444,7 +457,7 @@ fun ComposeScreen(
                                 PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
                             )
                         },
-                        enabled = !uiState.isPosting && uiState.mediaAttachments.size < 20,
+                        enabled = !isEditing && !uiState.isPosting && uiState.mediaAttachments.size < 20,
                     ) {
                         Icon(
                             imageVector = Icons.Filled.Image,
@@ -457,6 +470,7 @@ fun ComposeScreen(
 
                     TextButton(
                         onClick = { showVisibilityMenu = true },
+                        enabled = !isEditing && !uiState.isPosting,
                         contentPadding = androidx.compose.foundation.layout.PaddingValues(
                             horizontal = 8.dp,
                             vertical = 4.dp
@@ -481,7 +495,7 @@ fun ComposeScreen(
                         )
 
                         DropdownMenu(
-                            expanded = showVisibilityMenu,
+                            expanded = showVisibilityMenu && !isEditing,
                             onDismissRequest = { showVisibilityMenu = false }
                         ) {
                             visibilityMenuItem(
@@ -655,7 +669,7 @@ fun ComposeScreen(
                         modifier = Modifier.alpha(if (postEnabled) 1f else 0.4f)
                     ) {
                         Text(
-                            text = stringResource(R.string.post),
+                            text = stringResource(if (isEditing) R.string.save else R.string.post),
                             color = colors.composeOnAccent
                         )
                     }

--- a/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/compose/ComposeViewModel.kt
@@ -59,6 +59,8 @@ data class ComposeUiState(
     val quotedPost: Post? = null,
     val isLoadingQuotedPost: Boolean = false,
     val quotedPostLoadFailed: Boolean = false,
+    val editPostId: String? = null,
+    val isLoadingEditTarget: Boolean = false,
     val mediaAttachments: List<ComposeMediaAttachment> = emptyList(),
     val isPosting: Boolean = false,
     val isPosted: Boolean = false,
@@ -254,6 +256,62 @@ class ComposeViewModel @Inject constructor(
                 }
                 .onFailure {
                     _uiState.update { it.copy(isLoadingQuotedPost = false, quotedPostLoadFailed = true) }
+                }
+        }
+    }
+
+    fun setEditTarget(postId: String) {
+        val currentState = _uiState.value
+        if (currentState.editPostId == postId && !currentState.isLoadingEditTarget) return
+
+        _uiState.update {
+            it.copy(
+                editPostId = postId,
+                isLoadingEditTarget = true,
+                error = null,
+            )
+        }
+        viewModelScope.launch {
+            repository.getPostDetail(postId)
+                .onSuccess { result ->
+                    val post = result.post
+                    val rawContent = post.rawContent
+                    if (post.typename != "Note" || rawContent.isNullOrBlank()) {
+                        _uiState.update {
+                            it.copy(
+                                editPostId = null,
+                                isLoadingEditTarget = false,
+                                error = "This note cannot be edited"
+                            )
+                        }
+                        return@onSuccess
+                    }
+
+                    _uiState.update {
+                        it.copy(
+                            content = rawContent,
+                            cursorPosition = rawContent.length,
+                            language = post.language ?: it.language,
+                            visibility = post.visibility,
+                            quotePolicy = post.quotePolicy,
+                            editPostId = post.id,
+                            isLoadingEditTarget = false,
+                            mediaAttachments = emptyList(),
+                            mentionQuery = null,
+                            mentionStartIndex = -1,
+                            mentionSuggestions = emptyList(),
+                            isLoadingMentions = false,
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            editPostId = null,
+                            isLoadingEditTarget = false,
+                            error = error.message ?: "Unable to load note"
+                        )
+                    }
                 }
         }
     }
@@ -487,6 +545,12 @@ class ComposeViewModel @Inject constructor(
     fun post() {
         val state = _uiState.value
         if (state.content.isBlank() || state.isPosting) return
+        val editPostId = state.editPostId
+        if (editPostId != null) {
+            updateExistingNote(state, editPostId)
+            return
+        }
+
         val media = state.mediaAttachments.map { attachment ->
             val mediumId = attachment.uploadedMediumId
             when {
@@ -525,6 +589,30 @@ class ComposeViewModel @Inject constructor(
                     state.replyToId?.let { replyTargetId ->
                         replyPostedSignal.emit(ReplyPostedEvent(replyTargetId, newPost))
                     }
+                    _uiState.update { it.copy(isPosting = false, isPosted = true) }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            error = error.message,
+                            isPosting = false
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun updateExistingNote(state: ComposeUiState, editPostId: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPosting = true, error = null) }
+
+            repository.updateNote(
+                noteId = editPostId,
+                content = state.content,
+                language = state.language,
+                quotePolicy = state.effectiveQuotePolicy(),
+            )
+                .onSuccess {
                     _uiState.update { it.copy(isPosting = false, isPosted = true) }
                 }
                 .onFailure { error ->

--- a/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/explore/ExploreScreen.kt
@@ -56,6 +56,7 @@ fun ExploreScreen(
     onProfileClick: (String) -> Unit,
     onReplyClick: (String) -> Unit,
     onQuoteClick: (String) -> Unit = {},
+    onEditClick: (String) -> Unit = {},
     onSignInClick: () -> Unit,
     isLoggedIn: Boolean,
     viewModel: ExploreViewModel = hiltViewModel()
@@ -219,6 +220,7 @@ fun ExploreScreen(
                                         onProfileClick = onProfileClick,
                                         onReplyClick = onReplyClick,
                                         onQuoteClick = onQuoteClick,
+                                        onEditClick = onEditClick,
                                         viewModel = viewModel,
                                     )
                                 }
@@ -239,6 +241,7 @@ fun ExploreScreen(
                                         onProfileClick = onProfileClick,
                                         onReplyClick = onReplyClick,
                                         onQuoteClick = onQuoteClick,
+                                        onEditClick = onEditClick,
                                         viewModel = viewModel,
                                     )
                                 }
@@ -267,6 +270,7 @@ private fun ExplorePostItem(
     onProfileClick: (String) -> Unit,
     onReplyClick: (String) -> Unit,
     onQuoteClick: (String) -> Unit,
+    onEditClick: (String) -> Unit,
     viewModel: ExploreViewModel,
 ) {
     PostCard(
@@ -287,6 +291,9 @@ private fun ExplorePostItem(
         } else null,
         onQuoteClick = if (isLoggedIn) {
             { onQuoteClick(post.sharedPost?.id ?: post.id) }
+        } else null,
+        onEditClick = if (isLoggedIn) {
+            { onEditClick(it.id) }
         } else null,
         onReactionClick = if (isLoggedIn) {
             { viewModel.toggleFavourite(post) }

--- a/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/postdetail/PostDetailScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.outlined.AddReaction
 import androidx.compose.material.icons.outlined.BookmarkBorder
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.FormatQuote
 import androidx.compose.material.icons.outlined.Group
 import androidx.compose.material.icons.outlined.Lock
@@ -124,6 +125,7 @@ import pub.hackers.android.ui.components.QuotedPostPreview
 import pub.hackers.android.ui.components.ReactionPicker
 import pub.hackers.android.ui.components.TocList
 import pub.hackers.android.ui.components.TocPanel
+import pub.hackers.android.ui.components.canEditNote
 import pub.hackers.android.ui.components.canPinToViewerProfile
 import pub.hackers.android.ui.components.contentWarningText
 import pub.hackers.android.ui.components.hasContentWarning
@@ -145,10 +147,13 @@ import java.util.Locale
 @Composable
 fun PostDetailScreen(
     postId: String,
+    refreshSignal: Boolean = false,
+    onRefreshConsumed: () -> Unit = {},
     onNavigateBack: () -> Unit,
     onProfileClick: (String) -> Unit,
     onReplyClick: (String) -> Unit,
     onQuoteClick: (String) -> Unit = {},
+    onEditClick: (String) -> Unit = {},
     onPostClick: (String) -> Unit,
     isLoggedIn: Boolean = true,
     viewModel: PostDetailViewModel = hiltViewModel()
@@ -166,6 +171,13 @@ fun PostDetailScreen(
     var showShareConfirmation by remember { mutableStateOf(false) }
     var webViewUrl by remember { mutableStateOf<String?>(null) }
     var showTocSheet by remember { mutableStateOf(false) }
+
+    LaunchedEffect(refreshSignal) {
+        if (refreshSignal) {
+            viewModel.refresh()
+            onRefreshConsumed()
+        }
+    }
 
     val screenScope = rememberCoroutineScope()
     val lazyListState = rememberLazyListState()
@@ -422,12 +434,18 @@ fun PostDetailScreen(
                                 )
                             }
                         }
-                        if (uiState.canDelete || uiState.post?.canPinToViewerProfile() == true) {
+                        if (uiState.canDelete ||
+                            uiState.post?.canPinToViewerProfile() == true ||
+                            uiState.post?.canEditNote() == true
+                        ) {
                             PostDetailActionMenu(
                                 canDelete = uiState.canDelete,
                                 isDeleting = uiState.isDeleting,
                                 post = uiState.post,
                                 onPinClick = { viewModel.togglePin() },
+                                onEditClick = {
+                                    uiState.post?.id?.let(onEditClick)
+                                },
                                 onDelete = {
                                     if (confirmBeforeDelete) {
                                         showDeleteConfirmation = true
@@ -550,6 +568,7 @@ private fun PostDetailActionMenu(
     isDeleting: Boolean,
     post: Post?,
     onPinClick: () -> Unit,
+    onEditClick: () -> Unit,
     onDelete: () -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -581,6 +600,21 @@ private fun PostDetailActionMenu(
                     onClick = {
                         expanded = false
                         onPinClick()
+                    },
+                )
+            }
+            if (post?.canEditNote() == true) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.compose_edit)) },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Outlined.Edit,
+                            contentDescription = null,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onEditClick()
                     },
                 )
             }

--- a/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/profile/ProfileScreen.kt
@@ -94,6 +94,7 @@ fun ProfileScreen(
     onProfileClick: (String) -> Unit = {},
     onReplyClick: (String) -> Unit = {},
     onQuoteClick: (String) -> Unit = {},
+    onEditClick: (String) -> Unit = {},
     onEditProfileClick: () -> Unit = {},
     refreshSignal: Boolean = false,
     onRefreshConsumed: () -> Unit = {},
@@ -262,6 +263,7 @@ fun ProfileScreen(
                                     onProfileClick = onProfileClick,
                                     onReplyClick = onReplyClick,
                                     onQuoteClick = onQuoteClick,
+                                    onEditClick = onEditClick,
                                     onPinClick = { viewModel.togglePin(it) },
                                     onExternalShareClick = { post ->
                                         val shareUrl = post.url ?: post.iri
@@ -336,6 +338,7 @@ fun ProfileScreen(
                                                 post.sharedPost?.id ?: post.id
                                             )
                                         },
+                                        onEditClick = { onEditClick(it.id) },
                                         onPinClick = { viewModel.togglePin(it) },
                                         onReactionClick = null,
                                         onExternalShareClick = {
@@ -383,6 +386,7 @@ private fun PinnedPostsSection(
     onProfileClick: (String) -> Unit,
     onReplyClick: (String) -> Unit,
     onQuoteClick: (String) -> Unit,
+    onEditClick: (String) -> Unit,
     onPinClick: (Post) -> Unit,
     onExternalShareClick: (Post) -> Unit,
 ) {
@@ -419,6 +423,7 @@ private fun PinnedPostsSection(
                 onShareClick = null,
                 onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
                 onReactionClick = null,
+                onEditClick = { onEditClick(it.id) },
                 onPinClick = onPinClick,
                 onExternalShareClick = { onExternalShareClick(post.sharedPost ?: post) },
                 onQuotedPostClick = onPostClick,

--- a/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/search/SearchScreen.kt
@@ -62,6 +62,7 @@ fun SearchScreen(
     onProfileClick: (String) -> Unit,
     onReplyClick: (String) -> Unit = {},
     onQuoteClick: (String) -> Unit = {},
+    onEditClick: (String) -> Unit = {},
     initialQuery: String? = null,
     viewModel: SearchViewModel = hiltViewModel()
 ) {
@@ -213,6 +214,7 @@ fun SearchScreen(
                                                 onProfileClick = onProfileClick,
                                                 onReplyClick = onReplyClick,
                                                 onQuoteClick = onQuoteClick,
+                                                onEditClick = onEditClick,
                                                 onExternalShare = { shareUrl ->
                                                     val sendIntent = Intent().apply {
                                                         action = Intent.ACTION_SEND
@@ -282,6 +284,7 @@ fun SearchScreen(
                                             onProfileClick = onProfileClick,
                                             onReplyClick = onReplyClick,
                                             onQuoteClick = onQuoteClick,
+                                            onEditClick = onEditClick,
                                             onExternalShare = { shareUrl ->
                                                 val sendIntent = Intent().apply {
                                                     action = Intent.ACTION_SEND
@@ -449,6 +452,7 @@ private fun SearchPostItem(
     onProfileClick: (String) -> Unit,
     onReplyClick: (String) -> Unit,
     onQuoteClick: (String) -> Unit,
+    onEditClick: (String) -> Unit,
     onExternalShare: (String) -> Unit
 ) {
     PostCard(
@@ -457,6 +461,7 @@ private fun SearchPostItem(
         onProfileClick = onProfileClick,
         onReplyClick = { onReplyClick(post.sharedPost?.id ?: post.id) },
         onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
+        onEditClick = { onEditClick(it.id) },
         onReactionClick = null,
         onExternalShareClick = {
             val displayPost = post.sharedPost ?: post

--- a/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/timeline/TimelineScreen.kt
@@ -63,6 +63,7 @@ fun TimelineScreen(
     onProfileClick: (String) -> Unit,
     onComposeClick: (String?) -> Unit,
     onQuoteClick: (String) -> Unit = {},
+    onEditClick: (String) -> Unit = {},
     onSettingsClick: () -> Unit,
     onRecommendedActorsClick: () -> Unit = {},
     onComposeArticleClick: () -> Unit = {},
@@ -281,6 +282,7 @@ fun TimelineScreen(
                                             }
                                         },
                                         onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
+                                        onEditClick = { onEditClick(it.id) },
                                         onReactionClick = { viewModel.toggleFavourite(post) },
                                         onReactionLongPress = {
                                             viewModel.showReactionPicker(post.sharedPost?.id ?: post.id)
@@ -342,6 +344,7 @@ fun TimelineScreen(
                                             }
                                         },
                                         onQuoteClick = { onQuoteClick(post.sharedPost?.id ?: post.id) },
+                                        onEditClick = { onEditClick(it.id) },
                                         onReactionClick = { viewModel.toggleFavourite(post) },
                                         onReactionLongPress = {
                                             viewModel.showReactionPicker(post.sharedPost?.id ?: post.id)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="compose_hint">What\'s on your mind?</string>
     <string name="compose_language_label">Language</string>
     <string name="post">Post</string>
+    <string name="save">Save</string>
     <string name="cancel">Cancel</string>
     <string name="compose_edit">Edit</string>
     <string name="compose_preview">Preview</string>

--- a/app/src/test/java/pub/hackers/android/ui/screens/compose/ComposeViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/compose/ComposeViewModelTest.kt
@@ -61,9 +61,14 @@ class ComposeViewModelTest {
         id: String = "post-1",
         actor: Actor = sampleActor,
         mentions: List<String> = emptyList(),
+        typename: String = "Note",
+        rawContent: String? = null,
+        language: String? = null,
+        visibility: PostVisibility = PostVisibility.PUBLIC,
+        quotePolicy: QuotePolicy = QuotePolicy.EVERYONE,
     ) = Post(
         id = id,
-        typename = "Note",
+        typename = typename,
         name = null,
         published = Instant.parse("2025-01-01T00:00:00Z"),
         summary = null,
@@ -71,10 +76,14 @@ class ComposeViewModelTest {
         excerpt = "hello",
         url = null,
         viewerHasShared = false,
+        rawContent = rawContent,
+        language = language,
         actor = actor,
         media = emptyList(),
         engagementStats = EngagementStats(replies = 0, reactions = 0, shares = 0, quotes = 0),
         mentions = mentions,
+        visibility = visibility,
+        quotePolicy = quotePolicy,
         reactionGroups = emptyList(),
     )
 
@@ -143,6 +152,123 @@ class ComposeViewModelTest {
         vm.setInitialContent("shared content")
 
         assertEquals("user typed this", vm.uiState.value.content)
+    }
+
+    @Test
+    fun `setEditTarget loads raw note content`() = runTest {
+        val post = samplePost(
+            rawContent = "raw **markdown**",
+            language = "ko",
+            visibility = PostVisibility.UNLISTED,
+            quotePolicy = QuotePolicy.FOLLOWERS,
+        )
+        coEvery { repository.getPostDetail("post-1") } returns Result.success(
+            PostDetailResult(
+                post = post,
+                reactionGroups = emptyList(),
+                replies = emptyList(),
+                hasMoreReplies = false,
+                repliesEndCursor = null,
+            )
+        )
+
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.setEditTarget("post-1")
+        advanceUntilIdle()
+
+        assertEquals("post-1", vm.uiState.value.editPostId)
+        assertEquals("raw **markdown**", vm.uiState.value.content)
+        assertEquals("ko", vm.uiState.value.language)
+        assertEquals(PostVisibility.UNLISTED, vm.uiState.value.visibility)
+        assertEquals(QuotePolicy.FOLLOWERS, vm.uiState.value.quotePolicy)
+    }
+
+    @Test
+    fun `setEditTarget rejects notes without raw content`() = runTest {
+        coEvery { repository.getPostDetail("post-1") } returns Result.success(
+            PostDetailResult(
+                post = samplePost(rawContent = null),
+                reactionGroups = emptyList(),
+                replies = emptyList(),
+                hasMoreReplies = false,
+                repliesEndCursor = null,
+            )
+        )
+
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.setEditTarget("post-1")
+        advanceUntilIdle()
+
+        assertEquals(null, vm.uiState.value.editPostId)
+        assertEquals("This note cannot be edited", vm.uiState.value.error)
+    }
+
+    @Test
+    fun `post updates existing note in edit mode`() = runTest {
+        val existingPost = samplePost(
+            rawContent = "old content",
+            language = "en",
+            quotePolicy = QuotePolicy.EVERYONE,
+        )
+        val updatedPost = samplePost(
+            id = "post-1",
+            rawContent = "new content",
+            language = "ja",
+            quotePolicy = QuotePolicy.SELF,
+        )
+        coEvery { repository.getPostDetail("post-1") } returns Result.success(
+            PostDetailResult(
+                post = existingPost,
+                reactionGroups = emptyList(),
+                replies = emptyList(),
+                hasMoreReplies = false,
+                repliesEndCursor = null,
+            )
+        )
+        coEvery {
+            repository.updateNote(
+                noteId = "post-1",
+                content = "new content",
+                language = "ja",
+                quotePolicy = QuotePolicy.SELF,
+            )
+        } returns Result.success(updatedPost)
+
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.setEditTarget("post-1")
+        advanceUntilIdle()
+        vm.updateContent("new content")
+        vm.updateLanguage("ja")
+        vm.updateQuotePolicy(QuotePolicy.SELF)
+        vm.post()
+        advanceUntilIdle()
+
+        coVerify {
+            repository.updateNote(
+                noteId = "post-1",
+                content = "new content",
+                language = "ja",
+                quotePolicy = QuotePolicy.SELF,
+            )
+        }
+        coVerify(exactly = 0) {
+            repository.createNote(
+                content = any(),
+                language = any(),
+                visibility = any(),
+                quotePolicy = any(),
+                replyTargetId = any(),
+                quotedPostId = any(),
+                media = any(),
+            )
+        }
+        assertEquals(true, vm.uiState.value.isPosted)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add the `updateNote` GraphQL operation and map owner-only raw note content into the domain model.
- Reuse the existing note composer for edit mode with content, language, and quote-policy updates.
- Expose Edit from post action menus for editable owned notes and refresh post detail after saving.

## Validation
- `./gradlew :app:testDebugUnitTest --tests pub.hackers.android.ui.screens.compose.ComposeViewModelTest :app:lintDebug`