### PR TITLE
Add support for handling banned accounts in login mutations and tests

### DIFF
--- a/app/src/main/graphql/pub/hackers/android/operations.graphql
+++ b/app/src/main/graphql/pub/hackers/android/operations.graphql
@@ -605,13 +605,19 @@ mutation LoginByUsername($username: String!, $locale: Locale!, $verifyUrl: URITe
 
 mutation CompleteLoginChallenge($token: UUID!, $code: String!) {
     completeLoginChallenge(token: $token, code: $code) {
-        id
-        account {
+        __typename
+        ... on Session {
             id
-            username
-            name
-            avatarUrl
-            handle
+            account {
+                id
+                username
+                name
+                avatarUrl
+                handle
+            }
+        }
+        ... on AccountBannedError {
+            since
         }
     }
 }
@@ -622,13 +628,19 @@ mutation GetPasskeyAuthenticationOptions($sessionId: UUID!) {
 
 mutation LoginByPasskey($sessionId: UUID!, $authenticationResponse: JSON!, $platform: String = "android") {
     loginByPasskey(sessionId: $sessionId, authenticationResponse: $authenticationResponse, platform: $platform) {
-        id
-        account {
+        __typename
+        ... on Session {
             id
-            username
-            name
-            avatarUrl
-            handle
+            account {
+                id
+                username
+                name
+                avatarUrl
+                handle
+            }
+        }
+        ... on AccountBannedError {
+            since
         }
     }
 }

--- a/app/src/main/graphql/pub/hackers/android/schema.graphqls
+++ b/app/src/main/graphql/pub/hackers/android/schema.graphqls
@@ -160,6 +160,10 @@ input AccountLinkInput {
   url: URL!
 }
 
+type AccountBannedError {
+  since: DateTime!
+}
+
 type AccountNotFoundError {
   query: String!
 }
@@ -905,6 +909,10 @@ type LoginChallenge {
   token: UUID!
 }
 
+union CompleteLoginChallengeResult = AccountBannedError|Session
+
+union LoginByPasskeyResult = AccountBannedError|Session
+
 union LoginResult = AccountNotFoundError|LoginChallenge
 
 """
@@ -977,7 +985,7 @@ type Mutation {
 
   bookmarkPost(input: BookmarkPostInput!): BookmarkPostResult!
 
-  completeLoginChallenge("The code of the login challenge." code: String!, "The token of the login challenge." token: UUID!): Session
+  completeLoginChallenge("The code of the login challenge." code: String!, "The token of the login challenge." token: UUID!): CompleteLoginChallengeResult
 
   """
   Complete the signup process by creating a new account and session.
@@ -1004,7 +1012,7 @@ type Mutation {
 
   loginByEmail("The email of the account to sign in." email: String!, "The locale for the sign-in email." locale: Locale!, "The RFC 6570-compliant URI Template for the verification link.  Available variabvles: `{token}` and `{code}`." verifyUrl: URITemplate!): LoginResult!
 
-  loginByPasskey("WebAuthn authentication response from the client." authenticationResponse: JSON!, platform: String = "web", "Temporary session ID used for authentication options." sessionId: UUID!): Session
+  loginByPasskey("WebAuthn authentication response from the client." authenticationResponse: JSON!, platform: String = "web", "Temporary session ID used for authentication options." sessionId: UUID!): LoginByPasskeyResult
 
   loginByUsername("The locale for the sign-in email." locale: Locale!, "The username of the account to sign in." username: String!, "The RFC 6570-compliant URI Template for the verification link.  Available variabvles: `{token}` and `{code}`." verifyUrl: URITemplate!): LoginResult!
 

--- a/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
+++ b/app/src/main/java/pub/hackers/android/data/repository/HackersPubRepository.kt
@@ -858,21 +858,17 @@ class HackersPubRepository @Inject constructor(
             if (response.hasErrors()) {
                 Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
             } else {
-                val session = response.data?.completeLoginChallenge
+                val result = response.data?.completeLoginChallenge
                     ?: return Result.failure(Exception("Invalid verification code"))
+                val session = result.onSession
 
-                Result.success(
-                    Session(
-                        id = session.id.toString(),
-                        account = Account(
-                            id = session.account.id,
-                            username = session.account.username,
-                            name = session.account.name,
-                            avatarUrl = session.account.avatarUrl.toString(),
-                            handle = session.account.handle
-                        )
+                when {
+                    session != null -> Result.success(session.toDomainSession())
+                    result.onAccountBannedError != null -> Result.failure(
+                        Exception(accountBannedMessage(result.onAccountBannedError.since))
                     )
-                )
+                    else -> Result.failure(Exception("Unknown login result: ${result.__typename}"))
+                }
             }
         } catch (e: Exception) {
             Result.failure(e)
@@ -910,25 +906,51 @@ class HackersPubRepository @Inject constructor(
             if (response.hasErrors()) {
                 Result.failure(Exception(response.errors?.firstOrNull()?.message ?: "Unknown error"))
             } else {
-                val session = response.data?.loginByPasskey
+                val result = response.data?.loginByPasskey
                     ?: return Result.failure(Exception("Passkey authentication failed"))
+                val session = result.onSession
 
-                Result.success(
-                    Session(
-                        id = session.id.toString(),
-                        account = Account(
-                            id = session.account.id,
-                            username = session.account.username,
-                            name = session.account.name,
-                            avatarUrl = session.account.avatarUrl.toString(),
-                            handle = session.account.handle
-                        )
+                when {
+                    session != null -> Result.success(session.toDomainSession())
+                    result.onAccountBannedError != null -> Result.failure(
+                        Exception(accountBannedMessage(result.onAccountBannedError.since))
                     )
-                )
+                    else -> Result.failure(Exception("Unknown passkey login result: ${result.__typename}"))
+                }
             }
         } catch (e: Exception) {
             Result.failure(e)
         }
+    }
+
+    private fun CompleteLoginChallengeMutation.OnSession.toDomainSession(): Session {
+        return Session(
+            id = id.toString(),
+            account = Account(
+                id = account.id,
+                username = account.username,
+                name = account.name,
+                avatarUrl = account.avatarUrl.toString(),
+                handle = account.handle
+            )
+        )
+    }
+
+    private fun LoginByPasskeyMutation.OnSession.toDomainSession(): Session {
+        return Session(
+            id = id.toString(),
+            account = Account(
+                id = account.id,
+                username = account.username,
+                name = account.name,
+                avatarUrl = account.avatarUrl.toString(),
+                handle = account.handle
+            )
+        )
+    }
+
+    private fun accountBannedMessage(since: Any): String {
+        return "Account is banned since $since"
     }
 
     suspend fun getPasskeyRegistrationOptions(accountId: String): Result<String> {

--- a/app/src/test/java/pub/hackers/android/data/repository/HackersPubRepositoryAuthTest.kt
+++ b/app/src/test/java/pub/hackers/android/data/repository/HackersPubRepositoryAuthTest.kt
@@ -1,0 +1,192 @@
+package pub.hackers.android.data.repository
+
+import android.content.Context
+import com.apollographql.apollo.ApolloCall
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.ApolloResponse
+import com.apollographql.apollo.api.Error
+import com.apollographql.apollo.api.Operation
+import com.benasher44.uuid.uuid4
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import pub.hackers.android.graphql.CompleteLoginChallengeMutation
+import pub.hackers.android.graphql.LoginByPasskeyMutation
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class HackersPubRepositoryAuthTest {
+
+    private val apolloClient = mockk<ApolloClient>()
+    private val okHttpClient = mockk<OkHttpClient>(relaxed = true)
+    private val context = mockk<Context>(relaxed = true)
+
+    private fun newRepository() = HackersPubRepository(
+        apolloClient = apolloClient,
+        okHttpClient = okHttpClient,
+        context = context,
+    )
+
+    private fun <D : Operation.Data> buildResponse(
+        operation: Operation<D>,
+        data: D?,
+        errors: List<Error>? = null,
+    ): ApolloResponse<D> = ApolloResponse.Builder(operation, uuid4())
+        .data(data)
+        .errors(errors)
+        .build()
+
+    private fun stubCompleteLoginChallenge(
+        data: CompleteLoginChallengeMutation.Data?,
+        errors: List<Error>? = null,
+    ) {
+        val call = mockk<ApolloCall<CompleteLoginChallengeMutation.Data>>()
+        every { apolloClient.mutation(any<CompleteLoginChallengeMutation>()) } answers {
+            val operation = firstArg<CompleteLoginChallengeMutation>()
+            coEvery { call.execute() } returns buildResponse(operation, data, errors)
+            call
+        }
+    }
+
+    private fun stubLoginByPasskey(
+        data: LoginByPasskeyMutation.Data?,
+        errors: List<Error>? = null,
+    ) {
+        val call = mockk<ApolloCall<LoginByPasskeyMutation.Data>>()
+        every { apolloClient.mutation(any<LoginByPasskeyMutation>()) } answers {
+            val operation = firstArg<LoginByPasskeyMutation>()
+            coEvery { call.execute() } returns buildResponse(operation, data, errors)
+            call
+        }
+    }
+
+    private fun completeLoginSessionData() = CompleteLoginChallengeMutation.Data(
+        completeLoginChallenge = CompleteLoginChallengeMutation.CompleteLoginChallenge(
+            __typename = "Session",
+            onSession = CompleteLoginChallengeMutation.OnSession(
+                id = "session-token",
+                account = CompleteLoginChallengeMutation.Account(
+                    id = "account-1",
+                    username = "alice",
+                    name = "Alice",
+                    avatarUrl = "https://hackers.pub/avatar.png",
+                    handle = "@alice@hackers.pub",
+                ),
+            ),
+            onAccountBannedError = null,
+        )
+    )
+
+    private fun completeLoginBannedData() = CompleteLoginChallengeMutation.Data(
+        completeLoginChallenge = CompleteLoginChallengeMutation.CompleteLoginChallenge(
+            __typename = "AccountBannedError",
+            onSession = null,
+            onAccountBannedError = CompleteLoginChallengeMutation.OnAccountBannedError(
+                since = "2026-07-05T00:00:00Z",
+            ),
+        )
+    )
+
+    private fun passkeySessionData() = LoginByPasskeyMutation.Data(
+        loginByPasskey = LoginByPasskeyMutation.LoginByPasskey(
+            __typename = "Session",
+            onSession = LoginByPasskeyMutation.OnSession(
+                id = "passkey-session-token",
+                account = LoginByPasskeyMutation.Account(
+                    id = "account-2",
+                    username = "bob",
+                    name = "Bob",
+                    avatarUrl = "https://hackers.pub/bob.png",
+                    handle = "@bob@hackers.pub",
+                ),
+            ),
+            onAccountBannedError = null,
+        )
+    )
+
+    private fun passkeyBannedData() = LoginByPasskeyMutation.Data(
+        loginByPasskey = LoginByPasskeyMutation.LoginByPasskey(
+            __typename = "AccountBannedError",
+            onSession = null,
+            onAccountBannedError = LoginByPasskeyMutation.OnAccountBannedError(
+                since = "2026-07-05T00:00:00Z",
+            ),
+        )
+    )
+
+    @Test
+    fun `completeLoginChallenge maps Session union result`() = runTest {
+        stubCompleteLoginChallenge(completeLoginSessionData())
+
+        val result = newRepository().completeLoginChallenge(
+            token = "challenge-token",
+            code = "ABCDEF",
+        )
+
+        assertTrue(result.isSuccess)
+        val session = result.getOrThrow()
+        assertEquals("session-token", session.id)
+        assertEquals("account-1", session.account.id)
+        assertEquals("alice", session.account.username)
+        assertEquals("@alice@hackers.pub", session.account.handle)
+    }
+
+    @Test
+    fun `completeLoginChallenge returns failure for banned account result`() = runTest {
+        stubCompleteLoginChallenge(completeLoginBannedData())
+
+        val result = newRepository().completeLoginChallenge(
+            token = "challenge-token",
+            code = "ABCDEF",
+        )
+
+        assertTrue(result.isFailure)
+        assertEquals(
+            "Account is banned since 2026-07-05T00:00:00Z",
+            result.exceptionOrNull()?.message,
+        )
+    }
+
+    @Test
+    fun `loginByPasskey maps Session union result`() = runTest {
+        stubLoginByPasskey(passkeySessionData())
+
+        val result = newRepository().loginByPasskey(
+            sessionId = "session-id",
+            authenticationResponse = mapOf("id" to "credential-id"),
+        )
+
+        assertTrue(result.isSuccess)
+        val session = result.getOrThrow()
+        assertEquals("passkey-session-token", session.id)
+        assertEquals("account-2", session.account.id)
+        assertEquals("bob", session.account.username)
+        assertEquals("@bob@hackers.pub", session.account.handle)
+    }
+
+    @Test
+    fun `loginByPasskey returns failure for banned account result`() = runTest {
+        stubLoginByPasskey(passkeyBannedData())
+
+        val result = newRepository().loginByPasskey(
+            sessionId = "session-id",
+            authenticationResponse = mapOf("id" to "credential-id"),
+        )
+
+        assertTrue(result.isFailure)
+        assertEquals(
+            "Account is banned since 2026-07-05T00:00:00Z",
+            result.exceptionOrNull()?.message,
+        )
+    }
+}


### PR DESCRIPTION

# Resolved Symptoms

- Fixed an issue where email-based login did not complete on Android
- Fixed a failure in the login flow after verifying the email code/link

# Root Cause

- The `completeLoginChallenge` response can return a union result: either `Session` or `AccountBannedError`
- The Android GraphQL operation and repository logic still assumed the response was always a `Session`
- `loginByPasskey` uses the same kind of authentication result, so it could hit the same response-mapping issue

# Solution

- Updated `completeLoginChallenge` and `loginByPasskey` GraphQL operations to request `__typename` and union fragments
- Mapped successful `Session` results into the existing domain `Session` model
- Handled `AccountBannedError` as a failed login result with a message that includes the banned timestamp
- Added repository tests for successful session responses and banned-account responses for both email and passkey login

# References

- Closes #160
