### PR TITLE
Mark notifications as read on every tab activation

### DIFF
--- a/app/src/main/java/pub/hackers/android/FeatureFlags.kt
+++ b/app/src/main/java/pub/hackers/android/FeatureFlags.kt
@@ -2,5 +2,5 @@ package pub.hackers.android
 
 object FeatureFlags {
     const val PASSKEY_AUTH_ENABLED = true
-    const val MARK_NOTIFICATIONS_AS_READ_ENABLED = false
+    const val MARK_NOTIFICATIONS_AS_READ_ENABLED = true
 }

--- a/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsScreen.kt
@@ -67,6 +67,11 @@ fun NotificationsScreen(
     val listState = rememberLazyListState()
     val colors = LocalAppColors.current
 
+    // Mark as read every time the tab is activated (screen re-enters composition).
+    LaunchedEffect(Unit) {
+        viewModel.markAsRead()
+    }
+
     // Mark as seen once the initial refresh finishes successfully with items.
     LaunchedEffect(items.loadState.refresh, items.itemCount) {
         if (items.loadState.refresh is LoadState.NotLoading && items.itemCount > 0) {

--- a/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/pub/hackers/android/ui/screens/notifications/NotificationsViewModel.kt
@@ -26,13 +26,13 @@ class NotificationsViewModel @Inject constructor(
             .flow
             .cachedIn(viewModelScope)
 
-    init {
+    fun markAsSeen() {
+        viewModelScope.launch { notificationStateManager.markAsSeen() }
+    }
+
+    fun markAsRead() {
         if (FeatureFlags.MARK_NOTIFICATIONS_AS_READ_ENABLED) {
             viewModelScope.launch { repository.markNotificationsAsRead() }
         }
-    }
-
-    fun markAsSeen() {
-        viewModelScope.launch { notificationStateManager.markAsSeen() }
     }
 }

--- a/app/src/test/java/pub/hackers/android/ui/screens/notifications/NotificationsViewModelTest.kt
+++ b/app/src/test/java/pub/hackers/android/ui/screens/notifications/NotificationsViewModelTest.kt
@@ -45,6 +45,27 @@ class NotificationsViewModelTest {
     }
 
     @Test
+    fun `markAsRead delegates to repository`() = runTest {
+        val vm = newViewModel()
+
+        vm.markAsRead()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.markNotificationsAsRead() }
+    }
+
+    @Test
+    fun `markAsRead can be called multiple times`() = runTest {
+        val vm = newViewModel()
+
+        vm.markAsRead()
+        vm.markAsRead()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repository.markNotificationsAsRead() }
+    }
+
+    @Test
     fun `notifications flow is exposed`() = runTest {
         // Smoke test — just verify the property exists and is not null.
         // Actual PagingData emissions require paging-testing setup per-method.


### PR DESCRIPTION
## Summary
- Move the mark-as-read mutation call out of `NotificationsViewModel.init` (which only fires once, since the ViewModel survives tab switches via the nav graph's `saveState`/`restoreState`) into a `markAsRead()` function triggered from a `LaunchedEffect` in `NotificationsScreen`, mirroring the existing `markAsSeen()` pattern — so it fires every time the Notifications tab is activated, not just the first time.
- Enable `FeatureFlags.MARK_NOTIFICATIONS_AS_READ_ENABLED` now that the server exposes `MarkNotificationsAsReadMutation`.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `./gradlew :app:lintDebug`
- [x] `./gradlew :app:testDebugUnitTest --tests "*NotificationsViewModelTest*"`
- [ ] Manual: switch to the Notifications tab repeatedly and confirm the unread badge/read-state updates correctly each time