### PR TITLE
Add upload keystore fingerprint to assetlinks.json reference copy

### DIFF
--- a/docs/assetlinks.json
+++ b/docs/assetlinks.json
@@ -8,7 +8,8 @@
       "namespace": "android_app",
       "package_name": "pub.hackers.android",
       "sha256_cert_fingerprints": [
-        "AD:C6:2C:B4:7B:C0:7D:26:48:D5:C8:E5:51:88:BF:1E:82:33:B4:CC:5A:A3:74:49:25:D0:C4:3C:32:D7:12:BB"
+        "AD:C6:2C:B4:7B:C0:7D:26:48:D5:C8:E5:51:88:BF:1E:82:33:B4:CC:5A:A3:74:49:25:D0:C4:3C:32:D7:12:BB",
+        "52:A0:14:21:02:CD:30:FD:8B:29:A3:ED:80:2B:0A:BE:AF:AB:37:29:79:39:84:1A:B7:9E:39:05:AF:64:D5:1A"
       ]
     }
   },


### PR DESCRIPTION
### Problem

`docs/assetlinks.json` here is a reference copy of the Digital Asset Links file served from `hackers-pub/hackerspub`. It only listed the Google Play App Signing certificate fingerprint for `pub.hackers.android`, missing the fingerprint of `hackerspub-release.jks` — the keystore this repo's own `.github/workflows/fdroid-release.yml` uses to sign APKs distributed via GitHub Releases/F-Droid. Those installs fail Android's Digital Asset Links check (needed for passkey support) because their signing cert isn't listed.

Companion PR on the backend: hackers-pub/hackerspub#362, which fixes the same gap in the actually-served `assetlinks.json` files and adds the corresponding entry to `models/passkey.ts`'s WebAuthn origin allowlist.

### Fix

Add `52:A0:14:21:...:64:D5:1A` (the `hackerspub-release.jks` fingerprint, confirmed via `keytool -list -v -keystore hackerspub-release.jks -alias hackerspub`) alongside the existing Play Signing fingerprint.

### AI Disclosure

Investigated and drafted with **Claude Code** (`claude-sonnet-5`); see hackers-pub/hackerspub#362 for the full investigation. Change here is a one-line JSON addition to keep this reference copy in sync; verified against the actual `hackerspub-release.jks` file in this repo.